### PR TITLE
style: rustfmt the ctx sql sources

### DIFF
--- a/src/analytics/duckdb_impl.rs
+++ b/src/analytics/duckdb_impl.rs
@@ -711,9 +711,7 @@ impl Analytics {
 
         // Column metadata is only available after the statement has executed.
         let columns: Vec<SqlColumn> = {
-            let executed = rows
-                .as_ref()
-                .expect("statement is available after query()");
+            let executed = rows.as_ref().expect("statement is available after query()");
             let col_count = executed.column_count();
             let names = executed.column_names();
             (0..col_count)

--- a/src/commands/sql.rs
+++ b/src/commands/sql.rs
@@ -393,7 +393,11 @@ mod engine {
         }
 
         let mut out = String::new();
-        push_row(&mut out, &headers.iter().map(|h| h.to_string()).collect::<Vec<_>>(), &widths);
+        push_row(
+            &mut out,
+            &headers.iter().map(|h| h.to_string()).collect::<Vec<_>>(),
+            &widths,
+        );
         push_separator(&mut out, &widths);
         for row in &rendered {
             push_row(&mut out, row, &widths);
@@ -433,11 +437,7 @@ mod engine {
 
     fn render_csv(result: &SqlResult) {
         let mut out = String::new();
-        let headers: Vec<String> = result
-            .columns
-            .iter()
-            .map(|c| csv_field(&c.name))
-            .collect();
+        let headers: Vec<String> = result.columns.iter().map(|c| csv_field(&c.name)).collect();
         out.push_str(&headers.join(","));
         out.push_str("\r\n");
 
@@ -513,8 +513,7 @@ mod tests {
     #[test]
     fn schema_reference_matches_docs_page() {
         let manifest = env!("CARGO_MANIFEST_DIR");
-        let doc_path =
-            std::path::Path::new(manifest).join("docs/website/docs/sql-schema.md");
+        let doc_path = std::path::Path::new(manifest).join("docs/website/docs/sql-schema.md");
         let doc = std::fs::read_to_string(&doc_path)
             .unwrap_or_else(|e| panic!("read {}: {}", doc_path.display(), e));
 

--- a/tests/sql.rs
+++ b/tests/sql.rs
@@ -315,10 +315,7 @@ fn multi_statement_semantics() {
         .stdout(predicate::str::contains("42"));
 
     // Two result-producing statements -> error (only the final may return rows).
-    sql(temp.path())
-        .arg("SELECT 1; SELECT 2")
-        .assert()
-        .code(2);
+    sql(temp.path()).arg("SELECT 1; SELECT 2").assert().code(2);
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #12. CI `lint` (`cargo fmt --all -- --check`) flagged a few hand-wrapped lines in the `ctx sql` implementation and its tests. This applies `cargo fmt` — no logic changes.

Verified locally: `cargo fmt --all -- --check` clean, `cargo clippy -- -D warnings` clean, `cargo test --test sql` 17/17, `ctx sql` bin unit tests 5/5, builds with and without the `duckdb` feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)