### PR TITLE
ci: report ctx analysis on pull requests

### DIFF
--- a/.github/scripts/render-ctx-pr-comment.cjs
+++ b/.github/scripts/render-ctx-pr-comment.cjs
@@ -1,0 +1,139 @@
+'use strict';
+
+const MARKER = '<!-- ctx-pr-report -->';
+const MAX_COMMENT_LENGTH = 60_000;
+
+function text(value) {
+  return String(value ?? '')
+    .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, ' ')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('@', '&#64;')
+    .replaceAll('|', '&#124;')
+    .replaceAll('`', '&#96;')
+    .replace(/[\r\n]+/g, ' ')
+    .slice(0, 300);
+}
+
+function number(value, fallback = 0) {
+  return Number.isFinite(Number(value)) ? Number(value) : fallback;
+}
+
+function data(document) {
+  return document && typeof document === 'object' && document.data
+    ? document.data
+    : (document || {});
+}
+
+function symbol(value) {
+  const item = value || {};
+  const name = text(item.qualified_name || item.name || 'unknown');
+  const file = text(item.file || 'unknown');
+  const line = number(item.line_start, 0);
+  return `${name} (${file}${line ? `:${line}` : ''})`.slice(0, 300);
+}
+
+function renderComment(report, options = {}) {
+  const metadata = report.metadata || {};
+  const audit = report.audit || {};
+  const stats = data(report.stats);
+  const score = data(report.score);
+  const metrics = score.metrics || {};
+  const duplicates = data(report.duplicates);
+  const hotspots = data(report.hotspots);
+  const check = data(report.check);
+  const map = data(report.map);
+  const artifactUrl = text(options.artifactUrl || '');
+  const lines = [
+    MARKER,
+    `<!-- ctx-pr-report-run:${number(options.runId)} -->`,
+    '## ctx analysis',
+    '',
+    `Analyzed \`${text(String(metadata.head_sha || '').slice(0, 12))}\` against \`${text(String(metadata.base_sha || '').slice(0, 12))}\` with ctx ${text(report.stats?.ctx_version || 'unknown')}.`,
+    '',
+    '| PR delta | Value |',
+    '|---|---:|',
+    `| Files changed | ${number(metrics.files_changed ?? score.files_changed)} |`,
+    `| Complexity delta | ${number(metrics.complexity_delta)} |`,
+    `| Fan-out delta | ${number(metrics.fan_out_delta)} |`,
+    `| Symbols added / removed | ${number(metrics.symbols_added)} / ${number(metrics.symbols_removed)} |`,
+    `| New duplicate pairs | ${number(metrics.new_duplication, (duplicates.pairs || []).length)} |`,
+    `| Architecture violations | ${number(metrics.check_violations, check.summary?.violations)} |`,
+    `| Whole-codebase audit | ${number(audit.overall_score).toFixed(1)} / 10 |`,
+    '',
+    '### Repository health',
+    '',
+    `Indexed **${number(stats.files)} files**, **${number(stats.symbols)} symbols**, **${number(stats.functions)} functions**, and **${number(stats.edges)} relationships**.`,
+    '',
+    '| Audit category | Score | Issues |',
+    '|---|---:|---:|',
+  ];
+
+  for (const category of (audit.categories || [])) {
+    lines.push(`| ${text(category.name)} | ${number(category.score).toFixed(1)} | ${number(category.issue_count)} |`);
+  }
+
+  const issues = (audit.issues || []).filter((issue) => issue.severity !== 'info');
+  lines.push('', '<details>', `<summary>Audit findings (${issues.length})</summary>`, '');
+  if (issues.length === 0) lines.push('No critical or warning findings.');
+  for (const issue of issues.slice(0, 20)) {
+    const location = `${text(issue.file)}${issue.line ? `:${number(issue.line)}` : ''}`;
+    lines.push(`- **${text(issue.severity)} · ${text(issue.category)} · ${location}** — ${text(issue.message)}`);
+  }
+  if (issues.length > 20) lines.push(`- … ${issues.length - 20} more in the artifact.`);
+  lines.push('', '</details>', '');
+
+  const pairs = duplicates.pairs || [];
+  lines.push('<details>', `<summary>New near-duplicate functions (${pairs.length})</summary>`, '');
+  if (pairs.length === 0) lines.push('No new near-duplicate functions were found in changed files.');
+  for (const pair of pairs.slice(0, 15)) {
+    lines.push(`- **${number(pair.similarity).toFixed(3)} similarity:** ${symbol(pair.a)} ↔ ${symbol(pair.b)}`);
+  }
+  if (pairs.length > 15) lines.push(`- … ${pairs.length - 15} more in the artifact.`);
+  lines.push('', '</details>', '');
+
+  const violations = check.violations || [];
+  lines.push('<details>', `<summary>Architecture-rule findings (${violations.length})</summary>`, '');
+  if (violations.length === 0) lines.push(text(check.note || 'No architecture-rule violations were found.'));
+  for (const violation of violations.slice(0, 15)) {
+    lines.push(`- **${text(violation.rule_id || violation.rule)}** — ${text(violation.message || violation.reason)}`);
+  }
+  if (violations.length > 15) lines.push(`- … ${violations.length - 15} more in the artifact.`);
+  lines.push('', '</details>', '');
+
+  const entries = hotspots.entries || [];
+  lines.push('<details>', `<summary>Changed-code hotspots (${entries.length})</summary>`, '', '| File | Churn | Complexity | Score |', '|---|---:|---:|---:|');
+  for (const entry of entries.slice(0, 20)) {
+    lines.push(`| ${text(entry.file)} | ${number(entry.commits)} | ${number(entry.complexity)} | ${number(entry.score).toFixed(3)} |`);
+  }
+  if (entries.length === 0) lines.push('| _No changed file met the churn threshold_ |  |  |  |');
+  lines.push('', '</details>', '');
+
+  const mapEntries = map.entries || [];
+  lines.push('<details>', `<summary>Architectural map (${mapEntries.length} ranked symbols)</summary>`, '', '```text');
+  lines.push(String(map.tree || '')
+    .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, (character) => character === '\n' ? '\n' : ' ')
+    .replaceAll('@', '&#64;')
+    .replaceAll('```', "''' ")
+    .slice(0, 12_000));
+  lines.push('```', '');
+  for (const entry of mapEntries.slice(0, 40)) {
+    lines.push(`- **${text(entry.file)}:${number(entry.line)}** — ${text(entry.signature)}`);
+  }
+  if (mapEntries.length > 40) lines.push(`- … ${mapEntries.length - 40} more in the artifact.`);
+  lines.push('', '</details>', '');
+
+  for (const note of (score.notes || [])) lines.push(`> ${text(note)}`);
+  if (score.check_violations_note) lines.push(`> Architecture check: ${text(score.check_violations_note)}`);
+  lines.push('', `Full machine-readable results: [workflow artifact](${artifactUrl}).`, '', '_Generated by ctx. This comment is updated on every PR revision._');
+
+  let body = lines.join('\n');
+  if (body.length > MAX_COMMENT_LENGTH) {
+    const footer = `\n\n</details>\n\n_Comment truncated to fit GitHub's limit; see the [complete workflow artifact](${artifactUrl})._`;
+    body = `${body.slice(0, MAX_COMMENT_LENGTH - footer.length)}${footer}`;
+  }
+  return body;
+}
+
+module.exports = { MARKER, MAX_COMMENT_LENGTH, renderComment, text };

