### PR TITLE
fix: make diff budget selection deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Made `ctx diff` and `ctx review` token-budget selection deterministic by ordering equally ranked
+  files by repository-relative path before greedy packing (#60).
+
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,
   harness regeneration after binary upgrades, and unresolved map focus behavior (#64).

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -487,13 +487,9 @@ pub fn diff_context(
         }
     }
 
-    // 6. Sort by priority and select files within token limit
+    // 6. Sort by priority and path, then select files within token limit
     let mut files: Vec<ContextFile> = context_files.into_values().collect();
-    files.sort_by(|a, b| {
-        b.priority
-            .partial_cmp(&a.priority)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    sort_context_files(&mut files);
 
     let (selected, total_tokens, omitted) = select_by_token_budget(files, config.max_tokens);
 
@@ -506,6 +502,15 @@ pub fn diff_context(
         truncated: omitted > 0,
         omitted_count: omitted,
     })
+}
+
+/// Order context files deterministically before greedy token-budget selection.
+fn sort_context_files(files: &mut [ContextFile]) {
+    files.sort_by(|a, b| {
+        b.priority
+            .total_cmp(&a.priority)
+            .then_with(|| a.path.cmp(&b.path))
+    });
 }
 
 /// Expand context for a symbol using call graph analysis.
@@ -931,6 +936,61 @@ index abc123..def456 100644
         assert_eq!(selected.len(), 2);
         assert_eq!(total, 300);
         assert_eq!(omitted, 1);
+    }
+
+    #[test]
+    fn test_context_files_sort_by_priority_then_path() {
+        let mut files = vec![
+            context_file("low.rs", 0.6, 1),
+            context_file("z_high.rs", 1.0, 1),
+            context_file("middle.rs", 0.8, 1),
+            context_file("a_high.rs", 1.0, 1),
+        ];
+
+        sort_context_files(&mut files);
+
+        let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+        assert_eq!(paths, ["a_high.rs", "z_high.rs", "middle.rs", "low.rs"]);
+    }
+
+    #[test]
+    fn test_context_budget_selection_is_permutation_invariant() {
+        let files = [
+            context_file("a_large.rs", 1.0, 200),
+            context_file("b_small.rs", 1.0, 100),
+            context_file("c_small.rs", 1.0, 100),
+        ];
+        let permutations = [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ];
+
+        for permutation in permutations {
+            let mut permuted: Vec<ContextFile> = permutation
+                .into_iter()
+                .map(|index| files[index].clone())
+                .collect();
+            sort_context_files(&mut permuted);
+
+            let (selected, total, omitted) = select_by_token_budget(permuted, 200);
+            let paths: Vec<&str> = selected.iter().map(|file| file.path.as_str()).collect();
+            assert_eq!(paths, ["a_large.rs"]);
+            assert_eq!(total, 200);
+            assert_eq!(omitted, 2);
+        }
+    }
+
+    fn context_file(path: &str, priority: f32, token_count: usize) -> ContextFile {
+        ContextFile {
+            path: path.to_string(),
+            priority,
+            reason: ContextReason::Changed(ChangeType::Modified),
+            token_count,
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- deterministically rank diff context by priority descending and repository-relative path ascending
- preserve greedy whole-file token packing without introducing token-size ranking
- add mixed-priority and permutation regression tests
- record the compatible correctness fix in Unreleased

Closes #60.

## Validation

- focused diff ranking regressions
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo test --locked --no-default-features`
- governance, agent-doc, versioning, binary-version, and CLI-contract checks
- clean-tree `scripts/ci.sh`, including both publish dry-runs

## Compatibility

No CLI, JSON, exit-code, schema, public API, version, or lockfile change. Constrained diff/review runs become reproducible instead of inheriting randomized HashMap order.

Manual review required before merge. Please apply `contract-review` only after acknowledging the compatibility impact.