### PR TITLE
fix: fingerprint Solidity functions in ctx duplicates (AGE-2)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -362,7 +362,8 @@ internal and unstable. Access is read-only and engine-hardened.
     /// token shingles (identifiers -> ID, literals -> LIT, comments dropped),
     /// so renamed variables and changed literals still match. Fingerprints
     /// are built during `ctx index`; reindex before running this command.
-    /// Solidity functions are skipped (no tree-sitter grammar).
+    /// Solidity functions are fingerprinted too (tokenized with the
+    /// solang-parser lexer).
     ///
     /// Breaking change: this replaces the old line-based detector and its
     /// percent/line-count flags.

--- a/src/commands/duplicates.rs
+++ b/src/commands/duplicates.rs
@@ -70,9 +70,9 @@ pub fn run_duplicates(
                 "threshold": threshold,
                 "min_tokens": min_tokens,
                 "against": against,
-                // Solidity is parsed with solang-parser (no tree-sitter
-                // grammar), so its functions are never fingerprinted.
-                "skipped_languages": ["solidity"],
+                // Every supported language is fingerprinted (Solidity via the
+                // solang-parser lexer), so nothing is skipped.
+                "skipped_languages": [],
                 "pairs": json_pairs,
             }),
         )?;
@@ -129,9 +129,6 @@ fn print_human(pairs: &[DuplicatePair], threshold: f64, min_tokens: i64, against
     println!("Found {} near-duplicate pair(s).", pairs.len());
     println!(
         "Note: idiomatic boilerplate can look structurally similar; raise --min-tokens to filter short functions."
-    );
-    println!(
-        "Note: Solidity functions are not fingerprinted (no tree-sitter grammar) and are skipped."
     );
 }
 

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -18,8 +18,9 @@
 //!    Jaccard similarity over re-derived shingle sets.
 //!
 //! Notes and limitations:
-//! - Solidity is parsed with solang-parser (no tree-sitter grammar), so
-//!   Solidity functions are not fingerprinted and never appear in results.
+//! - Solidity has no tree-sitter grammar in this build; it is tokenized with
+//!   the solang-parser lexer instead (see `tokenize`), so Solidity functions
+//!   are fingerprinted just like the tree-sitter languages.
 //! - Nested functions share tokens with their enclosing function: both are
 //!   fingerprinted over their own line ranges, and the parent's range
 //!   includes the child's tokens.
@@ -101,7 +102,8 @@ pub struct Tok {
 }
 
 /// Map a [`Language`] to its tree-sitter grammar, or `None` for languages
