### PR TITLE
feat: lexical path boost + oversized-top budget guarantee for ctx smart

### DIFF
--- a/src/commands/smart_cmd.rs
+++ b/src/commands/smart_cmd.rs
@@ -92,6 +92,18 @@ pub fn run_smart(
         }
     );
 
+    // If the single most-relevant file alone exceeds the budget it is included
+    // anyway (rather than silently dropped); tell the user why little else fits.
+    if let Some(top) = result.selected_files.first() {
+        if top.token_count > max_tokens {
+            eprintln!(
+                "note: {} ({} tokens) exceeds the {}-token budget; included alone \
+                 — raise --max-tokens to include more",
+                top.path, top.token_count, max_tokens
+            );
+        }
+    }
+
     // Convert selected files to FileEntry format for context generation
     let entries: Vec<walker::FileEntry> = result
         .selected_files

--- a/src/mcp/tools/analysis.rs
+++ b/src/mcp/tools/analysis.rs
@@ -202,7 +202,9 @@ pub async fn smart_context(
     // Resolve provider: explicit `provider` string wins, else the deprecated
     // `use_openai` bool, else the `.ctx/config.toml` default, else local. Network
     // providers embed asynchronously so they don't block the async runtime.
-    let config = crate::config::CtxConfig::load(&std::env::current_dir().unwrap_or_default());
+    // (Named `project_config` so it doesn't shadow the `SmartConfig` above.)
+    let project_config =
+        crate::config::CtxConfig::load(&std::env::current_dir().unwrap_or_default());
     let provider = match params.provider.as_deref() {
         Some("openai") => Provider::Openai,
         Some("ollama") => Provider::Ollama,
@@ -210,7 +212,7 @@ pub async fn smart_context(
         None => Provider::resolve(
             None,
             params.use_openai.unwrap_or(false),
-            config.embedding.provider,
+            project_config.embedding.provider,
         ),
         Some(other) => {
             return Err(internal_error(format!(
@@ -235,8 +237,8 @@ pub async fn smart_context(
         }
         Provider::Ollama => {
             let provider = OllamaProvider::from_config_async(
-                config.embedding.model.as_deref(),
-                config.embedding.host.as_deref(),
+                project_config.embedding.model.as_deref(),
+                project_config.embedding.host.as_deref(),
             )
             .await
             .map_err(|e| internal_error(format!("Failed to initialize Ollama provider: {}", e)))?;

--- a/src/smart.rs
+++ b/src/smart.rs
@@ -15,7 +15,7 @@
 //! }
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 
 use crate::analytics::{Analytics, CallGraphNode, ImpactNode};
@@ -23,6 +23,7 @@ use crate::db::Database;
 use crate::embeddings::{semantic_search, Embedding, EmbeddingProvider, SearchResult};
 use crate::error::{CtxError, Result};
 use crate::tokens::{count_file_tokens, select_by_token_budget, Encoding, HasTokenCount};
+use crate::utils::lexical_tokens;
 
 /// Configuration for smart context selection.
 #[derive(Debug, Clone)]
@@ -126,6 +127,10 @@ pub struct FileSelection {
     pub reasons: Vec<SelectionReason>,
     /// Token count for this file
     pub token_count: usize,
+    /// Number of distinct task tokens that appear in this file's path or in the
+    /// names of the symbols that selected it (see [`FileSelection::compute_lexical_score`]).
+    /// A high-precision relevance signal layered on top of the semantic/graph tiers.
+    pub lexical_score: f32,
 }
 
 impl HasTokenCount for FileSelection {
@@ -143,6 +148,7 @@ impl FileSelection {
             relevance_score: score,
             reasons: vec![reason],
             token_count: 0,
+            lexical_score: 0.0,
         }
     }
 
@@ -172,6 +178,25 @@ impl FileSelection {
                 _ => None,
             })
             .reduce(f32::max)
+    }
+
+    /// Count the distinct `task_tokens` that appear in this file's **path**.
+    ///
+    /// This is the lexical relevance signal: when a task word ("openai",
+    /// "solidity", "sql") is literally present in a candidate's path, that is
+    /// strong, high-precision evidence the file is on-topic even if the embedding
+    /// ranked it low. Returns 0.0 when there is no overlap.
+    ///
+    /// Path only — deliberately *not* symbol names. Matching symbol names is
+    /// low-precision: ubiquitous identifiers (notably `ctx`, the tool's own name,
+    /// which appears as a test helper across `tests/*_cli.rs`) would score a hit
+    /// on nearly every file and drown out the genuinely on-topic one.
+    fn compute_lexical_score(&self, task_tokens: &BTreeSet<String>) -> f32 {
+        if task_tokens.is_empty() {
+            return 0.0;
+        }
+        let path_tokens = lexical_tokens(&self.path);
+        task_tokens.intersection(&path_tokens).count() as f32
     }
 }
 
@@ -264,11 +289,21 @@ pub fn smart_context_with_embedding(
         selection.token_count = count_file_token_safe(&selection.path, config.encoding);
     }
 
+    // 4b. Lexical relevance: reward candidates whose path or matched symbol names
+    // contain the task's own tokens. This rescues on-topic files the embedding
+    // ranked low (e.g. `embeddings/openai.rs` for "…openai") without any tunable
+    // float weight — the score is a plain distinct-token-hit count.
+    let task_tokens = lexical_tokens(task);
+    for selection in &mut selections {
+        selection.lexical_score = selection.compute_lexical_score(&task_tokens);
+    }
+
     // 5. Rank files by relevance
     rank_files(&mut selections);
 
-    // 6. Apply token limit
-    let (selected, total_tokens, omitted) = select_by_token_budget(selections, config.max_tokens);
+    // 6. Apply token limit, but never silently drop the single most-relevant file.
+    let (selected, total_tokens, omitted) =
+        select_with_guaranteed_top(selections, config.max_tokens);
 
     Ok(SmartContext {
         task: task.to_string(),
@@ -277,6 +312,36 @@ pub fn smart_context_with_embedding(
         truncated: omitted > 0,
         omitted_count: omitted,
     })
+}
+
+/// Apply the token budget while guaranteeing the top-ranked file is always
+/// included — even when that file alone exceeds the budget.
+///
+/// The greedy first-fit selector would otherwise skip an oversized rank-1 file
+/// (e.g. a 9k-token parser larger than the whole 8k budget) and backfill with
+/// smaller, less-relevant files, so the command returns everything *except* the
+/// file the task is really about. Here the top file is force-included, then the
+/// remainder is first-fit against the leftover budget via the shared
+/// [`select_by_token_budget`].
+fn select_with_guaranteed_top(
+    ranked: Vec<FileSelection>,
+    max_tokens: usize,
+) -> (Vec<FileSelection>, usize, usize) {
+    let mut iter = ranked.into_iter();
+    let Some(top) = iter.next() else {
+        return (Vec::new(), 0, 0);
+    };
+    let top_tokens = top.token_count;
+    let rest: Vec<FileSelection> = iter.collect();
+    // Budget the remainder against whatever is left after the guaranteed top file
+    // (saturating: an oversized top file leaves a zero budget for the rest).
+    let remaining_budget = max_tokens.saturating_sub(top_tokens);
+    let (mut selected_rest, rest_tokens, omitted) = select_by_token_budget(rest, remaining_budget);
+
+    let mut selected = Vec::with_capacity(selected_rest.len() + 1);
+    selected.push(top);
+    selected.append(&mut selected_rest);
+    (selected, top_tokens + rest_tokens, omitted)
 }
 
 /// Add a file to the selection map, merging reasons if already present.
@@ -363,33 +428,49 @@ fn add_file_from_call_graph(
     let _ = caller_name; // Suppress unused warning
 }
 
+/// Ranking key for a file: `(is_low_relevance, lexical_score, tier_score)`.
+///
+/// - **Relevance tier** (`is_low_relevance`): a file is in the top tier if it has
+///   a direct semantic match **or** a lexical hit (a task token in its path/name).
+///   Graph-only files with no lexical hit sort last, so a generic call-graph hub
+///   (flat weight 0.8) never displaces an on-topic file.
+/// - **`lexical_score`**: within a tier, more task-token hits rank first — this is
+///   what surfaces `embeddings/openai.rs` for "…openai" over a higher-scored but
+///   off-topic semantic match.
+/// - **`tier_score`**: the semantic score for semantic matches, else
+///   `relevance_score`; scores are only ever compared within the same scale.
+fn rank_key(f: &FileSelection) -> (bool, f32, f32) {
+    let sem = f.best_semantic_score();
+    let is_low_relevance = sem.is_none() && f.lexical_score == 0.0;
+    let tier_score = sem.unwrap_or(f.relevance_score);
+    (is_low_relevance, f.lexical_score, tier_score)
+}
+
 /// Rank files for selection. The ordering is tiered and fully deterministic:
 ///
-/// 1. Files with a direct semantic match rank above files pulled in only through
-///    call-graph expansion. Without this, a graph neighbour's flat weight (0.8 for
-///    `CalledBy`, 0.7 for `Calls`) outranks the compressed semantic score (~0.4–0.6)
-///    of the very seed that expanded it, so generic hubs displace the on-topic file.
-/// 2. Within the semantic tier, higher semantic score first; within the graph-only
-///    tier, higher `relevance_score` first.
+/// 1. Relevant files (semantic match or lexical hit) rank above files pulled in
+///    only through call-graph expansion.
+/// 2. Within a tier: more lexical hits first, then higher tier score.
 /// 3. Ties break by `path` ascending. Because the input is collected from a
 ///    `HashMap`, this tie-break is what makes the command deterministic across runs
-///    (many files share the same 0.5/0.7/0.8 weight).
+///    (many files share the same 0.5/0.7/0.8 weight and the same lexical score).
 fn rank_files(files: &mut [FileSelection]) {
     files.sort_by(|a, b| {
-        let a_sem = a.best_semantic_score();
-        let b_sem = b.best_semantic_score();
-        // Tier: semantic matches (Some) sort before graph-only (None).
-        // Score compared within a tier only: semantic score for the semantic tier,
-        // relevance_score for the graph-only tier — never across scales.
-        let a_key = (a_sem.is_none(), a_sem.unwrap_or(a.relevance_score));
-        let b_key = (b_sem.is_none(), b_sem.unwrap_or(b.relevance_score));
+        let a_key = rank_key(a);
+        let b_key = rank_key(b);
         a_key
             .0
-            .cmp(&b_key.0)
+            .cmp(&b_key.0) // false (relevant) sorts before true (low-relevance)
             .then_with(|| {
                 b_key
                     .1
-                    .partial_cmp(&a_key.1)
+                    .partial_cmp(&a_key.1) // lexical_score descending
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                b_key
+                    .2
+                    .partial_cmp(&a_key.2) // tier_score descending
                     .unwrap_or(std::cmp::Ordering::Equal)
             })
             .then_with(|| a.path.cmp(&b.path))
@@ -546,18 +627,21 @@ mod tests {
                 relevance_score: 1.0,
                 reasons: vec![SelectionReason::Explicit],
                 token_count: 100,
+                lexical_score: 0.0,
             },
             FileSelection {
                 path: "b.rs".to_string(),
                 relevance_score: 0.8,
                 reasons: vec![SelectionReason::Explicit],
                 token_count: 200,
+                lexical_score: 0.0,
             },
             FileSelection {
                 path: "c.rs".to_string(),
                 relevance_score: 0.5,
                 reasons: vec![SelectionReason::Explicit],
                 token_count: 150,
+                lexical_score: 0.0,
             },
         ];
 
@@ -593,6 +677,7 @@ mod tests {
                         score: 0.9,
                     }],
                     token_count: 500,
+                    lexical_score: 0.0,
                 },
                 FileSelection {
                     path: "src/lib.rs".to_string(),
@@ -602,6 +687,7 @@ mod tests {
                         depth: 1,
                     }],
                     token_count: 300,
+                    lexical_score: 0.0,
                 },
             ],
             total_tokens: 800,
@@ -662,18 +748,21 @@ mod tests {
                 relevance_score: 0.3,
                 reasons: vec![SelectionReason::Explicit],
                 token_count: 100,
+                lexical_score: 0.0,
             },
             FileSelection {
                 path: "high.rs".to_string(),
                 relevance_score: 0.9,
                 reasons: vec![SelectionReason::Explicit],
                 token_count: 100,
+                lexical_score: 0.0,
             },
             FileSelection {
                 path: "mid.rs".to_string(),
                 relevance_score: 0.5,
                 reasons: vec![SelectionReason::Explicit],
                 token_count: 100,
+                lexical_score: 0.0,
             },
         ];
 
@@ -699,6 +788,7 @@ mod tests {
                     depth: 1,
                 }],
                 token_count: 100,
+                lexical_score: 0.0,
             },
             FileSelection {
                 path: "on_topic.rs".to_string(),
@@ -708,6 +798,7 @@ mod tests {
                     score: 0.5,
                 }],
                 token_count: 100,
