### PR TITLE
fix: separate resolved callers from uncertain name matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Caller lookup now reports only resolved `calls` edges to the selected symbol, while preserving
+  conservative same-language unresolved evidence in a separate section instead of mixing in
+  cross-language or same-name false positives (#61).
+
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,
   harness regeneration after binary upgrades, and unresolved map focus behavior (#64).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Caller lookup now reports only resolved `calls` edges to the selected symbol, while preserving
-  conservative same-language unresolved evidence in a separate section instead of mixing in
-  cross-language or same-name false positives (#61).
+- BREAKING: Caller lookup now reports only resolved `calls` edges to the selected symbol, while
+  preserving conservative same-language unresolved evidence in a separate section instead of mixing
+  in cross-language or same-name false positives (#61). The documented `callers` JSON array narrows
+  in meaning: entries that previously appeared through bare name matching now surface under
+  `unresolved_callers` or not at all, so consumers reading `callers` see fewer, higher-confidence
+  entries than before.
 
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -309,6 +309,12 @@ Functions that call 'authenticate':
     > if (!authenticate(req.token)) return 401
 ```
 
+Resolved callers are identity-based: ctx includes only `calls` edges resolved to the selected
+symbol ID. Potentially useful same-language name matches that could not be resolved are shown under
+`Unresolved same-language call evidence` (and as `unresolved_callers` in JSON). Verify that evidence
+against source; cross-language matches, qualified calls without matching qualified context, and
+edges resolved to another same-named symbol are excluded.
+
 ### Dependencies (What Does This Call?)
 
 See what a function depends on:

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -176,11 +176,26 @@ Exit codes: running without `--keyword` when no embeddings have been generated i
       "context": "index::open_database(&root)?"
     }
   ],
+  "unresolved_callers": [
+    {
+      "symbol": { "name": "retry_open", "qualified_name": null, "kind": "function", "file": "src/retry.rs", "line_start": 20, "line_end": 27 },
+      "line": 22,
+      "context": "open_database(path)?"
+    }
+  ],
   "ambiguous": []
 }
 ```
 
-Disambiguation: when several symbols match the name and no `--file` filter is given, `target` is `null`, `callers` is empty, and `ambiguous` lists the candidate SymbolRefs. When the symbol is not found at all, all three are empty/`null`.
+`callers` contains only resolved `calls` edges whose target ID is the selected symbol. It never
+contains an edge resolved to another same-named symbol. `unresolved_callers` preserves conservative
+name-based evidence separately: the source must use the target's language, and qualified symbols
+require matching qualified call context. Treat these entries as leads to verify in source, not as
+resolved relationships.
+
+Disambiguation: when several symbols match the name and no `--file` filter is given, `target` is
+`null`, `callers` and `unresolved_callers` are empty, and `ambiguous` lists the candidate
+SymbolRefs. When the symbol is not found at all, all three arrays are empty and `target` is `null`.
 
 ### `query.deps`
 

--- a/docs/website/docs/code-intelligence.md
+++ b/docs/website/docs/code-intelligence.md
@@ -331,6 +331,12 @@ Functions that call 'authenticate':
     > if (!authenticate(req.token)) return 401
 ```
 
+Resolved callers are identity-based: ctx includes only `calls` edges resolved to the selected
+symbol ID. Potentially useful same-language name matches that could not be resolved are shown under
+`Unresolved same-language call evidence` (and as `unresolved_callers` in JSON). Verify that evidence
+against source; cross-language matches, qualified calls without matching qualified context, and
+edges resolved to another same-named symbol are excluded.
+
 ### Dependencies (What Does This Call?)
 
 See what a function depends on:

--- a/docs/website/docs/cookbook/find-existing-implementations.md
+++ b/docs/website/docs/cookbook/find-existing-implementations.md
@@ -151,6 +151,12 @@ ctx query callers classify --file src/harness/mod.rs --depth 2
 ctx query find Ownership --json
 ```
 
+The worked evidence above was collected with ctx 0.3.5 and remains illustrative rather than a
+stable product contract. That release could mix unresolved same-name matches into ordinary caller
+results. Current output keeps `callers` identity-resolved and labels conservative same-language
+leads separately as `unresolved_callers`; inspect either kind against source before inferring a
+dependency.
+
 `classify` already performs the complete task:
 
 1. report a missing path as `Missing`;
@@ -241,7 +247,7 @@ Do not assume a pattern narrowed the search unless the returned paths prove it.
 | Short keyword queries | Found checksum primitives without embeddings | Long queries were diluted by generic vocabulary |
 | `fan_in` in similar results | Identified functions with established consumers | Popularity does not prove semantic suitability |
 | Candidate source inspection | Revealed encoding, header, and fallback semantics | One helper did not show the higher-level policy |
-| Caller tracing | Found the composed ownership workflow | Static caller results still require source verification |
+| Caller tracing | Found the composed ownership workflow | Resolved and separately labeled unresolved evidence still require source verification |
 | Behavioral test inspection | Established overwrite and foreign-file policy | Tests can be missed if search stops at the first utility |
 
 The reliable loop is **describe behavior, vary retrieval mode, inspect candidates, trace their

--- a/docs/website/docs/json-output.md
+++ b/docs/website/docs/json-output.md
@@ -153,11 +153,26 @@ If no embeddings have been generated yet, `results` is empty and a hint is print
       "context": "index::open_database(&root)?"
     }
   ],
+  "unresolved_callers": [
+    {
+      "symbol": { "name": "retry_open", "qualified_name": null, "kind": "function", "file": "src/retry.rs", "line_start": 20, "line_end": 27 },
+      "line": 22,
+      "context": "open_database(path)?"
+    }
+  ],
   "ambiguous": []
 }
 ```
 
-Disambiguation: when several symbols match the name and no `--file` filter is given, `target` is `null`, `callers` is empty, and `ambiguous` lists the candidate SymbolRefs. When the symbol is not found at all, all three are empty/`null`.
+`callers` contains only resolved `calls` edges whose target ID is the selected symbol. It never
+contains an edge resolved to another same-named symbol. `unresolved_callers` preserves conservative
+name-based evidence separately: the source must use the target's language, and qualified symbols
+require matching qualified call context. Treat these entries as leads to verify in source, not as
+resolved relationships.
+
+Disambiguation: when several symbols match the name and no `--file` filter is given, `target` is
+`null`, `callers` and `unresolved_callers` are empty, and `ambiguous` lists the candidate
+SymbolRefs. When the symbol is not found at all, all three arrays are empty and `target` is `null`.
 
 ### `query.deps`
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -99,7 +99,45 @@ enum CallersOutcome {
     Found {
         target: Box<db::Symbol>,
         callers: Vec<CallerEntry>,
+        unresolved_callers: Vec<CallerEntry>,
     },
+}
+
+/// Whether an unresolved call's source text is credible evidence for `target`.
+///
+/// Methods and other qualified symbols require their qualified name. A bare
+/// symbol accepts only a bare call: receiver/type-qualified calls are evidence
+/// for a different symbol even when the final name is the same.
+fn unresolved_context_matches(target: &db::Symbol, context: Option<&str>) -> bool {
+    let qualified_name = target
+        .qualified_name
+        .as_deref()
+        .filter(|qualified| *qualified != target.name);
+
+    if let Some(qualified_name) = qualified_name {
+        return context.is_some_and(|context| context.contains(qualified_name));
+    }
+
+    let Some(context) = context else {
+        return true;
+    };
+
+    context.match_indices(&target.name).any(|(offset, _)| {
+        let prefix = context[..offset].trim_end();
+        !prefix.ends_with("::") && !prefix.ends_with('.') && !prefix.ends_with("->")
+    })
+}
+
+fn sort_caller_entries(entries: &mut [CallerEntry]) {
+    entries.sort_by(|left, right| {
+        left.symbol
+            .file_path
+            .cmp(&right.symbol.file_path)
+            .then_with(|| left.symbol.line_start.cmp(&right.symbol.line_start))
+            .then_with(|| left.symbol.id.cmp(&right.symbol.id))
+            .then_with(|| left.line.cmp(&right.line))
+            .then_with(|| left.context.cmp(&right.context))
+    });
 }
 
 /// Look up the callers of `function`, without printing anything.
@@ -122,53 +160,13 @@ fn collect_callers(
 
     let sym = &symbols[0];
 
-    // Get callers for this specific symbol
-    // Strategy:
-    // 1. Get edges resolved to this symbol's ID (most accurate)
-    // 2. Get edges by name, filtered to likely matches based on context
-    let id_edges = db.get_incoming_edges(&sym.id)?;
-    let name_edges = db.get_incoming_edges(&sym.name)?;
-
-    // Build patterns for context matching
-    // For "src/foo.rs::MyType::method@10", we check for:
-    // - Full qualified name: "MyType::method"
-    // - Just the parent type: "MyType::" (for cases like "MyType::new()")
-    let qualified_name = sym.qualified_name.as_deref().unwrap_or(&sym.name);
-    let parent_prefix = qualified_name
-        .rsplit_once("::")
-        .map(|(parent, _)| format!("{}::", parent));
-
-    // Start with ID-resolved edges (most accurate)
-    let mut edges = id_edges;
-    let has_id_edges = !edges.is_empty();
-
-    // Add name-based edges that aren't duplicates and likely refer to this symbol
-    for edge in name_edges {
-        // Skip if already have this edge (by source_id + line)
-        let is_duplicate = edges
-            .iter()
-            .any(|e| e.source_id == edge.source_id && e.line == edge.line);
-        if is_duplicate {
+    // Ordinary caller results are identity-based: only resolved call edges to
+    // the selected symbol may appear here.
+    let mut callers = Vec::new();
+    for edge in db.get_incoming_edges(&sym.id)? {
+        if edge.kind != db::EdgeKind::Calls || edge.target_id.as_deref() != Some(sym.id.as_str()) {
             continue;
         }
-
-        // Determine if this edge likely refers to our symbol
-        let likely_match = if let Some(ref ctx) = edge.context {
-            // Check if context contains our qualified name or parent type
-            ctx.contains(qualified_name) || parent_prefix.as_ref().is_some_and(|p| ctx.contains(p))
-        } else {
-            // No context - include only if we have no ID-resolved edges
-            // (fallback for completely unresolved graphs)
-            !has_id_edges
-        };
-
-        if likely_match {
-            edges.push(edge);
-        }
-    }
-
-    let mut callers = Vec::new();
-    for edge in edges {
         if let Some(s) = db.get_symbol(&edge.source_id)? {
             callers.push(CallerEntry {
                 symbol: s,
@@ -177,10 +175,39 @@ fn collect_callers(
             });
         }
     }
+    sort_caller_entries(&mut callers);
+
+    // Preserve conservative, potentially useful name evidence separately.
+    // Cross-language edges and edges resolved to any symbol are excluded.
+    let target_language = db.get_file_language(&sym.file_path)?;
+    let mut unresolved_callers = Vec::new();
+    if target_language.is_some() {
+        for edge in db.get_incoming_edges(&sym.name)? {
+            if edge.kind != db::EdgeKind::Calls
+                || edge.target_id.is_some()
+                || edge.target_name != sym.name
+                || !unresolved_context_matches(sym, edge.context.as_deref())
+            {
+                continue;
+            }
+            if let Some(source) = db.get_symbol(&edge.source_id)? {
+                if db.get_file_language(&source.file_path)? != target_language {
+                    continue;
+                }
+                unresolved_callers.push(CallerEntry {
+                    symbol: source,
+                    line: edge.line,
+                    context: edge.context,
+                });
+            }
+        }
+    }
+    sort_caller_entries(&mut unresolved_callers);
 
     Ok(CallersOutcome::Found {
         target: Box::new(symbols.into_iter().next().expect("checked non-empty")),
         callers,
+        unresolved_callers,
     })
 }
 
@@ -190,16 +217,30 @@ fn callers_data(outcome: &CallersOutcome) -> serde_json::Value {
         CallersOutcome::NotFound => serde_json::json!({
             "target": serde_json::Value::Null,
             "callers": [],
+            "unresolved_callers": [],
             "ambiguous": [],
         }),
         CallersOutcome::Ambiguous(symbols) => serde_json::json!({
             "target": serde_json::Value::Null,
             "callers": [],
+            "unresolved_callers": [],
             "ambiguous": symbols.iter().map(SymbolRef::from).collect::<Vec<_>>(),
         }),
-        CallersOutcome::Found { target, callers } => serde_json::json!({
+        CallersOutcome::Found {
+            target,
+            callers,
+            unresolved_callers,
+        } => serde_json::json!({
             "target": SymbolRef::from(target.as_ref()),
             "callers": callers
+                .iter()
+                .map(|c| serde_json::json!({
+                    "symbol": SymbolRef::from(&c.symbol),
+                    "line": c.line,
+                    "context": c.context,
+                }))
+                .collect::<Vec<_>>(),
+            "unresolved_callers": unresolved_callers
                 .iter()
                 .map(|c| serde_json::json!({
                     "symbol": SymbolRef::from(&c.symbol),
@@ -246,27 +287,54 @@ fn query_callers(
                 ),
             );
         }
-        CallersOutcome::Found { target, callers } => {
-            if callers.is_empty() {
+        CallersOutcome::Found {
+            target,
+            callers,
+            unresolved_callers,
+        } => {
+            if callers.is_empty() && unresolved_callers.is_empty() {
                 eprintln!("No callers found for '{}' ({})", function, target.file_path);
                 return Ok(());
             }
 
-            println!(
-                "Functions that call '{}' ({}):",
-                target.name, target.file_path
-            );
-            println!("{}", "-".repeat(60));
-
-            for entry in callers {
+            if !callers.is_empty() {
                 println!(
-                    "  {} ({}:{})",
-                    entry.symbol.name,
-                    entry.symbol.file_path,
-                    entry.line.unwrap_or(entry.symbol.line_start)
+                    "Functions that call '{}' ({}):",
+                    target.name, target.file_path
                 );
-                if let Some(ctx) = entry.context {
-                    println!("    > {}", ctx);
+                println!("{}", "-".repeat(60));
+
+                for entry in callers {
+                    println!(
+                        "  {} ({}:{})",
+                        entry.symbol.name,
+                        entry.symbol.file_path,
+                        entry.line.unwrap_or(entry.symbol.line_start)
+                    );
+                    if let Some(ctx) = entry.context {
+                        println!("    > {}", ctx);
+                    }
+                }
+            } else {
+                eprintln!(
+                    "No resolved callers found for '{}' ({})",
+                    function, target.file_path
+                );
+            }
+
+            if !unresolved_callers.is_empty() {
+                println!("\nUnresolved same-language call evidence:");
+                println!("{}", "-".repeat(60));
+                for entry in unresolved_callers {
+                    println!(
+                        "  {} ({}:{})",
+                        entry.symbol.name,
+                        entry.symbol.file_path,
+                        entry.line.unwrap_or(entry.symbol.line_start)
+                    );
+                    if let Some(ctx) = entry.context {
+                        println!("    > {}", ctx);
+                    }
                 }
             }
         }
@@ -818,6 +886,7 @@ mod tests {
         assert_eq!(callers[0]["symbol"]["name"], "callerfn");
         assert_eq!(callers[0]["line"], 12);
         assert_eq!(callers[0]["context"], "targetfn()");
+        assert_eq!(data["unresolved_callers"], serde_json::json!([]));
     }
 
     #[test]
@@ -828,6 +897,7 @@ mod tests {
 
         assert!(data["target"].is_null());
         assert_eq!(data["callers"], serde_json::json!([]));
+        assert_eq!(data["unresolved_callers"], serde_json::json!([]));
         assert_eq!(data["ambiguous"], serde_json::json!([]));
     }
 
@@ -859,9 +929,155 @@ mod tests {
 
         assert!(data["target"].is_null());
         assert_eq!(data["callers"], serde_json::json!([]));
+        assert_eq!(data["unresolved_callers"], serde_json::json!([]));
         let ambiguous = data["ambiguous"].as_array().unwrap();
         assert_eq!(ambiguous.len(), 2);
         assert_eq!(ambiguous[0]["name"], "targetfn");
+    }
+
+    #[test]
+    fn test_callers_separate_same_language_unresolved_evidence() {
+        let db = seeded_db();
+        for (path, language) in [
+            ("src/a.rs", "rust"),
+            ("src/z.rs", "rust"),
+            ("tests/helpers.py", "python"),
+        ] {
+            db.upsert_file(
+                &FileRecord {
+                    path: path.to_string(),
+                    content_hash: format!("hash-{path}"),
+                    size_bytes: 1,
+                    language: Some(language.to_string()),
+                    last_indexed: 0,
+                },
+                None,
+            )
+            .unwrap();
+        }
+
+        for (id, name, file, line) in [
+            ("src/a.rs::early", "early", "src/a.rs", 5),
+            ("src/z.rs::late", "late", "src/z.rs", 20),
+            ("src/z.rs::other", "targetfn", "src/z.rs", 1),
+            (
+                "tests/helpers.py::python_caller",
+                "python_caller",
+                "tests/helpers.py",
+                3,
+            ),
+        ] {
+            db.insert_symbol(&make_symbol(id, name, file, line))
+                .unwrap();
+        }
+
+        let edges = [
+            // Same-language bare calls remain useful, deterministic evidence.
+            Edge {
+                source_id: "src/z.rs::late".to_string(),
+                target_id: None,
+                target_name: "targetfn".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(22),
+                col: None,
+                context: Some("targetfn()".to_string()),
+            },
+            Edge {
+                source_id: "src/a.rs::early".to_string(),
+                target_id: None,
+                target_name: "targetfn".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(7),
+                col: None,
+                context: Some("targetfn()".to_string()),
+            },
+            // Cross-language evidence is never associated with the Rust target.
+            Edge {
+                source_id: "tests/helpers.py::python_caller".to_string(),
+                target_id: None,
+                target_name: "targetfn".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(4),
+                col: None,
+                context: Some("targetfn()".to_string()),
+            },
+            // Qualified syntax is not evidence for an unqualified free function.
+            Edge {
+                source_id: "src/z.rs::late".to_string(),
+                target_id: None,
+                target_name: "targetfn".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(23),
+                col: None,
+                context: Some("Other::targetfn()".to_string()),
+            },
+            // An edge resolved to the same-named symbol in another file belongs
+            // in neither result set for the selected target.
+            Edge {
+                source_id: "src/z.rs::late".to_string(),
+                target_id: Some("src/z.rs::other".to_string()),
+                target_name: "targetfn".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(24),
+                col: None,
+                context: Some("targetfn()".to_string()),
+            },
+            // Incoming non-call relationships are not callers.
+            Edge {
+                source_id: "src/z.rs::late".to_string(),
+                target_id: Some("src/x.rs::targetfn".to_string()),
+                target_name: "targetfn".to_string(),
+                kind: EdgeKind::Uses,
+                line: Some(25),
+                col: None,
+                context: Some("targetfn".to_string()),
+            },
+        ];
+        for edge in edges {
+            db.insert_edge(&edge).unwrap();
+        }
+
+        let outcome = collect_callers(&db, "targetfn", Some("src/x.rs")).unwrap();
+        let data = callers_data(&outcome);
+
+        let callers = data["callers"].as_array().unwrap();
+        assert_eq!(callers.len(), 1);
+        assert_eq!(callers[0]["symbol"]["name"], "callerfn");
+
+        let unresolved = data["unresolved_callers"].as_array().unwrap();
+        assert_eq!(unresolved.len(), 2);
+        assert_eq!(unresolved[0]["symbol"]["name"], "early");
+        assert_eq!(unresolved[1]["symbol"]["name"], "late");
+    }
+
+    #[test]
+    fn test_qualified_unresolved_callers_require_qualified_context() {
+        let db = seeded_db();
+        let mut target = make_symbol("src/x.rs::Worker::run", "run", "src/x.rs", 30);
+        target.kind = SymbolKind::Method;
+        target.qualified_name = Some("Worker::run".to_string());
+        db.insert_symbol(&target).unwrap();
+
+        for (line, context) in [(40, "run()"), (41, "Other::run()"), (42, "Worker::run()")] {
+            db.insert_edge(&Edge {
+                source_id: "src/x.rs::callerfn".to_string(),
+                target_id: None,
+                target_name: "run".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(line),
+                col: None,
+                context: Some(context.to_string()),
+            })
+            .unwrap();
+        }
+
+        let outcome = collect_callers(&db, "run", Some("src/x.rs")).unwrap();
+        let data = callers_data(&outcome);
+        assert_eq!(data["callers"], serde_json::json!([]));
+        let unresolved = data["unresolved_callers"].as_array().unwrap();
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0]["line"], 42);
+        assert_eq!(unresolved[0]["context"], "Worker::run()");
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -355,6 +355,16 @@ impl Database {
             .optional()
     }
 
+    /// Get the parser language recorded for an indexed file.
+    pub fn get_file_language(&self, path: &str) -> Result<Option<String>> {
+        self.conn
+            .query_row("SELECT language FROM files WHERE path = ?", [path], |row| {
+                row.get(0)
+            })
+            .optional()
+            .map(|language| language.flatten())
+    }
+
     /// Check if a file needs reindexing based on hash.
     pub fn needs_update(&self, path: &str, new_hash: &str) -> Result<bool> {
         match self.get_file_hash(path)? {

--- a/tests/query_callers_cli.rs
+++ b/tests/query_callers_cli.rs
@@ -1,0 +1,109 @@
+//! Regression fixtures for identity-safe `ctx query callers` output.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn indexed_mixed_language_fixture() -> TempDir {
+    let temp = TempDir::new().expect("create fixture");
+    let src = temp.path().join("src");
+    let scripts = temp.path().join("scripts");
+    std::fs::create_dir_all(&src).expect("create Rust fixture directory");
+    std::fs::create_dir_all(&scripts).expect("create Python fixture directory");
+
+    std::fs::write(
+        src.join("main.rs"),
+        r#"
+fn run() {}
+
+fn run_main() {
+    run();
+}
+
+fn main() {
+    run_main();
+}
+"#,
+    )
+    .expect("write Rust target fixture");
+    std::fs::write(
+        src.join("same_name.rs"),
+        r#"
+fn run() {}
+
+fn calls_other_run() {
+    run();
+}
+"#,
+    )
+    .expect("write same-name Rust fixture");
+    std::fs::write(
+        src.join("unresolved.rs"),
+        r#"
+fn rust_probe() {
+    run();
+}
+"#,
+    )
+    .expect("write unresolved Rust fixture");
+    std::fs::write(
+        scripts.join("runner.py"),
+        r#"
+import subprocess
+
+def run():
+    return None
+
+def python_probe():
+    run()
+    subprocess.run(["true"])
+"#,
+    )
+    .expect("write Python fixture");
+
+    Command::cargo_bin("ctx")
+        .unwrap()
+        .current_dir(temp.path())
+        .arg("index")
+        .assert()
+        .success();
+
+    temp
+}
+
+#[test]
+fn callers_are_resolved_to_the_selected_id_and_unresolved_evidence_is_separate() {
+    let temp = indexed_mixed_language_fixture();
+    let output = Command::cargo_bin("ctx")
+        .unwrap()
+        .current_dir(temp.path())
+        .args(["--json", "query", "callers", "run", "--file", "src/main.rs"])
+        .output()
+        .expect("query callers JSON");
+    assert!(
+        output.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let envelope: Value = serde_json::from_slice(&output.stdout).expect("valid JSON envelope");
+    let data = &envelope["data"];
+    assert_eq!(data["target"]["file"], "src/main.rs");
+
+    let callers = data["callers"].as_array().expect("callers array");
+    assert_eq!(callers.len(), 1);
+    assert_eq!(callers[0]["symbol"]["name"], "run_main");
+    assert_eq!(callers[0]["symbol"]["file"], "src/main.rs");
+
+    let unresolved = data["unresolved_callers"]
+        .as_array()
+        .expect("unresolved callers array");
+    assert_eq!(unresolved.len(), 1);
+    assert_eq!(unresolved[0]["symbol"]["name"], "rust_probe");
+    assert_eq!(unresolved[0]["symbol"]["file"], "src/unresolved.rs");
+
+    let serialized = serde_json::to_string(data).unwrap();
+    assert!(!serialized.contains("python_probe"));
+    assert!(!serialized.contains("calls_other_run"));
+    assert!(!serialized.contains("subprocess.run"));
+}


### PR DESCRIPTION
## Summary

- restrict authoritative caller results to resolved call edges targeting the selected symbol ID
- expose conservative same-language unresolved call evidence separately in human and JSON output
- exclude cross-language matches, edges resolved to another same-named symbol, non-call edges, and insufficiently qualified method evidence
- add unit and mixed Rust/Python indexed CLI regressions
- update JSON, code-intelligence, cookbook, and Unreleased documentation

Closes #61.

## Validation

- focused query units: 10/10
- mixed-language indexed CLI regression: 1/1
- Docusaurus production build
- full clean-tree `scripts/ci.sh`, including Clippy, all/minimal feature tests, contracts, and both publish dry-runs

`ctx check` was not applicable because the isolated worktree intentionally has no local `.ctx/rules.toml`.

## Compatibility

The existing `callers` array becomes identity-precise; uncertain matches move to the additive `unresolved_callers` array. No CLI flag, envelope, exit-code, schema, version, or lockfile change.

Manual review required before merge. Please apply `contract-review` only after acknowledging the JSON semantic change.