### PR TITLE
fix: exact-name symbol lookup silently fails on snake_case names

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -586,14 +586,18 @@ impl Database {
         let file_like = file_pattern.map(glob_to_like_pattern);
 
         // Build dynamic SQL based on filters
-        // We use separate parameters for exact match (?1), like match (?2), and starts_with (?3)
+        // We use separate parameters for exact match (?1), like match (?2), and starts_with (?3).
+        // The like/starts_with patterns are produced by escape_like_pattern, which escapes the
+        // LIKE metacharacters (`%`, `_`, `\`) with a backslash, so every LIKE that consumes them
+        // must declare `ESCAPE '\'` — otherwise the escaped `\_`/`\%` are treated literally and
+        // names containing underscores (e.g. `run_sql`) never match.
         let mut sql = String::from(
             r#"
             SELECT id, file_path, name, qualified_name, kind, visibility,
                    signature, brief, docstring, line_start, line_end,
                    col_start, col_end, parent_id, source
             FROM symbols
-            WHERE (name LIKE ?2 OR qualified_name LIKE ?2)
+            WHERE (name LIKE ?2 ESCAPE '\' OR qualified_name LIKE ?2 ESCAPE '\')
             "#,
         );
 
@@ -603,7 +607,9 @@ impl Database {
         // Add file pattern filter if provided
         let file_param_pos = if file_pattern.is_some() {
             let pos = next_param;
-            sql.push_str(&format!(" AND file_path LIKE ?{}", pos));
+            // file_path patterns come from glob_to_like_pattern, which also backslash-escapes
+            // literal `%`/`_`/`\`, so this LIKE needs the same ESCAPE clause.
+            sql.push_str(&format!(" AND file_path LIKE ?{} ESCAPE '\\'", pos));
             next_param += 1;
             Some(pos)
         } else {
@@ -627,7 +633,7 @@ impl Database {
             r#"
             ORDER BY
                 CASE WHEN name = ?1 THEN 0
-                     WHEN name LIKE ?3 THEN 1
+                     WHEN name LIKE ?3 ESCAPE '\' THEN 1
                      ELSE 2 END,
                 name
             LIMIT ?{}
@@ -2476,6 +2482,82 @@ mod tests {
             .unwrap();
         assert_eq!(filtered.len(), 1);
         assert!(filtered[0].file_path.contains("embeddings"));
+    }
+
+    #[test]
+    fn test_find_symbols_with_underscore_name() {
+        // Regression: escape_like_pattern turns `_` into `\_`, and the LIKE clauses must
+        // declare `ESCAPE '\'` for that to match. Without it, any snake_case name (the
+        // dominant style in Rust/Go/Python) was unreachable by exact name via
+        // find_symbols_filtered — silently returning zero rows for query find/explain/
+        // source/callers/deps/impact.
+        let db = Database::open_in_memory().unwrap();
+
+        // symbols.file_path is a FK into files.path, so register the file first.
+        db.upsert_file(
+            &FileRecord {
+                path: "src/commands/sql.rs".to_string(),
+                content_hash: "abc123".to_string(),
+                size_bytes: 100,
+                language: Some("rust".to_string()),
+                last_indexed: 0,
+            },
+            None,
+        )
+        .unwrap();
+
+        for (id, name) in &[
+            ("a::run_sql", "run_sql"),
+            ("b::run_sql_duckdb", "run_sql_duckdb"),
+            ("c::runsql", "runsql"),
+        ] {
+            let symbol = Symbol {
+                id: id.to_string(),
+                file_path: "src/commands/sql.rs".to_string(),
+                name: name.to_string(),
+                qualified_name: None,
+                kind: SymbolKind::Function,
+                visibility: Visibility::Public,
+                signature: None,
+                brief: None,
+                docstring: None,
+                line_start: 1,
+                line_end: 5,
+                col_start: 0,
+                col_end: 1,
+                parent_id: None,
+                source: None,
+            };
+            db.insert_symbol(&symbol).unwrap();
+        }
+
+        // Exact snake_case name must be found (this returned zero rows before the fix).
+        let exact = db.find_symbols_filtered("run_sql", 10, None, None).unwrap();
+        assert!(
+            exact.iter().any(|s| s.name == "run_sql"),
+            "exact underscore name 'run_sql' must be found"
+        );
+
+        // The underscore must be treated literally, not as the LIKE single-char wildcard:
+        // searching "run_sql" must NOT match "runsql".
+        assert!(
+            !exact.iter().any(|s| s.name == "runsql"),
+            "'_' must be literal, not a wildcard matching 'runsql'"
+        );
+
+        // Exact match ranks ahead of the longer prefix match.
+        assert_eq!(
+            exact.first().map(|s| s.name.as_str()),
+            Some("run_sql"),
+            "exact match should sort before 'run_sql_duckdb'"
+        );
+
+        // Substring search across the underscore still works.
+        let prefix = db.find_symbols_filtered("run_sql", 10, None, None).unwrap();
+        assert!(
+            prefix.iter().any(|s| s.name == "run_sql_duckdb"),
+            "substring search should still surface 'run_sql_duckdb'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`query find`, `query callers`, `query deps`, `query impact`, `explain`, and `source` return **"not found" for any symbol whose name contains an underscore** — i.e. most snake_case identifiers in Rust/Go/Python/C codebases.

```
$ ctx query find get            # ✅ found
$ ctx query find run_sql        # ⛔ "No symbols found"
$ ctx query find discover_files # ⛔ "No symbols found"
$ ctx query impact run_audit    # ⚠️ "No impact detected"  ← silently wrong
```

The symbols are indexed — `ctx sql`, `search`, and `semantic` all find them. Only the LIKE-based exact-name path fails.

## Root cause

`find_symbols_filtered` (`src/db/schema.rs`) escapes LIKE metacharacters (`%`, `_`, `\`) with a backslash (`escape_like_pattern`, and `glob_to_like_pattern` for the file filter), but **none of the LIKE clauses declared `ESCAPE '\'`**. In SQLite the backslash is not the escape character unless declared, so the escaped `\_` was matched literally as "backslash + any char" — which never matches a name like `run_sql`. Substrings without underscores matched fine, which is why the bug hid in plain sight.

The `impact` variant is the most dangerous: it returns *"No impact detected"* rather than an error, which a caller (human or agent) reads as "safe to change."

## Fix

Add `ESCAPE '\'` to all three affected LIKE clauses:
- `name` / `qualified_name` substring match
- the `file_path` glob filter
- the `starts_with` prefix match in the `ORDER BY`

## Why the tests missed it

The existing `find_symbols_filtered` tests only used underscore-free names (`new`, `main`, `targetfn`). This PR adds `test_find_symbols_with_underscore_name`, which looks up a snake_case name by exact match and asserts the underscore is treated **literally** (does not wildcard-match `runsql`) and that exact match still ranks ahead of the longer prefix match.

## Verification

- New regression test fails before the fix, passes after.
- Full suite green: **379 tests, 0 failures**; `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.
- End-to-end against a real index: `query find run_sql`, `explain open_sql_sandbox`, and `query impact find_symbols_filtered` all now resolve correctly.