+                lexical_score: 0.0,
             },
         ];
 
@@ -732,6 +823,7 @@ mod tests {
                 score,
             }],
             token_count: 100,
+            lexical_score: 0.0,
         };
         // Two files tie at 0.6; "a.rs" must precede "b.rs" by path.
         let mut files = vec![mk("b.rs", 0.6), mk("c.rs", 0.4), mk("a.rs", 0.6)];
@@ -759,6 +851,7 @@ mod tests {
                         depth: 1,
                     }],
                     token_count: 100,
+                    lexical_score: 0.0,
                 },
                 FileSelection {
                     path: "a_graph.rs".to_string(),
@@ -768,6 +861,7 @@ mod tests {
                         depth: 1,
                     }],
                     token_count: 100,
+                    lexical_score: 0.0,
                 },
                 FileSelection {
                     path: "seed.rs".to_string(),
@@ -777,6 +871,7 @@ mod tests {
                         score: 0.5,
                     }],
                     token_count: 100,
+                    lexical_score: 0.0,
                 },
             ]
         };
@@ -794,6 +889,171 @@ mod tests {
         assert_eq!(order_a, order_b);
         // Semantic seed first, then graph files tie-broken by path.
         assert_eq!(order_a, vec!["seed.rs", "a_graph.rs", "z_graph.rs"]);
+    }
+
+    /// A graph-only file whose path/name matches a task token (lexical_score > 0)
+    /// is promoted into the relevant tier, above a semantic match that shares no
+    /// task token. This is what surfaces `embeddings/openai.rs` for "…openai".
+    #[test]
+    fn test_lexical_promotes_graph_only_file() {
+        let mut files = vec![
+            FileSelection {
+                path: "off_topic_semantic.rs".to_string(),
+                relevance_score: 0.6,
+                reasons: vec![SelectionReason::SemanticMatch {
+                    symbol: "unrelated".to_string(),
+                    score: 0.6,
+                }],
+                token_count: 100,
+                lexical_score: 0.0,
+            },
+            FileSelection {
+                path: "embeddings/openai.rs".to_string(),
+                relevance_score: 0.7, // Calls, graph-only
+                reasons: vec![SelectionReason::Calls {
+                    callee: "embed".to_string(),
+                    depth: 1,
+                }],
+                token_count: 100,
+                lexical_score: 2.0, // "embeddings" + "openai"
+            },
+        ];
+
+        rank_files(&mut files);
+
+        assert_eq!(
+            files[0].path, "embeddings/openai.rs",
+            "a lexical hit must outrank a semantic match with no task-token overlap"
+        );
+    }
+
+    /// Within the relevant tier, more lexical hits rank first; equal lexical scores
+    /// fall back to tier score, then path.
+    #[test]
+    fn test_lexical_orders_within_tier() {
+        let mk = |path: &str, score: f32, lex: f32| FileSelection {
+            path: path.to_string(),
+            relevance_score: score,
+            reasons: vec![SelectionReason::SemanticMatch {
+                symbol: "s".to_string(),
+                score,
+            }],
+            token_count: 100,
+            lexical_score: lex,
+        };
+        // two_hits has the most lexical overlap and must lead despite a lower score.
+        let mut files = vec![
+            mk("high_score_no_lexical.rs", 0.9, 0.0),
+            mk("two_hits.rs", 0.4, 2.0),
+            mk("one_hit.rs", 0.4, 1.0),
+        ];
+
+        rank_files(&mut files);
+
+        assert_eq!(
+            files.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+            vec!["two_hits.rs", "one_hit.rs", "high_score_no_lexical.rs"]
+        );
+    }
+
+    /// `compute_lexical_score` counts distinct task tokens present in a file's
+    /// path (only), and does not count symbol names — so ubiquitous identifiers
+    /// like `ctx` cannot inflate the score.
+    #[test]
+    fn test_compute_lexical_score() {
+        let sel = FileSelection {
+            path: "src/embeddings/openai.rs".to_string(),
+            relevance_score: 0.5,
+            // Symbol name deliberately contains "ctx"; it must NOT be counted.
+            reasons: vec![SelectionReason::SemanticMatch {
+                symbol: "ctx_embed".to_string(),
+                score: 0.5,
+            }],
+            token_count: 100,
+            lexical_score: 0.0,
+        };
+        // "embeddings" + "openai" from the path overlap the task; "with" is a stopword.
+        let task = lexical_tokens("generate embeddings with openai");
+        assert!((sel.compute_lexical_score(&task) - 2.0).abs() < 0.001);
+        // "ctx" appears in the symbol but not the path, so it does not match.
+        let ctx_task = lexical_tokens("ctx tooling");
+        assert!((sel.compute_lexical_score(&ctx_task)).abs() < 0.001);
+        // No overlap -> 0.
+        let other = lexical_tokens("parse solidity contracts");
+        assert!((sel.compute_lexical_score(&other)).abs() < 0.001);
+    }
+
+    /// The rank-1 file is always included even when it alone exceeds the budget,
+    /// rather than being silently dropped in favour of smaller lower-ranked files.
+    #[test]
+    fn test_budget_includes_oversized_top_file() {
+        let ranked = vec![
+            FileSelection {
+                path: "huge_top.rs".to_string(),
+                relevance_score: 0.9,
+                reasons: vec![SelectionReason::SemanticMatch {
+                    symbol: "s".to_string(),
+                    score: 0.9,
+                }],
+                token_count: 9000, // larger than the whole budget
+                lexical_score: 1.0,
+            },
+            FileSelection {
+                path: "small_next.rs".to_string(),
+                relevance_score: 0.5,
+                reasons: vec![SelectionReason::SemanticMatch {
+                    symbol: "s".to_string(),
+                    score: 0.5,
+                }],
+                token_count: 500,
+                lexical_score: 0.0,
+            },
+        ];
+
+        let (selected, total, omitted) = select_with_guaranteed_top(ranked, 8000);
+
+        assert_eq!(selected.len(), 1, "only the oversized top file is included");
+        assert_eq!(selected[0].path, "huge_top.rs");
+        assert_eq!(total, 9000);
+        assert_eq!(omitted, 1, "the smaller file is omitted for lack of budget");
+    }
+
+    /// When the top file fits, the remainder is first-fit against the leftover
+    /// budget (same behaviour as before for the non-oversized case).
+    #[test]
+    fn test_budget_first_fits_remainder() {
+        let ranked = vec![
+            FileSelection {
+                path: "top.rs".to_string(),
+                relevance_score: 0.9,
+                reasons: vec![SelectionReason::Explicit],
+                token_count: 3000,
+                lexical_score: 0.0,
+            },
+            FileSelection {
+                path: "mid.rs".to_string(),
+                relevance_score: 0.8,
+                reasons: vec![SelectionReason::Explicit],
+                token_count: 4000,
+                lexical_score: 0.0,
+            },
+            FileSelection {
+                path: "tail.rs".to_string(),
+                relevance_score: 0.7,
+                reasons: vec![SelectionReason::Explicit],
+                token_count: 2000, // would overflow the 8000 budget after top+mid
+                lexical_score: 0.0,
+            },
+        ];
+
+        let (selected, total, omitted) = select_with_guaranteed_top(ranked, 8000);
+
+        assert_eq!(
+            selected.iter().map(|f| f.path.as_str()).collect::<Vec<_>>(),
+            vec!["top.rs", "mid.rs"]
+        );
+        assert_eq!(total, 7000);
+        assert_eq!(omitted, 1);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,59 @@
 //!
 //! This module contains helper functions used across multiple command modules.
 
+use std::collections::BTreeSet;
+
+/// Stopwords excluded from lexical token matching: articles, prepositions, and
+/// generic task verbs that carry no file-identifying signal (so "add a new X"
+/// matches on "X", not on "add"/"new").
+const LEXICAL_STOPWORDS: &[&str] = &[
+    "a", "an", "the", "of", "in", "on", "to", "for", "with", "and", "or", "by", "as", "at", "is",
+    "are", "be", "it", "this", "that", "from", "into", "via", "add", "new", "make", "use", "using",
+];
+
+/// Split a string into normalized lexical tokens for path / identifier matching.
+///
+/// Lowercases, splits on any non-alphanumeric character **and** on camelCase
+/// boundaries (so `parseSolidity` → `parse`, `solidity`), drops tokens of length
+/// ≤ 1, and removes a small stopword set. Used to score how strongly a task
+/// description lexically overlaps a file path or symbol name — a high-precision
+/// relevance signal that embedding similarity can miss.
+pub fn lexical_tokens(s: &str) -> BTreeSet<String> {
+    let mut tokens = BTreeSet::new();
+    let mut current = String::new();
+    // Was the previous char a lowercase letter or digit? Used to detect the
+    // lower→upper camelCase boundary that starts a new word.
+    let mut prev_lower_or_digit = false;
+
+    for ch in s.chars() {
+        if ch.is_alphanumeric() {
+            if ch.is_uppercase() && prev_lower_or_digit && !current.is_empty() {
+                push_token(&mut tokens, &current);
+                current.clear();
+            }
+            current.extend(ch.to_lowercase());
+            prev_lower_or_digit = ch.is_lowercase() || ch.is_numeric();
+        } else {
+            if !current.is_empty() {
+                push_token(&mut tokens, &current);
+                current.clear();
+            }
+            prev_lower_or_digit = false;
+        }
+    }
+    if !current.is_empty() {
+        push_token(&mut tokens, &current);
+    }
+    tokens
+}
+
+/// Insert a normalized token, dropping length-≤-1 tokens and stopwords.
+fn push_token(tokens: &mut BTreeSet<String>, tok: &str) {
+    if tok.len() > 1 && !LEXICAL_STOPWORDS.contains(&tok) {
+        tokens.insert(tok.to_string());
+    }
+}
+
 /// Truncate a string with ellipsis, respecting UTF-8 char boundaries.
 ///
 /// If the string is longer than `max` characters, it will be truncated
@@ -53,6 +106,47 @@ pub fn truncate_path(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn toks(s: &str) -> Vec<String> {
+        lexical_tokens(s).into_iter().collect()
+    }
+
+    #[test]
+    fn test_lexical_tokens_path_splits_on_separators() {
+        // Path splits on '/' and '.'; tokens are lowercased, deduped, sorted.
+        assert_eq!(
+            toks("src/embeddings/openai.rs"),
+            vec!["embeddings", "openai", "rs", "src"]
+        );
+    }
+
+    #[test]
+    fn test_lexical_tokens_underscore_splits_each_word() {
+        // snake_case splits into individual words (no combined "run_sql" token).
+        assert_eq!(toks("run_sql_duckdb"), vec!["duckdb", "run", "sql"]);
+    }
+
+    #[test]
+    fn test_lexical_tokens_camelcase() {
+        // camelCase and PascalCase split into words, lowercased.
+        assert_eq!(toks("parseSolidity"), vec!["parse", "solidity"]);
+        assert_eq!(toks("SmartConfig"), vec!["config", "smart"]);
+        // digits stay attached to their word
+        assert_eq!(toks("v1Symbols"), vec!["symbols", "v1"]);
+    }
+
+    #[test]
+    fn test_lexical_tokens_stopwords_and_length() {
+        // Stopwords and single chars are dropped; result is deduped + sorted.
+        assert_eq!(
+            toks("add a new output format to ctx sql"),
+            vec!["ctx", "format", "output", "sql"]
+        );
+        assert_eq!(
+            toks("generate embeddings with openai"),
+            vec!["embeddings", "generate", "openai"]
+        );
+    }
 
     #[test]
     fn test_truncate_str_ascii() {

--- a/tests/smart_relevance.rs
+++ b/tests/smart_relevance.rs
@@ -1,0 +1,254 @@
+//! Deterministic, offline regression guard for `ctx smart` file-selection ranking.
+//!
+//! `ctx smart` normally embeds the task with a downloaded ONNX model (fastembed),
+//! which is neither offline nor byte-stable across architectures — so we cannot
+//! drive the real CLI in CI. Instead these tests hand-build a tiny on-disk index
+//! (files + symbols + edges) and **seed exact embedding vectors** via the library
+//! API, then call `ctx::smart::smart_context_with_embedding` directly with a
+//! crafted query vector. This exercises the full seed → call-graph expand →
+//! lexical → rank → budget pipeline deterministically, with no model download.
+//!
+//! The scenarios reproduce the two ranking behaviours that motivated the lexical
+//! path boost (PR #25):
+//!   1. a task token in a file's PATH promotes the on-topic file over a
+//!      higher-semantic-scored file whose only "match" is a symbol NAME
+//!      (the `ctx` test-helper regression that was originally caught by hand);
+//!   2. a graph-only candidate whose path matches the task is surfaced to the top
+//!      instead of being outranked by the semantic matches and dropped.
+//!
+//! Requires the `duckdb` feature: call-graph expansion goes through the real
+//! DuckDB-backed `Analytics`. In `--no-default-features` builds the analytics
+//! stub returns no edges, so this file compiles to nothing there.
+#![cfg(feature = "duckdb")]
+
+use std::path::Path;
+
+use ctx::analytics::Analytics;
+use ctx::db::{Database, Edge, EdgeKind, FileRecord, Symbol, SymbolKind, Visibility};
+use ctx::embeddings::Embedding;
+use ctx::smart::{smart_context_with_embedding, SmartConfig};
+use tempfile::TempDir;
+
+/// One symbol to seed: its file path, symbol name, optional embedding vector
+/// (None = present in the index but not a semantic hit), and optional call edge
+/// to another symbol id (source of a `Calls` edge, for call-graph expansion).
+struct Seed {
+    path: &'static str,
+    name: &'static str,
+    embedding: Option<[f32; 4]>,
+    calls: Option<String>, // target symbol id of a `Calls` edge from this symbol
+}
+
+fn file_record(path: &str) -> FileRecord {
+    FileRecord {
+        path: path.to_string(),
+        content_hash: "hash".to_string(),
+        size_bytes: 0,
+        language: Some("rust".to_string()),
+        last_indexed: 0,
+    }
+}
+
+fn symbol(path: &str, name: &str) -> Symbol {
+    Symbol {
+        id: Symbol::make_id(path, name, None),
+        file_path: path.to_string(),
+        name: name.to_string(),
+        qualified_name: None,
+        kind: SymbolKind::Function,
+        visibility: Visibility::Public,
+        signature: None,
+        brief: None,
+        docstring: None,
+        line_start: 1,
+        line_end: 2,
+        col_start: 0,
+        col_end: 0,
+        parent_id: None,
+        source: None,
+    }
+}
+
+/// Build a temp `.ctx/codebase.sqlite` from the seeds and return the temp dir
+/// (the index root) so the caller can open a fresh reader + Analytics on it.
+fn build_fixture(seeds: &[Seed]) -> TempDir {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    std::fs::create_dir_all(root.join(".ctx")).unwrap();
+    let db_path = root.join(".ctx").join("codebase.sqlite");
+
+    // Scope the writer so it is dropped (WAL checkpointed) before Analytics
+    // attaches the file READ_ONLY.
+    {
+        let db = Database::open(&db_path).unwrap();
+
+        // De-duplicate file rows (several symbols may share a file).
+        let mut seen_files = std::collections::BTreeSet::new();
+        for s in seeds {
+            if seen_files.insert(s.path) {
+                db.upsert_file(&file_record(s.path), None).unwrap();
+            }
+        }
+        for s in seeds {
+            db.insert_symbol(&symbol(s.path, s.name)).unwrap();
+        }
+        for s in seeds {
+            if let Some(target_id) = &s.calls {
+                db.insert_edge(&Edge {
+                    source_id: Symbol::make_id(s.path, s.name, None),
+                    target_id: Some(target_id.clone()),
+                    target_name: "callee".to_string(),
+                    kind: EdgeKind::Calls,
+                    line: Some(1),
+                    col: None,
+                    context: None,
+                })
+                .unwrap();
+            }
+        }
+        for s in seeds {
+            if let Some(vec) = s.embedding {
+                db.store_embedding(
+                    &Symbol::make_id(s.path, s.name, None),
+                    "test",
+                    "default",
+                    &vec,
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    temp
+}
+
+/// Ranked paths that `ctx smart` selects for `task` against the fixture at `root`,
+/// using `query` as the (seeded) task embedding.
+fn ranked_paths(root: &Path, task: &str, query: [f32; 4]) -> Vec<String> {
+    let db = Database::open(&root.join(".ctx").join("codebase.sqlite")).unwrap();
+    let analytics = Analytics::open(root).unwrap();
+    let embedding = Embedding::new(query.to_vec());
+    let result =
+        smart_context_with_embedding(&db, &analytics, task, &embedding, SmartConfig::default())
+            .unwrap();
+    result.selected_files.into_iter().map(|f| f.path).collect()
+}
+
+fn rank_of(paths: &[String], path: &str) -> Option<usize> {
+    paths.iter().position(|p| p == path)
+}
+
+/// Regression guard: a task token in a file's PATH must promote the on-topic
+/// file over a file that scores higher semantically and merely contains a symbol
+/// *named* like a task token. This is the `ctx`-helper case: `tests/*_cli.rs`
+/// define a helper `ctx`, and "ctx" is in the task — but matching symbol NAMES
+/// (rather than paths) let those test files displace `commands/sql.rs`.
+#[test]
+fn path_match_beats_symbol_name_noise() {
+    // Fixture paths use a `fixture/` prefix so they do NOT exist on disk relative
+    // to the test's CWD — token counts are a deterministic 0 and the budget never
+    // interferes with the ordering under test.
+    let seeds = [
+        // Highest semantic score, symbol literally named "ctx", path has no task token.
+        Seed {
+            path: "fixture/tests/foo_cli.rs",
+            name: "ctx",
+            embedding: Some([1.0, 0.0, 0.0, 0.0]),
+            calls: None,
+        },
+        // Lower semantic score, but its PATH contains the task token "sql".
+        Seed {
+            path: "fixture/commands/sql.rs",
+            name: "run_sql",
+            embedding: Some([0.8, 0.6, 0.0, 0.0]),
+            calls: None,
+        },
+        // Off-topic filler.
+        Seed {
+            path: "fixture/other.rs",
+            name: "helper",
+            embedding: Some([0.6, 0.8, 0.0, 0.0]),
+            calls: None,
+        },
+    ];
+    let temp = build_fixture(&seeds);
+
+    // Query closest to the "ctx" symbol: semantic order is foo_cli > sql > other.
+    let paths = ranked_paths(
+        temp.path(),
+        "add output format to ctx sql",
+        [1.0, 0.0, 0.0, 0.0],
+    );
+
+    let sql = rank_of(&paths, "fixture/commands/sql.rs");
+    let noise = rank_of(&paths, "fixture/tests/foo_cli.rs");
+    assert!(sql.is_some(), "on-topic sql.rs must be selected: {paths:?}");
+    assert!(
+        noise.is_some(),
+        "foo_cli.rs should still be selected: {paths:?}"
+    );
+    assert!(
+        sql < noise,
+        "path match (commands/sql.rs) must outrank the higher-semantic symbol-name \
+         noise (tests/foo_cli.rs); got {paths:?}. If this fails, lexical scoring is \
+         matching symbol names instead of the path."
+    );
+    assert_eq!(
+        paths.first().map(String::as_str),
+        Some("fixture/commands/sql.rs"),
+        "the path-matched file should rank first: {paths:?}"
+    );
+}
+
+/// A candidate reachable only through call-graph expansion (never a direct
+/// semantic hit) whose PATH matches the task must be promoted to the top, rather
+/// than sitting below every semantic match. Guards the lexical tier-promotion
+/// that surfaces `embeddings/openai.rs` for "…openai".
+#[test]
+fn graph_only_path_match_is_promoted() {
+    let openai_id = Symbol::make_id("fixture/embeddings/openai.rs", "call_api", None);
+    let seeds = [
+        // Semantic hit that CALLS the openai symbol; its path matches "embeddings".
+        Seed {
+            path: "fixture/embeddings/mod.rs",
+            name: "embed_all",
+            embedding: Some([1.0, 0.0, 0.0, 0.0]),
+            calls: Some(openai_id.clone()),
+        },
+        // Graph-only: no embedding, so it is never a semantic hit — it enters only
+        // via the Calls edge above. Its path contains "embeddings" AND "openai".
+        Seed {
+            path: "fixture/embeddings/openai.rs",
+            name: "call_api",
+            embedding: None,
+            calls: None,
+        },
+        // Another semantic hit with no task-token path overlap.
+        Seed {
+            path: "fixture/other.rs",
+            name: "helper",
+            embedding: Some([0.7, 0.714, 0.0, 0.0]),
+            calls: None,
+        },
+    ];
+    let temp = build_fixture(&seeds);
+
+    let paths = ranked_paths(
+        temp.path(),
+        "generate embeddings with openai",
+        [1.0, 0.0, 0.0, 0.0],
+    );
+
+    assert_eq!(
+        paths.first().map(String::as_str),
+        Some("fixture/embeddings/openai.rs"),
+        "the graph-only file whose path matches two task tokens should rank first; got {paths:?}"
+    );
+    // And it must rank above the semantic match that expanded it.
+    let openai = rank_of(&paths, "fixture/embeddings/openai.rs");
+    let modrs = rank_of(&paths, "fixture/embeddings/mod.rs");
+    assert!(
+        openai < modrs,
+        "openai.rs (2 path hits) must outrank embeddings/mod.rs (1 path hit): {paths:?}"
+    );
+}


### PR DESCRIPTION
Follow-up to #18. After #18 made `ctx smart` deterministic and semantic-first, two residual misses remained — and diagnosis (via `ctx smart --dry-run`, which lists the full candidate set) showed they have **different root causes**:

| Case | Cause | Fix |
|---|---|---|
| `embeddings/openai.rs` missing for "generate embeddings with openai" | It's a candidate (tier-1 `Calls`) whose path contains "openai", but ranks below the semantic matches and is squeezed out by the budget | **Lexical path boost** |
| `parser/solidity.rs` missing for "parse solidity contracts" | Already **rank-1** `SemanticMatch`, but **9074 tokens > the 8000 budget**, so greedy first-fit drops it and backfills with smaller files | **Budget guarantee** |

(The original #18 case — "add a new output format to ctx sql" → `src/commands/sql.rs` at rank 1 — must not regress.)

There is no relevance-eval harness in the repo to tune against (the merged `perf/`, `snapshot`, and run-record work are timing / code-metrics / agent-outcome tools, not file-selection evals), so this uses **integer token-overlap counts** — no float coefficient — and is validated against concrete queries + unit tests.

## Part A — lexical path boost
- New shared `utils::lexical_tokens`: lowercases, splits on non-alphanumeric **and** camelCase boundaries, drops length-≤-1 tokens and a small stopword set.
- `FileSelection.lexical_score` = count of distinct task tokens present in the file's **path**. **Path only, not symbol names** — matching identifiers is low-precision: `ctx` (the tool's own name) appears as a test helper across `tests/*_cli.rs` and would score a hit on nearly every file, demoting the on-topic one. (This was caught during end-to-end verification: an earlier symbol-name variant regressed the sql case by promoting test files; path-only fixes it.)
- `rank_files` treats a lexical hit as top-tier alongside semantic matches and orders lexical hits first within the tier. #18's determinism (path tie-break) and tiering are preserved.

## Part B — budget guarantee
- `select_with_guaranteed_top` always includes the rank-1 file even when it alone exceeds the budget, then first-fits the remainder (reusing the shared `select_by_token_budget`). The handler emits a one-line **stderr** note when the top file is oversized.

## Verification
- Full suite green: **fmt**, **clippy --all-targets -D warnings**, all tests pass (lib 305 incl. new tokenizer / lexical-promotion / path-only / budget tests; #18 tests still pass with `lexical_score = 0`).
- End-to-end (release build vs. the live index):
  - "generate embeddings with openai" → `src/embeddings/openai.rs` at **rank 1**.
  - "parse solidity contracts" → `src/parser/solidity.rs` included, with the oversize stderr note.
  - "add a new output format to ctx sql" → `src/commands/sql.rs` at **rank 1**, identical set across 5 runs (**no #18 regression**; the `ctx`-noise test files are correctly demoted).
- No `perf/` impact: `smart` is not a perf scenario.