-/// without one (Solidity is parsed with solang-parser and is skipped).
+/// without one. Solidity has no grammar here and returns `None`; it is
+/// tokenized with the solang-parser lexer in [`tokenize`] instead.
 fn ts_language(lang: Language) -> Option<tree_sitter::Language> {
     match lang {
         Language::Rust => Some(tree_sitter_rust::language()),
@@ -151,10 +153,15 @@ fn normalize_leaf(kind: &str, text: &str) -> String {
 
 /// Tokenize a whole source file into a normalized token stream.
 ///
-/// Returns `None` for languages without a tree-sitter grammar (Solidity,
-/// YAML, unknown) or when parsing fails. Tokens are the leaf nodes of the
-/// AST in document order; comments (and their subtrees) are dropped.
+/// Solidity is lexed with the solang-parser lexer; every other supported
+/// language is parsed with tree-sitter and reduced to its leaf nodes in
+/// document order. Comments are dropped in both paths. Returns `None` for
+/// languages without either backend (YAML, unknown) or when parsing fails.
 pub fn tokenize(lang: Language, source: &str) -> Option<Vec<Tok>> {
+    if lang == Language::Solidity {
+        return Some(tokenize_solidity(source));
+    }
+
     let ts_lang = ts_language(lang)?;
 
     PARSERS.with(|cell| {
@@ -200,6 +207,62 @@ pub fn tokenize(lang: Language, source: &str) -> Option<Vec<Tok>> {
 
         Some(tokens)
     })
+}
+
+/// Tokenize Solidity source with the solang-parser lexer.
+///
+/// The lexer yields `(start, token, end)` spans with comments already
+/// excluded, so normalization mirrors [`normalize_leaf`]: identifiers become
+/// `ID`; string/hex/address/number literals become `LIT`; keywords and
+/// punctuation are kept as their verbatim lexeme (via the token's `Display`).
+/// Each token's 1-indexed line is derived from its start byte offset, matching
+/// the line numbers the solang parser records for symbols.
+fn tokenize_solidity(source: &str) -> Vec<Tok> {
+    use solang_parser::lexer::{Lexer, Token};
+
+    let line_starts = line_start_offsets(source);
+
+    // The lexer collects comments and lexical errors out-of-band; we only
+    // consume the token stream, so both sinks are discarded.
+    let mut comments = Vec::new();
+    let mut errors = Vec::new();
+    let lexer = Lexer::new(source, 0, &mut comments, &mut errors);
+
+    lexer
+        .map(|(start, token, _end)| {
+            let text = match token {
+                Token::Identifier(_) => "ID".to_string(),
+                Token::StringLiteral(..)
+                | Token::AddressLiteral(_)
+                | Token::HexLiteral(_)
+                | Token::Number(..)
+                | Token::RationalNumber(..)
+                | Token::HexNumber(_) => "LIT".to_string(),
+                other => other.to_string(),
+            };
+            Tok {
+                text,
+                line: offset_to_line(&line_starts, start),
+            }
+        })
+        .collect()
+}
+
+/// Byte offset of the first character of each source line (line 1 at index 0).
+fn line_start_offsets(source: &str) -> Vec<usize> {
+    let mut starts = vec![0usize];
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            starts.push(i + 1);
+        }
+    }
+    starts
+}
+
+/// Map a byte offset to its 1-indexed source line via the precomputed
+/// line-start table (the count of line starts at or before the offset).
+fn offset_to_line(line_starts: &[usize], offset: usize) -> u32 {
+    line_starts.partition_point(|&s| s <= offset) as u32
 }
 
 /// Build the set of k-shingle hashes for a token stream.
@@ -306,8 +369,8 @@ pub fn band_keys(sig: &[u64; NUM_PERMS]) -> [u64; LSH_BANDS] {
 /// `symbols` are the parser-produced symbols (pre-id-rewrite); `id_map`
 /// translates their ids to the stored `path::[parent::]name@line` form.
 /// Symbols with fewer than [`SHINGLE_K`] tokens (no shingles) get no
-/// fingerprint. Returns an empty vec for languages without a tree-sitter
-/// grammar (e.g. Solidity).
+/// fingerprint. Returns an empty vec for languages [`tokenize`] cannot handle
+/// (e.g. YAML).
 pub fn file_fingerprints(
     lang: Language,
     source: &str,
@@ -546,9 +609,29 @@ mod tests {
     }
 
     #[test]
+    fn test_tokenize_solidity_normalization() {
+        let src = "contract C {\n    function add(uint256 first) public pure returns (uint256) {\n        // a helpful remark\n        return first + 42;\n    }\n}\n";
+        let toks = texts(Language::Solidity, src);
+
+        // Identifiers -> ID, numeric literals -> LIT, keywords/punctuation kept.
+        assert!(toks.contains(&"ID".to_string()));
+        assert!(toks.contains(&"LIT".to_string()));
+        assert!(toks.contains(&"function".to_string()));
+        assert!(toks.contains(&"+".to_string()));
+        // Raw identifier/literal text is gone.
+        assert!(!toks.contains(&"first".to_string()));
+        assert!(!toks.contains(&"42".to_string()));
+        // Comments are dropped entirely (the solang lexer excludes them).
+        assert!(!toks.iter().any(|t| t.contains("remark")));
+
+        // Renamed identifiers + changed literals produce the same stream.
+        let renamed = "contract C {\n    function add(uint256 second) public pure returns (uint256) {\n        return second + 7;\n    }\n}\n";
+        assert_eq!(toks, texts(Language::Solidity, renamed));
+    }
+
+    #[test]
     fn test_tokenize_unsupported_languages() {
-        // Solidity is parsed with solang-parser, not tree-sitter: skipped.
-        assert!(tokenize(Language::Solidity, "contract C {}").is_none());
+        // Languages with neither a tree-sitter grammar nor a lexer path.
         assert!(tokenize(Language::Yaml, "a: 1").is_none());
         assert!(tokenize(Language::Unknown, "whatever").is_none());
     }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1046,7 +1046,7 @@ pub fn render_table(headers: &[String], widths: &[usize]) -> String {
     }
 
     #[test]
-    fn test_solidity_files_produce_no_fingerprints() {
+    fn test_solidity_files_produce_fingerprints() {
         let temp = TempDir::new().unwrap();
         fs::write(
             temp.path().join("Token.sol"),
@@ -1058,8 +1058,8 @@ pub fn render_table(headers: &[String], widths: &[usize]) -> String {
         let result = indexer.index().unwrap();
         assert_eq!(result.files_indexed, 1);
 
-        // Solidity has no tree-sitter grammar: indexed, but zero
-        // fingerprint rows and no error.
-        assert!(indexer.database().get_fingerprints(0).unwrap().is_empty());
+        // Solidity is tokenized with the solang-parser lexer, so its
+        // functions are fingerprinted like any other language.
+        assert!(!indexer.database().get_fingerprints(0).unwrap().is_empty());
     }
 }

--- a/tests/duplicates_cli.rs
+++ b/tests/duplicates_cli.rs
@@ -57,6 +57,45 @@ pub fn render_table(headers: &[String], widths: &[usize]) -> String {
 }
 "#;
 
+/// A Solidity function with > 50 normalized tokens.
+const SOL_A: &str = r#"
+pragma solidity ^0.8.0;
+
+contract Ledger {
+    function processOrders(uint256[] memory items) public pure returns (uint256) {
+        uint256 total = 0;
+        for (uint256 i = 0; i < items.length; i++) {
+            if (items[i] > 10) {
+                total += items[i] * 2;
+            } else {
+                total += items[i] + 1;
+            }
+        }
+        return total;
+    }
+}
+"#;
+
+/// A structural copy of `SOL_A` with renamed identifiers and different
+/// number literals.
+const SOL_B: &str = r#"
+pragma solidity ^0.8.0;
+
+contract Register {
+    function sumInvoices(uint256[] memory entries) public pure returns (uint256) {
+        uint256 acc = 0;
+        for (uint256 j = 0; j < entries.length; j++) {
+            if (entries[j] > 99) {
+                acc += entries[j] * 7;
+            } else {
+                acc += entries[j] + 3;
+            }
+        }
+        return acc;
+    }
+}
+"#;
+
 fn ctx(dir: &Path, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_ctx"))
         .args(args)
@@ -127,10 +166,7 @@ fn test_duplicates_json_output_and_exit_codes() {
     assert_eq!(doc["command"], "duplicates");
     assert_eq!(doc["data"]["threshold"], 0.85);
     assert_eq!(doc["data"]["min_tokens"], 50);
-    assert_eq!(
-        doc["data"]["skipped_languages"],
-        serde_json::json!(["solidity"])
-    );
+    assert_eq!(doc["data"]["skipped_languages"], serde_json::json!([]));
 
     let pairs = doc["data"]["pairs"].as_array().unwrap();
     assert_eq!(pairs.len(), 1, "pairs: {}", doc["data"]["pairs"]);
@@ -156,6 +192,38 @@ fn test_duplicates_json_output_and_exit_codes() {
     assert!(ctx(root, &["index"]).status.success());
     let out = ctx(root, &["duplicates", "--fail-on-found"]);
     assert_eq!(out.status.code(), Some(0));
+}
+
+#[test]
+fn test_duplicates_detects_solidity_near_duplicates() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    write(root, "contracts/Ledger.sol", SOL_A);
+    write(root, "contracts/Register.sol", SOL_B);
+    assert!(ctx(root, &["index"]).status.success());
+
+    let out = ctx(root, &["duplicates", "--json"]);
+    assert_eq!(out.status.code(), Some(0), "informational run exits 0");
+    let doc: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout is a single JSON document");
+
+    // Solidity is fingerprinted now, so nothing is skipped.
+    assert_eq!(doc["data"]["skipped_languages"], serde_json::json!([]));
+
+    // The two structurally identical .sol functions are detected as a pair.
+    let pairs = doc["data"]["pairs"].as_array().unwrap();
+    let found = pairs.iter().any(|p| {
+        let names = [
+            p["a"]["name"].as_str().unwrap_or(""),
+            p["b"]["name"].as_str().unwrap_or(""),
+        ];
+        names.contains(&"processOrders") && names.contains(&"sumInvoices")
+    });
+    assert!(
+        found,
+        "expected the two .sol functions to pair: {}",
+        doc["data"]["pairs"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`ctx duplicates` silently skipped **all Solidity functions**. The MinHash near-duplicate detector normalizes each function into token shingles via tree-sitter, and Solidity has no tree-sitter grammar in this build (it's parsed with `solang-parser`), so `.sol` functions never got fingerprints at index time. On a Solidity-heavy repo this made the detector — and the perception of coverage — blind to the largest part of the codebase.

## Approach

Rather than add `tree-sitter-solidity` (which conflicts with the pinned `tree-sitter ~0.20.10` — the documented reason the project chose solang in the first place), **tokenize Solidity with the `solang-parser` lexer** already in the dependency tree.

- New `tokenize_solidity` in `src/fingerprint.rs`: lexes with `solang_parser::lexer::Lexer` and maps tokens with the same normalization as the tree-sitter path (`normalize_leaf`): identifiers → `ID`; string/hex/address/number literals → `LIT`; keywords and punctuation kept verbatim; comments dropped (the lexer excludes them). Each token's 1-indexed line is derived from its byte offset so `file_fingerprints` slices by symbol line range exactly as for other languages.
- `tokenize` short-circuits to this path for `Language::Solidity`; `ts_language` still returns `None` for it.
- Removes the now-false "skipped" surfaces: `skipped_languages` in `duplicates --json` no longer lists solidity, the human-readable skip note is gone, and the `duplicates`/module docs are updated.

## Scope note

`ctx audit`'s Duplication score is a **separate name-based heuristic that never consults MinHash**, so this change fixes `ctx duplicates` but does not by itself move the audit score. Rewiring audit's duplication category onto fingerprints is a possible follow-up, not included here.

## Tests

- New `test_tokenize_solidity_normalization` (identifiers→ID, literals→LIT, renamed identifiers produce an identical stream).
- Inverted `test_solidity_files_produce_no_fingerprints` → `test_solidity_files_produce_fingerprints`.
- Updated `tests/duplicates_cli.rs` skip-list expectation and added an end-to-end test asserting two structurally-identical `.sol` functions are detected as a near-duplicate pair.

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo test` ✅ (304 lib + all integration suites, 0 failures)

Refs AGE-2. Sibling of AGE-4 (modifier edges) and AGE-5 (qualified-call resolution).