### PR TITLE
feat: run ctx index and ctx embed in parallel by default (AGE-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `ctx index` and `ctx embed` now run in parallel by default; pass `--serial` for single-threaded execution. `ctx embed` parallelizes embedding computation across rayon threads (chunked provider calls, preserving order and the provider's retry/backoff) while storing serially. The `-j`/`--parallel` flag on `ctx index` is now a no-op (kept for backward compatibility)
+
 ## [0.3.2] - 2026-07-11
 
 ### Added

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,9 +132,13 @@ pub enum Command {
         #[arg(long)]
         force: bool,
 
-        /// Use parallel parsing for faster indexing on multi-core systems
-        #[arg(long, short = 'j')]
+        /// (deprecated: parallel indexing is now the default; this flag is a no-op)
+        #[arg(long, short = 'j', hide = true)]
         parallel: bool,
+
+        /// Disable parallel indexing (single-threaded)
+        #[arg(long)]
+        serial: bool,
 
         /// Disable .gitignore pattern matching
         #[arg(long)]
@@ -286,6 +290,10 @@ internal and unstable. Access is read-only and engine-hardened.
         /// Watch for index changes and auto-embed new symbols
         #[arg(long, short)]
         watch: bool,
+
+        /// Disable parallel embedding (single-threaded)
+        #[arg(long)]
+        serial: bool,
     },
 
     /// Semantic search using embeddings (requires embeddings to be generated)

--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -18,7 +18,13 @@ fn local_model_hint(provider: Provider) {
 }
 
 /// Generate embeddings for all symbols.
-pub fn run_embed(force: bool, verbose: bool, batch_size: usize, provider: Provider) -> Result<()> {
+pub fn run_embed(
+    force: bool,
+    verbose: bool,
+    batch_size: usize,
+    provider: Provider,
+    serial: bool,
+) -> Result<()> {
     let root = env::current_dir()?;
     let db = index::open_database(&root)?;
 
@@ -72,6 +78,7 @@ pub fn run_embed(force: bool, verbose: bool, batch_size: usize, provider: Provid
         &db,
         provider.as_ref(),
         batch_size,
+        serial,
         Some(&progress_callback),
     )?;
 
@@ -91,7 +98,12 @@ pub fn run_embed(force: bool, verbose: bool, batch_size: usize, provider: Provid
 }
 
 /// Watch for index changes and auto-embed new symbols.
-pub fn run_embed_watch(verbose: bool, batch_size: usize, provider: Provider) -> Result<()> {
+pub fn run_embed_watch(
+    verbose: bool,
+    batch_size: usize,
+    provider: Provider,
+    serial: bool,
+) -> Result<()> {
     use notify::RecursiveMode;
     use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
     use std::sync::mpsc::channel;
@@ -122,8 +134,13 @@ pub fn run_embed_watch(verbose: bool, batch_size: usize, provider: Provider) -> 
                 "Initial embedding: {} symbols missing embeddings...",
                 total_symbols - existing
             );
-            let embedded =
-                embeddings::embed_missing_symbols(&db, provider.as_ref(), batch_size, None)?;
+            let embedded = embeddings::embed_missing_symbols(
+                &db,
+                provider.as_ref(),
+                batch_size,
+                serial,
+                None,
+            )?;
             println!("Embedded {} symbols", embedded);
         } else {
             println!("All {} symbols already have embeddings", total_symbols);
@@ -177,6 +194,7 @@ pub fn run_embed_watch(verbose: bool, batch_size: usize, provider: Provider) -> 
                                     &db,
                                     provider.as_ref(),
                                     batch_size,
+                                    serial,
                                     None,
                                 ) {
                                     Ok(embedded) => {

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -17,8 +17,8 @@ pub struct IndexConfig {
     pub verbose: bool,
     /// Force full reindex
     pub force: bool,
-    /// Use parallel indexing
-    pub parallel: bool,
+    /// Disable parallel indexing (single-threaded). Parallel is the default.
+    pub serial: bool,
     /// Walker configuration
     pub walker: walker::WalkerConfig,
 }
@@ -30,7 +30,7 @@ impl IndexConfig {
         watch: bool,
         verbose: bool,
         force: bool,
-        parallel: bool,
+        serial: bool,
         no_gitignore: bool,
         no_default_ignores: bool,
         ignore_patterns: Vec<String>,
@@ -40,7 +40,7 @@ impl IndexConfig {
             watch,
             verbose,
             force,
-            parallel,
+            serial,
             walker: walker::WalkerConfig {
                 use_gitignore: !no_gitignore,
                 use_default_ignores: !no_default_ignores,
@@ -72,17 +72,17 @@ pub fn run_index(config: IndexConfig) -> Result<()> {
         }
     }
 
-    if config.parallel {
-        eprintln!("Indexing codebase (parallel mode)...");
+    if config.serial {
+        eprintln!("Indexing codebase (serial mode)...");
     } else {
         eprintln!("Indexing codebase...");
     }
 
     let mut indexer = index::Indexer::with_config(&root, config.verbose, config.walker.clone())?;
-    let result = if config.parallel {
-        indexer.index_parallel()?
-    } else {
+    let result = if config.serial {
         indexer.index()?
+    } else {
+        indexer.index_parallel()?
     };
 
     eprintln!(

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -30,6 +30,8 @@ pub use local::LocalProvider;
 pub use ollama::OllamaProvider;
 pub use openai::OpenAIProvider;
 
+use rayon::prelude::*;
+
 use crate::error::{CtxError, Result};
 
 /// Embedding dimension for different models
@@ -327,11 +329,44 @@ fn semantic_search_slow(
     Ok(scored)
 }
 
+/// Compute embeddings for a batch of texts, splitting the work across rayon
+/// threads. The batch is divided into chunks and each chunk's `embed_batch`
+/// call runs concurrently.
+///
+/// Ordering is preserved: rayon's parallel `collect` keeps the chunks in
+/// source order, and each chunk keeps its own internal order, so flattening
+/// yields a `Vec<Embedding>` that lines up 1:1 with `texts`. Each chunk goes
+/// through the provider's normal `embed_batch`, so the provider's retry/backoff
+/// (e.g. the OpenAI rate-limit handling) is fully preserved.
+fn embed_texts_parallel<P: EmbeddingProvider + ?Sized>(
+    provider: &P,
+    texts: &[&str],
+) -> Result<Vec<Embedding>> {
+    // One chunk per worker thread (at least one), so provider calls run
+    // concurrently without over-splitting small batches.
+    let num_chunks = rayon::current_num_threads().max(1);
+    let chunk_size = texts.len().div_ceil(num_chunks).max(1);
+
+    let per_chunk: Vec<Vec<Embedding>> = texts
+        .par_chunks(chunk_size)
+        .map(|chunk| provider.embed_batch(chunk))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(per_chunk.into_iter().flatten().collect())
+}
+
 /// Embed all symbols that don't have embeddings yet.
+///
+/// Embedding computation is parallelized across rayon threads by default; pass
+/// `serial = true` for the single-threaded path. Regardless of mode, every
+/// `db.store_embedding` call happens serially on the owning thread (the
+/// `Database` connection is not shared for writes), and embeddings are stored
+/// in symbol order.
 pub fn embed_missing_symbols<P: EmbeddingProvider + ?Sized>(
     db: &crate::db::Database,
     provider: &P,
     batch_size: usize,
+    serial: bool,
     progress_callback: Option<&dyn Fn(usize, usize)>,
 ) -> Result<usize> {
     let mut total_embedded = 0;
@@ -349,10 +384,15 @@ pub fn embed_missing_symbols<P: EmbeddingProvider + ?Sized>(
 
         let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
 
-        // Generate embeddings
-        let embeddings = provider.embed_batch(&text_refs)?;
+        // Generate embeddings (parallel compute by default, serial on opt-out).
+        // Both paths return embeddings in the same order as `text_refs`.
+        let embeddings = if serial {
+            provider.embed_batch(&text_refs)?
+        } else {
+            embed_texts_parallel(provider, &text_refs)?
+        };
 
-        // Store embeddings
+        // Store embeddings serially on the owning thread, in symbol order.
         for (symbol, embedding) in symbols.iter().zip(embeddings.iter()) {
             db.store_embedding(&symbol.id, provider.name(), "default", &embedding.vector)?;
         }
@@ -394,6 +434,46 @@ mod tests {
         normalize(&mut v);
         assert!((v[0] - 0.6).abs() < 1e-6);
         assert!((v[1] - 0.8).abs() < 1e-6);
+    }
+
+    /// Deterministic provider: embeds each text as a 1-dim vector holding the
+    /// byte length of the text. Lets us assert ordering without any network.
+    struct LenProvider;
+
+    impl EmbeddingProvider for LenProvider {
+        fn name(&self) -> &str {
+            "len"
+        }
+        fn dimension(&self) -> usize {
+            1
+        }
+        fn embed(&self, text: &str) -> Result<Embedding> {
+            Ok(Embedding::new(vec![text.len() as f32]))
+        }
+    }
+
+    #[test]
+    fn test_embed_texts_parallel_preserves_order() {
+        // Distinct lengths so each text has a unique embedding.
+        let texts = ["a", "bb", "ccc", "dddd", "eeeee", "ffffff", "g", "hh"];
+        let refs: Vec<&str> = texts.to_vec();
+
+        let serial = LenProvider.embed_batch(&refs).unwrap();
+        let parallel = embed_texts_parallel(&LenProvider, &refs).unwrap();
+
+        assert_eq!(serial.len(), texts.len());
+        assert_eq!(parallel.len(), texts.len());
+        for (i, text) in texts.iter().enumerate() {
+            let expected = text.len() as f32;
+            assert_eq!(serial[i].vector, vec![expected]);
+            assert_eq!(parallel[i].vector, vec![expected], "order mismatch at {i}");
+        }
+    }
+
+    #[test]
+    fn test_embed_texts_parallel_empty() {
+        let parallel = embed_texts_parallel(&LenProvider, &[]).unwrap();
+        assert!(parallel.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,9 @@ fn run(args: Args) -> Result<Outcome> {
             watch,
             verbose,
             force,
-            parallel,
+            // Deprecated no-op: parallel indexing is now the default.
+            parallel: _,
+            serial,
             no_gitignore,
             no_default_ignores,
             ignore_patterns,
@@ -99,7 +101,7 @@ fn run(args: Args) -> Result<Outcome> {
                 watch,
                 verbose,
                 force,
-                parallel,
+                serial,
                 no_gitignore,
                 no_default_ignores,
                 ignore_patterns,
@@ -154,12 +156,13 @@ fn run(args: Args) -> Result<Outcome> {
             provider,
             openai,
             watch,
+            serial,
         }) => {
             let provider = resolve_embed_provider(provider, openai);
             if watch {
-                commands::run_embed_watch(verbose, batch_size, provider)
+                commands::run_embed_watch(verbose, batch_size, provider, serial)
             } else {
-                commands::run_embed(force, verbose, batch_size, provider)
+                commands::run_embed(force, verbose, batch_size, provider, serial)
             }
         }
         Some(Command::Semantic {


### PR DESCRIPTION
## Summary

Parallel execution is now the **default** for `ctx index` and `ctx embed`; single-threaded is an explicit `--serial` opt-out. Previously parallelism was opt-in for `index` (`-j/--parallel`) and absent for `embed`, so the common path was slower than necessary on multi-core machines.

## Changes

**`ctx index`**
- Runs `index_parallel()` by default; `--serial` forces the single-threaded `index()` path (and logs "serial mode").
- `-j/--parallel` is kept as a **hidden, deprecated no-op** so existing scripts/CI don't break.
- `IndexConfig.parallel` → `IndexConfig.serial` (meaning inverted); all call sites updated (`src/main.rs`, `src/commands/index.rs`).

**`ctx embed`**
- New `--serial` flag.
- `embed_missing_symbols` gained a `serial` param. By default, embedding **compute** is parallelized across rayon threads via a new `embed_texts_parallel` helper (`par_chunks`, one `embed_batch` per chunk). Every `db.store_embedding` **write stays serial on the owning thread** — the SQLite `Connection` is `Send` but not `Sync`.
- **Ordering preserved:** rayon's ordered `collect` + per-chunk order means the flattened `Vec<Embedding>` lines up 1:1 with the input symbols.
- **Retry/backoff preserved:** each chunk goes through the provider's normal `embed_batch`, so the OpenAI rate-limit handling is untouched.

`--jobs N` was intentionally left out of scope (the rayon global pool governs thread count) — possible follow-up.

## Tests / docs

- Added `test_embed_texts_parallel_preserves_order` and `test_embed_texts_parallel_empty` (deterministic mock provider, asserts parallel output == serial and preserves order).
- `CHANGELOG.md` entry under `[Unreleased]`.

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo test` ✅ (305 lib + all integration suites, 0 failures)

Refs AGE-3.