### PR TITLE
fix: preserve annotated release tag in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # checkout resolves an annotated tag to GITHUB_SHA and updates the
+          # local tag ref to that commit. Restore the remote tag object before
+          # checking its type and peeled commit.
+          git fetch --force --no-tags origin \
+            "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
           git fetch --no-tags origin main:refs/remotes/origin/main
           test "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}")" = tag
           tagged_commit="$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{commit}")"


### PR DESCRIPTION
## Description

Fix the v0.3.5 release gate after actions/checkout flattened the fetched annotated tag ref to GITHUB_SHA. The gate now explicitly refetches the remote tag object before validating its type, peeled commit, and main-history ancestry.

The failed release attempts published no crate, assets, or GitHub Release.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Compatibility and release impact

- [x] No product compatibility-sensitive contract changed
- [ ] Contract changed additively; I updated the CLI snapshot if applicable
- [ ] Breaking change
- [ ] Release preparation

The workflow itself is a sensitive path and requires contract-review. This internal CI correction has no product changelog impact and requires skip-changelog.

## Checklist

- [x] cargo fmt --all -- --check
- [x] python3 scripts/check-governance.py check
- [x] Python versioning tests
- [x] scripts/check-agent-docs.sh
- [x] git diff --check
- [x] Reproduced checkout tag flattening and verified explicit refetch restores the annotated tag object

## Release recovery

After merge, replace the failed unpublished v0.3.5 tag on the new reviewed main commit, then rerun the tag-triggered Release workflow.