### PR TITLE
perf: first ubuntu-latest baseline

### DIFF
--- a/perf/baselines/README.md
+++ b/perf/baselines/README.md
@@ -6,10 +6,13 @@ specific** — a number captured on a MacBook is meaningless for
 `ubuntu-latest` — so each file is named after the runner class it was
 captured on (`ubuntu-latest.json`).
 
-There is intentionally **no baseline committed yet**: the harness was
-developed on macOS, and fabricating Linux numbers would make the gate either
-useless or flaky. Until a baseline lands, the regression gate warn-passes
-(missing entry => warn) and only the absolute budgets and the RSS gate apply.
+`ubuntu-latest.json` was captured from CI run
+[29126075011](https://github.com/agentis-tools/ctx/actions/runs/29126075011)
+(2026-07-10, commit `98e06386`, suite `full`, budget scale 1.5, perf
+profile). All seven scenarios are included — `index_cold_2k` (budget-less,
+informational) and `score_3_changed` (currently over its absolute budget,
+tracked separately) too: the baseline is the regression reference and is
+independent of the budget gate.
 
 ## Capturing / updating `ubuntu-latest.json`
 

--- a/perf/baselines/ubuntu-latest.json
+++ b/perf/baselines/ubuntu-latest.json
@@ -1,0 +1,38 @@
+{
+  "meta": {
+    "profile": "perf",
+    "fixture_format_version": 1,
+    "budget_scale_at_capture": 1.5,
+    "commit": "98e06386afcf0ec02df8ba13208bdf9444050bf3"
+  },
+  "scenarios": {
+    "check_against_head": {
+      "median_ms": 162.8,
+      "max_rss_kb": 55812
+    },
+    "index_cold_150k": {
+      "median_ms": 13641.7,
+      "max_rss_kb": 93652
+    },
+    "index_cold_2k": {
+      "median_ms": 8043.8,
+      "max_rss_kb": 67500
+    },
+    "index_incremental_1": {
+      "median_ms": 209.7,
+      "max_rss_kb": 47616
+    },
+    "map_cached": {
+      "median_ms": 46.2,
+      "max_rss_kb": 42552
+    },
+    "score_3_changed": {
+      "median_ms": 5965.1,
+      "max_rss_kb": 280368
+    },
+    "sql_v1_query": {
+      "median_ms": 266.2,
+      "max_rss_kb": 93080
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Commits the first `perf/baselines/ubuntu-latest.json`, enabling the CI regression gate (`median > baseline * 1.20`) that has so far been warn-passing for lack of a baseline. Also updates `perf/baselines/README.md` to record capture provenance in place of the "no baseline committed yet" note.

## Capture provenance

- CI run: [29126075011](https://github.com/agentis-tools/ctx/actions/runs/29126075011) (ubuntu-latest, 2026-07-10)
- Commit: `98e06386afcf0ec02df8ba13208bdf9444050bf3`
- Suite: `full`, budget scale 1.5, `perf` profile, `fixture_format_version` 1

| Scenario | Median | Max RSS |
| --- | --- | --- |
| `check_against_head` | 162.8 ms | 55,812 kB |
| `index_cold_150k` | 13,641.7 ms | 93,652 kB |
| `index_cold_2k` | 8,043.8 ms | 67,500 kB |
| `index_incremental_1` | 209.7 ms | 47,616 kB |
| `map_cached` | 46.2 ms | 42,552 kB |
| `score_3_changed` | 5,965.1 ms | 280,368 kB |
| `sql_v1_query` | 266.2 ms | 93,080 kB |

All seven scenarios are included, deliberately:

- `index_cold_2k` has no absolute budget (informational) but still benefits from regression tracking.
- `score_3_changed` currently **exceeds its absolute budget** (2000 ms, 3000 ms at scale 1.5) — tracked in #23. The baseline is the regression reference and is independent of the budget gate; the perf job stays advisory until #23 is fixed.

## Verification

- Baseline file matches the serde model in `perf/src/compare.rs` (`Baseline { meta { profile, fixture_format_version, budget_scale_at_capture, commit }, scenarios }`); shape asserted with a one-off script.
- `cargo test --manifest-path perf/Cargo.toml` — 20 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)