### PR TITLE
fix: Windows stack overflow in ctx binary + broken CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           # all-features covers the mcp feature (DuckDB compiles on Linux/macOS)
@@ -28,7 +29,6 @@ jobs:
             features: ""
           - os: windows-latest
             features: "--no-default-features"
-        rust: [stable]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `mcp` feature failed to compile the binary (`use crate::mcp` resolved against the binary crate instead of the library); CI now builds `--all-features` on Linux to prevent regressions
+- Stack overflow in the compiled binary on Windows (`~1 MiB` default thread stack) under normal parsing/graph-walking call depth; `main()` and rayon's global pool now run with an explicit 16 MiB stack
+- CI's `test` job matrix silently collapsed to a single `windows-latest --no-default-features` job instead of the intended 3 (ubuntu `--all-features`, macos default, windows `--no-default-features`), because the redundant, unused `rust: [stable]` matrix axis caused later `include` entries to overwrite earlier ones; `ubuntu-latest`/`macos-latest` had never actually run in CI
 
 ## [0.2.1] - 2026-06-17
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,24 @@ use ctx::exit::Outcome;
 
 /// Exit codes: 0 = clean, 1 = findings, 2 = operational error.
 fn main() -> ExitCode {
+    // The OS-provided main thread stack is too small on some platforms (notably
+    // Windows, which defaults to ~1 MiB) for this program's parsing/graph-walking
+    // call depth; run on a thread with a larger, explicit stack instead.
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(run_main)
+        .expect("failed to spawn main worker thread")
+        .join()
+        .expect("main worker thread panicked")
+}
+
+fn run_main() -> ExitCode {
+    // Same rationale as the main thread above: give rayon's global pool (used by
+    // `ctx index --parallel`) an explicit stack size instead of the platform default.
+    let _ = rayon::ThreadPoolBuilder::new()
+        .stack_size(16 * 1024 * 1024)
+        .build_global();
+
     let args = Args::parse();
 
     match run(args) {


### PR DESCRIPTION
## Summary

Surfaced while merging the Quality Intelligence Suite PR stack: PR #4 (hotspots)'s CI failed on the `test (stable)` job with a stack overflow inside the compiled `ctx` binary (`ctx index` crashing all 5 `hotspots_cli.rs` integration tests). Investigation turned up two separate, pre-existing bugs, both fixed here rather than inside a feature PR:

1. **Stack overflow**: Windows' default main-thread stack (~1 MiB, inherited from the PE header) is too small for this program's normal parsing/graph-walking call depth. `main()` now spawns its real work on a thread with an explicit 16 MiB stack; rayon's global pool (used by `ctx index --parallel`) gets the same treatment. Not reproducible locally on macOS (8 MiB default stack absorbs it), so this fixes the documented mechanism — final confirmation is the Windows CI leg on this PR.
2. **CI matrix bug**: the `test` job's matrix had an unused `rust: [stable]` axis alongside `include` entries that all share the same keys (`os`, `features`). Per GitHub's matrix-merge rules, each `include` entry overwrote the previous one instead of creating a separate job, so **only `windows-latest --no-default-features` has ever actually run** — `ubuntu-latest --all-features` (which the workflow comment says exists specifically to cover the `mcp`/DuckDB feature) and `macos-latest` have never been exercised in this project's CI history. Removed the dead `rust` axis and added `fail-fast: false` so a failure on one OS doesn't hide results on the others.

## Test plan
- `cargo build --all-features`, `cargo test --all-features`, `cargo fmt --check`, `cargo clippy --all-features -- -D warnings` all clean locally.
- This PR's own CI run is the first time `ubuntu-latest --all-features` and `macos-latest` will actually execute — watching for any latent failures those legs surface for the first time.