### PR TITLE
fix: restore Debian release packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 - Made the local CI and canonical plugin lockstep checks honor Cargo's configured target directory while validating the standalone downloadable ctx skill against its harness template.
 - Constrained fastembed to the last ONNX Runtime dependency line that still publishes Intel macOS binaries.
+- Supplied the Debian source stanza required for release-package dependency discovery.
 
 ## [0.3.5] - 2026-07-13
 

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -41,10 +41,13 @@ if [ -z "$maintainer" ]; then
   echo "ERROR: set DEB_MAINTAINER or configure a Cargo package author" >&2
   exit 1
 fi
-sed -e "s/@VERSION@/$version/g" \
-    -e "s|@MAINTAINER@|$maintainer|g" \
-    -e "s/@DEPENDS@//g" \
-    "$repo_root/packaging/deb/control.template" > "$work/debian/control"
+{
+  printf 'Source: ctx\n\n'
+  sed -e "s/@VERSION@/$version/g" \
+      -e "s|@MAINTAINER@|$maintainer|g" \
+      -e "s/@DEPENDS@//g" \
+      "$repo_root/packaging/deb/control.template"
+} > "$work/debian/control"
 depends="$(cd "$work" && dpkg-shlibdeps -O "$binary" | sed -n 's/^shlibs:Depends=//p')"
 if [ -z "$depends" ]; then
   echo "ERROR: dpkg-shlibdeps did not determine runtime dependencies" >&2


### PR DESCRIPTION
## Summary
- add the Debian source stanza required by current dpkg-shlibdeps
- keep the final binary-package control metadata unchanged
- document the release-packaging correction

## Release evidence
The v0.3.5 release build matrix passed on Linux, Intel macOS, Apple Silicon, and Windows. The downstream linux-packages job then failed before publication with:

    dpkg-shlibdeps: error: syntax error in debian/control at line 11: first block lacks a Source field

This supplies that required source paragraph only to dpkg-shlibdeps' discovery control file.

## Validation
- bash -n scripts/package-linux.sh
- python3 scripts/check-governance.py check
- python3 scripts/check-governance.py pr --base origin/main --labels contract-review
- git diff --check