### PR TITLE
fix: package Intel macOS without ONNX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
             features: ""
           - os: macos-15-intel
             target: x86_64-apple-darwin
-            features: ""
+            # ort-sys does not publish ONNX Runtime binaries for Intel macOS.
+            features: "--no-default-features"
           - os: macos-latest
             target: aarch64-apple-darwin
             features: ""


### PR DESCRIPTION
## Summary
- build the Intel macOS release artifact without default ONNX features
- document the ort-sys prebuilt-runtime limitation in the release matrix

## Why
The v0.3.5 release run failed because ort-sys does not provide prebuilt ONNX Runtime binaries for x86_64-apple-darwin. Windows already uses the same no-default-features packaging mode.

Failed job: https://github.com/agentis-tools/ctx/actions/runs/29296191657/job/86978590339

## Validation
- python3 scripts/check-governance.py check
- cargo fmt --all -- --check
- git diff --check