### PR TITLE
fix: resolve Solidity qualified library calls Lib.fn() (AGE-5)

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1610,6 +1610,9 @@ impl Database {
     ///
     /// This performs cross-file symbol resolution by matching target_name to symbols
     /// in the database. Resolution priority:
+    /// 0. Qualified match: the edge `context` equals a symbol's `qualified_name`
+    ///    exactly (e.g., "ChessPureLib.isKingInCheck"), disambiguating a bare name
+    ///    shared across files/languages.
     /// 1. Context match: the call context contains the type name (e.g., "TypeScriptParser::new()")
     /// 2. Unique: only one symbol with that name exists in the codebase
     /// 3. Same file unique: only one symbol with that name exists in the same file
@@ -1619,6 +1622,32 @@ impl Database {
     ///
     /// Returns the number of edges that were resolved.
     pub fn resolve_edge_targets(&self) -> Result<usize> {
+        // Step 0: Resolve edges whose `context` holds a fully qualified name by an
+        // EXACT match on a symbol's `qualified_name` (e.g. Solidity qualified calls
+        // like `ChessPureLib.isKingInCheck`). This must run BEFORE the substring
+        // LIKE match in Step 1: exact equality disambiguates the intended target
+        // even when the bare `target_name` collides across files/languages, and it
+        // sets `target_id` so the later `target_id IS NULL` steps skip the row.
+        let qualified_resolved = self.conn.execute(
+            r#"
+            UPDATE edges
+            SET target_id = (
+                SELECT id FROM symbols
+                WHERE qualified_name = edges.context
+                  AND kind IN ('function', 'method')
+                LIMIT 1
+            )
+            WHERE target_id IS NULL
+              AND context IS NOT NULL
+              AND (
+                SELECT COUNT(*) FROM symbols
+                WHERE qualified_name = edges.context
+                  AND kind IN ('function', 'method')
+              ) = 1
+            "#,
+            [],
+        )?;
+
         // Step 1: Resolve edges where the context contains the qualified name
         // e.g., context "TypeScriptParser::new()" matches symbol with qualified_name "TypeScriptParser::new"
         // Only resolve if exactly one symbol matches to avoid ambiguous resolution
@@ -1715,7 +1744,7 @@ impl Database {
             [],
         )?;
 
-        Ok(context_resolved + unique_resolved + same_file_unique)
+        Ok(qualified_resolved + context_resolved + unique_resolved + same_file_unique)
     }
 
     /// Insert (or replace) a batch of MinHash fingerprints in one transaction.

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1062,4 +1062,98 @@ pub fn render_table(headers: &[String], widths: &[usize]) -> String {
         // fingerprint rows and no error.
         assert!(indexer.database().get_fingerprints(0).unwrap().is_empty());
     }
+
+    /// AGE-5: a Solidity qualified call `ChessPureLib.isKingInCheck(...)` must
+    /// resolve to the library's method even when the bare name `isKingInCheck`
+    /// is ambiguous (also defined in another file). Before the fix the resolver
+    /// bailed on the ambiguous bare name and left `target_id` NULL, silently
+    /// zeroing the callee's fan-in/complexity/reachability metrics.
+    #[test]
+    fn test_solidity_qualified_call_resolves_across_ambiguous_bare_name() {
+        let temp = TempDir::new().unwrap();
+
+        // Library whose method we expect the qualified call to resolve to.
+        fs::write(
+            temp.path().join("ChessPureLib.sol"),
+            r#"pragma solidity ^0.8.0;
+library ChessPureLib {
+    function isKingInCheck(uint256 tb, bool forBlack) internal pure returns (bool) {
+        return tb > 0 && forBlack;
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        // A second library defining a colliding bare name, so a plain
+        // name lookup for `isKingInCheck` is ambiguous (COUNT > 1).
+        fs::write(
+            temp.path().join("OtherLib.sol"),
+            r#"pragma solidity ^0.8.0;
+library OtherLib {
+    function isKingInCheck(uint256 tb, bool forBlack) internal pure returns (bool) {
+        return tb < 0 || forBlack;
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        // Caller making the qualified call `ChessPureLib.isKingInCheck(...)`.
+        fs::write(
+            temp.path().join("Game.sol"),
+            r#"pragma solidity ^0.8.0;
+contract Game {
+    function check(uint256 tb, bool forBlack) public pure returns (bool) {
+        return ChessPureLib.isKingInCheck(tb, forBlack);
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        let mut indexer = Indexer::new_in_memory(temp.path()).unwrap();
+        indexer.index().unwrap();
+
+        let db = indexer.database();
+
+        // The bare name is ambiguous: two library methods share it.
+        let candidates: Vec<_> = db
+            .find_symbols("isKingInCheck", 50)
+            .unwrap()
+            .into_iter()
+            .filter(|s| s.kind == crate::db::SymbolKind::Function)
+            .collect();
+        assert!(
+            candidates.len() >= 2,
+            "expected the bare name to be ambiguous, got {} candidate(s)",
+            candidates.len()
+        );
+
+        // The intended target: ChessPureLib.isKingInCheck.
+        let chess_lib_method = candidates
+            .iter()
+            .find(|s| s.qualified_name.as_deref() == Some("ChessPureLib.isKingInCheck"))
+            .expect("expected a ChessPureLib.isKingInCheck symbol");
+
+        // The edge for the qualified call must resolve to the ChessPureLib method,
+        // not be left NULL and not point at the OtherLib method.
+        let call_edge = db
+            .get_incoming_edges("isKingInCheck")
+            .unwrap()
+            .into_iter()
+            .find(|e| e.kind == crate::db::EdgeKind::Calls)
+            .expect("expected a calls edge for isKingInCheck");
+
+        assert_eq!(
+            call_edge.context.as_deref(),
+            Some("ChessPureLib.isKingInCheck"),
+            "qualifier should be captured on the edge context"
+        );
+        assert_eq!(
+            call_edge.target_id.as_deref(),
+            Some(chess_lib_method.id.as_str()),
+            "qualified call must resolve to ChessPureLib.isKingInCheck, not NULL or the OtherLib symbol"
+        );
+    }
 }

--- a/src/parser/solidity.rs
+++ b/src/parser/solidity.rs
@@ -727,6 +727,7 @@ fn extract_call_edges(file_path: &str, source: &str, symbols: &[Symbol], edges: 
                 SourceUnitPart::ContractDefinition(def) => {
                     for cpart in &def.parts {
                         if let ContractPart::FunctionDefinition(func) = cpart {
+                            extract_modifier_edges(func, source, &func_ranges, symbols, edges);
                             if let Some(ref body) = func.body {
                                 extract_calls_from_statement(
                                     body,
@@ -742,6 +743,7 @@ fn extract_call_edges(file_path: &str, source: &str, symbols: &[Symbol], edges: 
                 }
                 SourceUnitPart::FunctionDefinition(func) => {
                     // Handle free functions (top-level functions outside contracts)
+                    extract_modifier_edges(func, source, &func_ranges, symbols, edges);
                     if let Some(ref body) = func.body {
                         extract_calls_from_statement(
                             body,
@@ -754,6 +756,56 @@ fn extract_call_edges(file_path: &str, source: &str, symbols: &[Symbol], edges: 
                     }
                 }
                 _ => {}
+            }
+        }
+    }
+}
+
+/// Emit `calls` edges for each modifier (or base-contract) invocation applied to
+/// a function via `FunctionAttribute::BaseOrModifier`.
+///
+/// This also covers constructor base-contract invocations
+/// (e.g. `constructor() Ownable(msg.sender)`); those are treated the same way -
+/// an edge to the base name is emitted, resolving `target_id` when a matching
+/// symbol exists and leaving it `None` otherwise (mirroring unresolved calls).
+fn extract_modifier_edges(
+    func: &pt::FunctionDefinition,
+    source: &str,
+    func_ranges: &[(u32, u32, String)],
+    symbols: &[Symbol],
+    edges: &mut Vec<Edge>,
+) {
+    for attr in &func.attributes {
+        if let FunctionAttribute::BaseOrModifier(_, base) = attr {
+            // The modifier/base name is the last segment of the identifier path.
+            let name = match base.name.identifiers.last() {
+                Some(id) => id.name.clone(),
+                None => continue,
+            };
+
+            let (line, _, col, _) = loc_to_lines(&base.loc, source);
+
+            // Find which function this attribute is on.
+            let source_id = func_ranges
+                .iter()
+                .find(|(start, end, _)| line >= *start && line <= *end)
+                .map(|(_, _, id)| id.clone());
+
+            if let Some(source_id) = source_id {
+                let target_id = symbols
+                    .iter()
+                    .find(|s| s.name == name && s.kind == SymbolKind::Function)
+                    .map(|s| s.id.clone());
+
+                edges.push(Edge {
+                    source_id,
+                    target_id,
+                    target_name: name,
+                    kind: EdgeKind::Calls,
+                    line: Some(line),
+                    col: Some(col),
+                    context: None,
+                });
             }
         }
     }
@@ -1236,6 +1288,20 @@ contract Ownable {
 
         let modifier = result.symbols.iter().find(|s| s.name == "onlyOwner");
         assert!(modifier.is_some());
+
+        // Applying the `onlyOwner` modifier to `transferOwnership` should produce a
+        // `calls` edge to the modifier, with `target_id` resolved to its symbol.
+        let modifier_edge = result
+            .edges
+            .iter()
+            .find(|e| e.target_name == "onlyOwner")
+            .expect("expected a calls edge to the onlyOwner modifier");
+        assert_eq!(modifier_edge.kind, EdgeKind::Calls);
+        assert_eq!(
+            modifier_edge.target_id.as_deref(),
+            Some(modifier.unwrap().id.as_str()),
+            "modifier edge target_id must resolve to the onlyOwner symbol"
+        );
     }
 
     #[test]

--- a/src/parser/solidity.rs
+++ b/src/parser/solidity.rs
@@ -960,11 +960,21 @@ fn extract_calls_from_expr(
         Expression::FunctionCall(loc, func_expr, _args) => {
             let (line, _, col, _) = loc_to_lines(loc, source);
 
-            // Get the function name
-            let func_name = match func_expr.as_ref() {
-                Expression::Variable(id) => Some(id.name.clone()),
-                Expression::MemberAccess(_, _, member) => Some(member.name.clone()),
-                _ => None,
+            // Get the function name and, for qualified calls like
+            // `LibraryName.fn(...)`, the fully qualified name so the resolver can
+            // disambiguate a bare name shared across files/languages.
+            let (func_name, context) = match func_expr.as_ref() {
+                Expression::Variable(id) => (Some(id.name.clone()), None),
+                Expression::MemberAccess(_, object, member) => {
+                    // Only capture the qualifier for a simple `Name.member` call;
+                    // chained/complex receivers stay unqualified (context: None).
+                    let context = match object.as_ref() {
+                        Expression::Variable(id) => Some(format!("{}.{}", id.name, member.name)),
+                        _ => None,
+                    };
+                    (Some(member.name.clone()), context)
+                }
+                _ => (None, None),
             };
 
             if let Some(name) = func_name {
@@ -988,7 +998,7 @@ fn extract_calls_from_expr(
                         kind: EdgeKind::Calls,
                         line: Some(line),
                         col: Some(col),
-                        context: None,
+                        context,
                     });
                 }
             }
@@ -1002,7 +1012,19 @@ fn extract_calls_from_expr(
         Expression::FunctionCallBlock(loc, func_expr, _) => {
             // Handle block-style function calls (used with modifiers)
             let (line, _, col, _) = loc_to_lines(loc, source);
-            if let Expression::Variable(id) = func_expr.as_ref() {
+            let (func_name, context) = match func_expr.as_ref() {
+                Expression::Variable(id) => (Some(id.name.clone()), None),
+                Expression::MemberAccess(_, object, member) => {
+                    let context = match object.as_ref() {
+                        Expression::Variable(id) => Some(format!("{}.{}", id.name, member.name)),
+                        _ => None,
+                    };
+                    (Some(member.name.clone()), context)
+                }
+                _ => (None, None),
+            };
+
+            if let Some(name) = func_name {
                 let source_id = func_ranges
                     .iter()
                     .find(|(start, end, _)| line >= *start && line <= *end)
@@ -1011,17 +1033,17 @@ fn extract_calls_from_expr(
                 if let Some(source_id) = source_id {
                     let target_id = symbols
                         .iter()
-                        .find(|s| s.name == id.name && s.kind == SymbolKind::Function)
+                        .find(|s| s.name == name && s.kind == SymbolKind::Function)
                         .map(|s| s.id.clone());
 
                     edges.push(Edge {
                         source_id,
                         target_id,
-                        target_name: id.name.clone(),
+                        target_name: name,
                         kind: EdgeKind::Calls,
                         line: Some(line),
                         col: Some(col),
-                        context: None,
+                        context,
                     });
                 }
             }


### PR DESCRIPTION
> **Stacked on #29 (AGE-4).** Base is the AGE-4 branch so the diff shows only the AGE-5 change; retarget to `main` once #29 merges.

## Summary

Solidity qualified calls `LibraryName.fn(...)` (e.g. `ChessPureLib.isKingInCheck(...)`) were captured as edges but frequently left **unresolved** (`target_id = NULL`) whenever the bare function name existed in ≥2 files (e.g. a Solidity library and a TypeScript mirror). Since `fan_in`/`fan_out`/complexity/reachability count only resolved edges, the callee's metrics silently collapsed to 0 — corrupting `hotspots` ranking, `query callers`/`impact`, and any reachability closure. Higher severity than the sibling Solidity issues because it **silently corrupts existing metrics** rather than omitting a feature.

## Root cause (two drop points)

1. **Qualifier discarded at capture** — the `MemberAccess` arm of `extract_calls_from_expr` kept only `member.name` and threw away the `ChessPureLib` object; the edge stored the bare name with `context: None`.
2. **Ambiguity bail in the resolver** — `resolve_edge_targets`'s unique-name step only resolves when the bare `target_name` matches exactly one symbol; ambiguous names were left NULL. No step consulted the qualifier or `qualified_name`.

## Fix

- **Parser** (`src/parser/solidity.rs`): for `Name.member(...)` calls, store the fully qualified `Name.member` in the edge's `context` (kept `target_name` = bare name for fallback and `get_incoming_edges`). Complex/chained receivers stay unqualified. Same treatment for block-style calls.
- **Resolver** (`src/db/schema.rs`): new **Step 0** resolves an edge whose `context` equals a symbol's `qualified_name` **exactly** (Solidity library methods already carry `qualified_name = "ChessPureLib.isKingInCheck"`), when unique. Ordered **before** the existing substring-`LIKE` step so the exact match wins and later `target_id IS NULL` steps skip the row — no regression to other languages' resolution (verified: the LIKE step keeps its `target_id IS NULL` guard).

The optional same-language tiebreak for *unqualified* ambiguous names was deferred (would risk cross-language behavior changes; the exact-qualified step resolves the reported cases).

## Tests

`test_solidity_qualified_call_resolves_across_ambiguous_bare_name`: two libraries define `isKingInCheck` (ambiguous, COUNT=2) and a caller does `ChessPureLib.isKingInCheck(...)`; asserts the edge resolves `target_id` to the **correct** library method, not NULL and not the other file's symbol.

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo test` ✅ (304 lib + all integration suites, 0 failures)

Refs AGE-5. Depends on #29 (AGE-4).