--- a/.github/scripts/render-ctx-pr-comment.test.cjs
+++ b/.github/scripts/render-ctx-pr-comment.test.cjs
@@ -1,0 +1,59 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { MARKER, MAX_COMMENT_LENGTH, renderComment } = require('./render-ctx-pr-comment.cjs');
+
+function fixture() {
+  const envelope = (payload) => ({ ctx_version: '0.3.4', data: payload });
+  return {
+    metadata: { pr_number: 7, head_sha: 'a'.repeat(40), base_sha: 'b'.repeat(40) },
+    audit: { overall_score: 8.25, categories: [{ name: 'complexity', score: 8, issue_count: 1 }], issues: [] },
+    stats: envelope({ files: 10, symbols: 20, functions: 12, edges: 30 }),
+    score: envelope({ metrics: { files_changed: 2, complexity_delta: 1 }, notes: [] }),
+    duplicates: envelope({ pairs: [] }),
+    hotspots: envelope({ entries: [] }),
+    check: envelope({ summary: { violations: 0 }, violations: [] }),
+    map: envelope({ tree: 'repo/\n└── src/', entries: [] }),
+  };
+}
+
+test('renders a bounded sticky report', () => {
+  const body = renderComment(fixture(), { artifactUrl: 'https://example.test/run/1', runId: 42 });
+  assert.ok(body.startsWith(MARKER));
+  assert.match(body, /ctx-pr-report-run:42/);
+  assert.match(body, /Whole-codebase audit \| 8\.3 \/ 10/);
+  assert.match(body, /Indexed \*\*10 files\*\*/);
+  assert.ok(body.length <= MAX_COMMENT_LENGTH);
+});
+
+test('neutralizes artifact-controlled markdown and mentions', () => {
+  const report = fixture();
+  report.audit.issues = [{ severity: 'warning', category: 'x|y', file: '<img>', message: '@team `boom`' }];
+  const body = renderComment(report, { artifactUrl: 'https://example.test' });
+  assert.doesNotMatch(body, /<img>/);
+  assert.doesNotMatch(body, /@team/);
+  assert.doesNotMatch(body, /`boom`/);
+  assert.match(body, /&lt;img&gt;/);
+  assert.match(body, /&#64;team/);
+});
+
+test('neutralizes map fence breaks, mentions, controls, and bidi overrides', () => {
+  const report = fixture();
+  report.map.data.tree = 'safe```\n@team\u0000\u202emore';
+  const body = renderComment(report, { artifactUrl: 'https://example.test' });
+  assert.doesNotMatch(body, /safe```/);
+  assert.doesNotMatch(body, /@team|\u0000|\u202e/);
+  assert.match(body, /&#64;team/);
+});
+
+test('truncates oversized reports below the GitHub comment limit', () => {
+  const report = fixture();
+  report.map.tree = 'x'.repeat(MAX_COMMENT_LENGTH * 2);
+  report.audit.issues = Array.from({ length: 100 }, (_, i) => ({
+    severity: 'warning', category: 'large', file: `file-${i}`, message: 'y'.repeat(2000),
+  }));
+  const body = renderComment(report, { artifactUrl: 'https://example.test' });
+  assert.ok(body.length <= MAX_COMMENT_LENGTH);
+  assert.match(body, /truncated|more in the artifact/);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
+      - name: Test PR report renderer
+        run: node --test .github/scripts/render-ctx-pr-comment.test.cjs
+
   publish-dry-run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ctx-pr-analysis.yml
+++ b/.github/workflows/ctx-pr-analysis.yml
@@ -27,18 +27,31 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install the pinned released ctx
+      - name: Install the pinned, verified ctx release
         env:
           CTX_VERSION: 0.3.4
         run: |
-          rustup toolchain install 1.91.0 --profile minimal
-          rustup default 1.91.0
-          # Run outside the checkout so PR-controlled .cargo/config.toml files
-          # cannot alter the registry, compiler, or install command.
+          set -euo pipefail
+          artifact="ctx-v${CTX_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          archive_dir="${artifact%.tar.gz}"
+          release_url="https://github.com/agentis-tools/ctx/releases/download/v${CTX_VERSION}"
+
+          # Work outside the checkout and verify the release archive against
+          # the separately published aggregate checksum before executing it.
           cd "${RUNNER_TEMP}"
-          cargo install agentis-ctx --version "=${CTX_VERSION}" --locked --root "${RUNNER_TEMP}/ctx"
-          test "$("${RUNNER_TEMP}/ctx/bin/ctx" --version)" = "ctx ${CTX_VERSION}"
-          echo "${RUNNER_TEMP}/ctx/bin" >> "${GITHUB_PATH}"
+          curl --fail --location --retry 3 --silent --show-error \
+            --output "${artifact}" "${release_url}/${artifact}"
+          curl --fail --location --retry 3 --silent --show-error \
+            --output SHA256SUMS "${release_url}/SHA256SUMS"
+          expected="$(awk -v artifact="${artifact}" '$2 == artifact { print $1 }' SHA256SUMS)"
+          test -n "${expected}"
+          echo "${expected}  ${artifact}" | sha256sum --check --strict -
+
+          mkdir -p "${RUNNER_TEMP}/ctx-bin"
+          tar -xzf "${artifact}" --strip-components=1 "${archive_dir}/ctx"
+          install -m 0755 ctx "${RUNNER_TEMP}/ctx-bin/ctx"
+          test "$("${RUNNER_TEMP}/ctx-bin/ctx" --version)" = "ctx ${CTX_VERSION}"
+          echo "${RUNNER_TEMP}/ctx-bin" >> "${GITHUB_PATH}"
 
       - name: Build ctx analysis artifact
         env:

--- a/.github/workflows/ctx-pr-analysis.yml
+++ b/.github/workflows/ctx-pr-analysis.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out the pull-request head
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -104,7 +104,7 @@ jobs:
           jq -e . ctx-pr-analysis/*.json > /dev/null
 
       - name: Upload full ctx results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: ctx-pr-analysis-${{ github.run_id }}
           path: ctx-pr-analysis/*.json

--- a/.github/workflows/ctx-pr-analysis.yml
+++ b/.github/workflows/ctx-pr-analysis.yml
@@ -1,0 +1,99 @@
+name: ctx PR analysis
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+# This workflow intentionally has no write permissions. It checks out and
+# analyzes untrusted pull-request code, then hands JSON to a separate
+# workflow_run workflow for publishing.
+permissions:
+  contents: read
+
+concurrency:
+  group: ctx-pr-analysis-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out the pull-request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install the pinned released ctx
+        env:
+          CTX_VERSION: 0.3.4
+        run: |
+          rustup toolchain install 1.91.0 --profile minimal
+          rustup default 1.91.0
+          # Run outside the checkout so PR-controlled .cargo/config.toml files
+          # cannot alter the registry, compiler, or install command.
+          cd "${RUNNER_TEMP}"
+          cargo install agentis-ctx --version "=${CTX_VERSION}" --locked --root "${RUNNER_TEMP}/ctx"
+          test "$("${RUNNER_TEMP}/ctx/bin/ctx" --version)" = "ctx ${CTX_VERSION}"
+          echo "${RUNNER_TEMP}/ctx/bin" >> "${GITHUB_PATH}"
+
+      - name: Build ctx analysis artifact
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p ctx-pr-analysis
+
+          # The base SHA is supplied by GitHub, not pull-request code. Fetching
+          # it explicitly makes --against work for both same-repo and fork PRs.
+          git fetch --no-tags origin "${BASE_SHA}"
+          ctx index
+
+          ctx audit --output json > ctx-pr-analysis/audit.json
+          ctx map --budget 12000 --format json > ctx-pr-analysis/map.json
+          ctx query stats --json > ctx-pr-analysis/stats.json
+          ctx score --against "${BASE_SHA}" --json > ctx-pr-analysis/score.json
+          ctx duplicates --against "${BASE_SHA}" --json > ctx-pr-analysis/duplicates.json
+          ctx hotspots --against "${BASE_SHA}" --limit 100 --json > ctx-pr-analysis/hotspots.json
+
+          if [[ -f .ctx/rules.toml ]]; then
+            # Findings use exit 1 and are still a successful analysis.
+            status=0
+            ctx check --against "${BASE_SHA}" --json > ctx-pr-analysis/check.json || status=$?
+            if [[ "${status}" -gt 1 ]]; then
+              exit "${status}"
+            fi
+          else
+            jq -n \
+              --arg version "$(ctx --version | awk '{print $2}')" \
+              --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              --arg against "${BASE_SHA}" \
+              '{ctx_version:$version,command:"check",generated_at:$generated_at,data:{against:$against,configured:false,summary:{violations:0,rules_violated:0},violations:[],note:"No .ctx/rules.toml is configured."}}' \
+              > ctx-pr-analysis/check.json
+          fi
+
+          jq -n \
+            --argjson pr_number "${PR_NUMBER}" \
+            --arg head_sha "${HEAD_SHA}" \
+            --arg base_sha "${BASE_SHA}" \
+            --arg repository "${REPOSITORY}" \
+            --argjson run_id "${RUN_ID}" \
+            '{schema_version:1,pr_number:$pr_number,head_sha:$head_sha,base_sha:$base_sha,repository:$repository,run_id:$run_id}' \
+            > ctx-pr-analysis/metadata.json
+
+          jq -e . ctx-pr-analysis/*.json > /dev/null
+
+      - name: Upload full ctx results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ctx-pr-analysis-${{ github.run_id }}
+          path: ctx-pr-analysis/*.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/ctx-pr-comment.yml
+++ b/.github/workflows/ctx-pr-comment.yml
@@ -1,0 +1,206 @@
+name: ctx PR comment
+
+on:
+  workflow_run:
+    workflows: ["ctx PR analysis"]
+    types: [completed]
+
+# This privileged workflow never checks out or executes pull-request code.
+# Its only inputs from the analysis run are parsed as untrusted JSON.
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ctx-pr-publish-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out trusted renderer from the default branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download this workflow run's analysis only
+        if: github.event.workflow_run.conclusion == 'success'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ctx-pr-analysis-${{ github.event.workflow_run.id }}
+          path: ctx-pr-analysis
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Render and update the sticky PR comment
+        if: github.event.workflow_run.conclusion == 'success'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          ANALYSIS_DIR: ctx-pr-analysis
+          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EXPECTED_BASE_SHA: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
+          EXPECTED_CTX_VERSION: 0.3.4
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { renderComment, MARKER } = require('./.github/scripts/render-ctx-pr-comment.cjs');
+
+            const dir = path.resolve(process.env.ANALYSIS_DIR);
+            const readJson = (name) => {
+              const file = path.join(dir, name);
+              const stat = fs.lstatSync(file);
+              if (!stat.isFile() || stat.size > 10 * 1024 * 1024) {
+                throw new Error(`Rejected invalid analysis file: ${name}`);
+              }
+              return JSON.parse(fs.readFileSync(file, 'utf8'));
+            };
+
+            const metadata = readJson('metadata.json');
+            const expectedRunId = Number(process.env.EXPECTED_RUN_ID);
+            const expectedPrNumber = Number(process.env.EXPECTED_PR_NUMBER);
+            const expectedHeadSha = process.env.EXPECTED_HEAD_SHA;
+            const expectedBaseSha = process.env.EXPECTED_BASE_SHA;
+            if (metadata.schema_version !== 1 ||
+                !Number.isSafeInteger(expectedPrNumber) || expectedPrNumber <= 0 ||
+                metadata.pr_number !== expectedPrNumber ||
+                metadata.head_sha !== expectedHeadSha ||
+                metadata.base_sha !== expectedBaseSha ||
+                metadata.repository !== process.env.EXPECTED_REPOSITORY ||
+                metadata.run_id !== expectedRunId) {
+              throw new Error('Analysis metadata failed validation');
+            }
+
+            const documents = {
+              stats: readJson('stats.json'),
+              score: readJson('score.json'),
+              duplicates: readJson('duplicates.json'),
+              hotspots: readJson('hotspots.json'),
+              check: readJson('check.json'),
+              map: readJson('map.json'),
+            };
+            const expectedCommands = {
+              stats: 'query.stats', score: 'score', duplicates: 'duplicates',
+              hotspots: 'hotspots', check: 'check', map: 'map',
+            };
+            for (const [name, document] of Object.entries(documents)) {
+              if (document.ctx_version !== process.env.EXPECTED_CTX_VERSION ||
+                  document.command !== expectedCommands[name] ||
+                  !document.data || typeof document.data !== 'object') {
+                throw new Error(`Analysis document failed validation: ${name}`);
+              }
+            }
+            const audit = readJson('audit.json');
+            if (!Number.isFinite(audit.overall_score) ||
+                !Array.isArray(audit.categories) || !Array.isArray(audit.issues)) {
+              throw new Error('Audit document failed validation');
+            }
+
+            const { owner, repo } = context.repo;
+            const getCurrentPr = () => github.rest.pulls.get({
+              owner, repo, pull_number: expectedPrNumber,
+            });
+            let pr = await getCurrentPr();
+            if (pr.data.state !== 'open' || pr.data.head.sha !== metadata.head_sha) {
+              core.notice('Skipping stale or closed pull-request analysis.');
+              return;
+            }
+
+            const report = {
+              metadata,
+              audit,
+              ...documents,
+            };
+            const body = renderComment(report, {
+              artifactUrl: `${context.serverUrl}/${owner}/${repo}/actions/runs/${expectedRunId}`,
+              runId: expectedRunId,
+            });
+
+            // Re-check immediately before the write so a newer synchronize run
+            // cannot be overwritten by this run's stale result.
+            pr = await getCurrentPr();
+            if (pr.data.state !== 'open' || pr.data.head.sha !== metadata.head_sha) {
+              core.notice('Skipping analysis that became stale before publishing.');
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: expectedPrNumber, per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.startsWith(MARKER));
+
+            const existingRunId = Number(existing?.body?.match(/ctx-pr-report-run:(\d+)/)?.[1] || 0);
+            if (existingRunId > expectedRunId) {
+              core.notice(`Skipping older run ${expectedRunId}; comment has run ${existingRunId}.`);
+              return;
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: expectedPrNumber, body,
+              });
+            }
+
+      - name: Report an analysis failure
+        if: github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.conclusion != 'cancelled'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          script: |
+            const marker = '<!-- ctx-pr-report -->';
+            const { owner, repo } = context.repo;
+            const pull_number = Number(process.env.PR_NUMBER);
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number });
+            if (pr.data.state !== 'open' || pr.data.head.sha !== process.env.HEAD_SHA) {
+              core.notice('Skipping stale or closed pull-request analysis failure.');
+              return;
+            }
+            const body = [
+              marker,
+              `<!-- ctx-pr-report-run:${process.env.RUN_ID} -->`,
+              '## ctx analysis',
+              '',
+              `The ctx analysis run ended with **${process.env.CONCLUSION}**.`,
+              '',
+              `[Open the workflow run for diagnostics](${process.env.RUN_URL}).`,
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pull_number, per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.startsWith(marker));
+            const existingRunId = Number(existing?.body?.match(/ctx-pr-report-run:(\d+)/)?.[1] || 0);
+            if (existingRunId > Number(process.env.RUN_ID)) {
+              core.notice('Skipping an older failed analysis run.');
+              return;
+            }
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pull_number, body,
+              });
+            }

--- a/.github/workflows/ctx-pr-comment.yml
+++ b/.github/workflows/ctx-pr-comment.yml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
       - name: Check out trusted renderer from the default branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Download this workflow run's analysis only
         if: github.event.workflow_run.conclusion == 'success'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ctx-pr-analysis-${{ github.event.workflow_run.id }}
           path: ctx-pr-analysis
@@ -40,7 +40,7 @@ jobs:
 
       - name: Render and update the sticky PR comment
         if: github.event.workflow_run.conclusion == 'success'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           ANALYSIS_DIR: ctx-pr-analysis
           EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Report an analysis failure
         if: github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.conclusion != 'cancelled'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/docs/integrations/ci-cd.md
+++ b/docs/integrations/ci-cd.md
@@ -148,52 +148,28 @@ Add to `package.json`:
 
 ## PR Context Generation
 
-### Auto-generate PR Context
+This repository dogfoods ctx on every pull request. The reporter is split into
+two workflows so pull requests from forks are supported without running
+untrusted code with a write-capable token:
 
-```yaml
-name: PR Context
+1. [`ctx-pr-analysis.yml`](../../.github/workflows/ctx-pr-analysis.yml) checks
+   out the PR with read-only permissions, runs a pinned ctx release, and
+   uploads the complete JSON result bundle.
+2. [`ctx-pr-comment.yml`](../../.github/workflows/ctx-pr-comment.yml) runs only
+   after analysis, checks out its renderer from the trusted default branch,
+   validates that the analyzed commit is still the PR head, and updates one
+   sticky bot comment.
 
-on:
-  pull_request:
-    types: [opened, synchronize]
+The comment includes the PR quality delta, repository-wide audit and stats,
+new near-duplicates, architecture-rule findings, changed-code hotspots, and a
+token-budgeted architectural map. Long lists are capped to fit GitHub's
+comment limit; the linked workflow artifact retains the full machine-readable
+analysis for 14 days.
 
-jobs:
-  context:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - name: Install ctx
-        run: cargo install agentis-ctx
-      
-      - name: Index codebase
-        run: ctx index
-      
-      - name: Generate change context
-        run: |
-          echo "## Changed Files Context" >> $GITHUB_STEP_SUMMARY
-          ctx diff ${{ github.event.pull_request.base.sha }} --summary >> $GITHUB_STEP_SUMMARY
-```
-
-### Comment on PRs
-
-```yaml
-- name: Comment context
-  uses: actions/github-script@v6
-  with:
-    script: |
-      const { execSync } = require('child_process');
-      const context = execSync('ctx diff origin/main --output markdown').toString();
-      
-      github.rest.issues.createComment({
-        issue_number: context.issue.number,
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        body: `## Code Context\n\n${context}`
-      });
-```
+Do not replace this arrangement with `pull_request_target` plus a checkout of
+the PR head. That would expose a write token to contributor-controlled code.
+The publishing workflow must also download the artifact from the exact
+triggering run and treat every artifact field as untrusted input.
 
 ## Quality Trends
 

--- a/docs/website/docs/integrations/ci-cd.md
+++ b/docs/website/docs/integrations/ci-cd.md
@@ -151,52 +151,21 @@ Add to `package.json`:
 
 ## PR Context Generation
 
-### Auto-generate PR Context
+This repository dogfoods ctx on every pull request. The reporter uses separate
+analysis and publishing workflows so fork pull requests can be analyzed
+without giving contributor-controlled code a write-capable token.
 
-```yaml
-name: PR Context
+The read-only workflow indexes the PR and stores a complete JSON bundle. A
+trusted `workflow_run` job then verifies that the analyzed commit is still the
+current PR head and updates one sticky bot comment. The report covers the PR
+quality delta, repository-wide audit and statistics, new near-duplicates,
+architecture rules, changed-code hotspots, and a token-budgeted architectural
+map. Long sections are capped for GitHub's comment limit, while the workflow
+artifact retains the full results for 14 days.
 
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-jobs:
-  context:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - name: Install ctx
-        run: cargo install agentis-ctx
-      
-      - name: Index codebase
-        run: ctx index
-      
-      - name: Generate change context
-        run: |
-          echo "## Changed Files Context" >> $GITHUB_STEP_SUMMARY
-          ctx diff ${{ github.event.pull_request.base.sha }} --summary >> $GITHUB_STEP_SUMMARY
-```
-
-### Comment on PRs
-
-```yaml
-- name: Comment context
-  uses: actions/github-script@v6
-  with:
-    script: |
-      const { execSync } = require('child_process');
-      const context = execSync('ctx diff origin/main --format markdown').toString();
-      
-      github.rest.issues.createComment({
-        issue_number: context.issue.number,
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        body: `## Code Context\n\n${context}`
-      });
-```
+Avoid `pull_request_target` workflows that check out the PR head: they can
+expose a write token to untrusted code. The publisher should download only the
+artifact from its exact triggering run and treat every field as untrusted.
 
 ## Quality Trends
 


### PR DESCRIPTION
## Summary

- run a read-only, fork-safe ctx analysis for every PR revision
- publish a sanitized, stale-safe sticky ctx report from a trusted workflow_run job
- include audit, score, duplicates, architecture checks, hotspots, repository stats, and map results
- retain the complete JSON analysis as a 14-day workflow artifact

## Security

The write-enabled commenter never checks out or executes PR code. It validates the PR, head/base SHAs, repository, run ID, schema, ctx version, and command envelopes against trusted workflow_run data before publishing.

## Validation

- node --test .github/scripts/render-ctx-pr-comment.test.cjs (4 passed)
- real ctx 0.3.4 analysis bundle rendered successfully (5,731-character comment)
- cargo test -- --skip embeddings:: (all relevant suites passed; existing sandbox-sensitive self-update socket tests cannot bind locally)
- workflow YAML parse and git diff --check