### PR TITLE
fix: honor positional patterns in smart, similar, and diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Positional file, directory, and glob patterns now scope `ctx smart`, `ctx similar`, and `ctx diff`
+  as advertised, including semantic seeds, graph expansion, and renamed or deleted diff paths (#57).
+
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,
   harness regeneration after binary upgrades, and unresolved map focus behavior (#64).

--- a/docs/commands/diff.md
+++ b/docs/commands/diff.md
@@ -5,7 +5,7 @@ Generate context for changed files with their related dependencies.
 ## Synopsis
 
 ```bash
-ctx diff [REF] [OPTIONS]
+ctx diff [REF] [PATTERNS]... [OPTIONS]
 ```
 
 ## Description
@@ -15,6 +15,11 @@ The `diff` command identifies changed files compared to a git reference and incl
 - **Code review** - Get context for reviewing a PR or commit
 - **Change impact** - Understand what's affected by your changes
 - **Pre-commit** - Verify changes before committing
+
+Optional positional patterns restrict both changed files and graph-expanded
+context. Literal files, directories, and globs are ORed together. Renames match
+when either the old or new path is in scope; deletions remain visible in the
+change summary. With no patterns, `.` includes all changed paths.
 
 ## Options
 
@@ -42,6 +47,9 @@ ctx diff main
 
 # Changes in feature branch
 ctx diff origin/main
+
+# Review only Rust sources and the public configuration contract
+ctx diff origin/main "src/**/*.rs" docs/configuration.md
 ```
 
 ### Review a Specific Commit

--- a/docs/commands/similar.md
+++ b/docs/commands/similar.md
@@ -5,7 +5,7 @@ Find existing functions similar to a description before writing new ones.
 ## Synopsis
 
 ```bash
-ctx similar "<query>" [OPTIONS]
+ctx similar "<query>" [PATTERNS]... [OPTIONS]
 ```
 
 ## Description
@@ -13,6 +13,10 @@ ctx similar "<query>" [OPTIONS]
 The `similar` command searches the index for functions that already do what you are about to write. Run it before adding a new function: reusing (or extending) an existing implementation is the cheapest way to avoid duplication that `ctx duplicates` and `ctx score` would flag later.
 
 By default the search is semantic (embedding-based, requires `ctx embed`); `--keyword` falls back to FTS5 keyword search over names, signatures, and doc comments.
+
+Optional positional patterns restrict candidates by file path. Literal files,
+directories, and globs are ORed together. With no patterns, `.` searches the
+whole indexed repository.
 
 ## Options
 
@@ -38,6 +42,9 @@ ctx similar "retry an operation with exponential backoff"
 
 # Keyword mode (no embeddings needed)
 ctx similar "parse config file" --keyword
+
+# Search only command sources and shared tests
+ctx similar "parse config file" src/commands/ "tests/**/*_cli.rs" --keyword
 
 # More candidates, OpenAI embeddings
 ctx similar "validate user input" --limit 20 --openai

--- a/docs/commands/smart.md
+++ b/docs/commands/smart.md
@@ -5,7 +5,7 @@ Intelligently select files relevant to a task description using embeddings and c
 ## Synopsis
 
 ```bash
-ctx smart <TASK> [OPTIONS]
+ctx smart <TASK> [PATTERNS]... [OPTIONS]
 ```
 
 ## Description
@@ -15,6 +15,11 @@ The `smart` command analyzes your task description and automatically selects the
 - **Semantic search** - Finds symbols related to your task using embeddings
 - **Call graph expansion** - Includes callers and callees of matched symbols
 - **Token budgeting** - Fits selection within your token limit
+
+Optional positional patterns scope the entire selection pipeline. Literal
+files, directories, and globs are ORed together; semantic matches and
+call-graph expansion both stay within that scope. With no patterns, `.` selects
+the whole repository.
 
 ## Prerequisites
 
@@ -43,6 +48,9 @@ ctx smart "add user authentication"
 
 # Review files for fixing a bug
 ctx smart "fix the login timeout issue"
+
+# Search and expand only within Rust source and one contract file
+ctx smart "change request validation" "src/**/*.rs" tests/contracts.rs
 ```
 
 ### With Token Budget

--- a/docs/website/docs/commands/diff.md
+++ b/docs/website/docs/commands/diff.md
@@ -11,7 +11,7 @@ Generate context for changed files with their related dependencies.
 ## Synopsis
 
 ```bash
-ctx diff [REVISION] [OPTIONS]
+ctx diff [REVISION] [PATTERNS]... [OPTIONS]
 ```
 
 ## Description
@@ -21,6 +21,11 @@ The `diff` command identifies changed files compared to a git reference and incl
 - **Code review** - Get context for reviewing a PR or commit
 - **Change impact** - Understand what's affected by your changes
 - **Pre-commit** - Verify changes before committing
+
+Optional positional patterns restrict both changed files and graph-expanded
+context. Literal files, directories, and globs are ORed together. Renames match
+when either the old or new path is in scope; deletions remain visible in the
+change summary. With no patterns, `.` includes all changed paths.
 
 ## Options
 
@@ -53,6 +58,9 @@ ctx diff main
 
 # Changes in feature branch
 ctx diff origin/main
+
+# Review only Rust sources and the public configuration contract
+ctx diff origin/main "src/**/*.rs" docs/configuration.md
 ```
 
 ### Review a Specific Commit

--- a/docs/website/docs/commands/similar.md
+++ b/docs/website/docs/commands/similar.md
@@ -11,7 +11,7 @@ Find existing functions similar to a description before writing new ones.
 ## Synopsis
 
 ```bash
-ctx similar "<query>" [OPTIONS]
+ctx similar "<query>" [PATTERNS]... [OPTIONS]
 ```
 
 ## Description
@@ -19,6 +19,10 @@ ctx similar "<query>" [OPTIONS]
 The `similar` command searches the index for functions that already do what you are about to write. Run it before adding a new function: reusing (or extending) an existing implementation is the cheapest way to avoid duplication that `ctx duplicates` and `ctx score` would flag later.
 
 By default the search is semantic (embedding-based, requires `ctx embed`); `--keyword` falls back to FTS5 keyword search over names, signatures, and doc comments.
+
+Optional positional patterns restrict candidates by file path. Literal files,
+directories, and globs are ORed together. With no patterns, `.` searches the
+whole indexed repository.
 
 ## Options
 
@@ -44,6 +48,9 @@ ctx similar "retry an operation with exponential backoff"
 
 # Keyword mode (no embeddings needed)
 ctx similar "parse config file" --keyword
+
+# Search only command sources and shared tests
+ctx similar "parse config file" src/commands/ "tests/**/*_cli.rs" --keyword
 
 # More candidates, OpenAI embeddings
 ctx similar "validate user input" --limit 20 --provider openai

--- a/docs/website/docs/commands/smart.md
+++ b/docs/website/docs/commands/smart.md
@@ -11,7 +11,7 @@ Intelligently select files relevant to a task description using embeddings and c
 ## Synopsis
 
 ```bash
-ctx smart <TASK> [OPTIONS]
+ctx smart <TASK> [PATTERNS]... [OPTIONS]
 ```
 
 ## Description
@@ -21,6 +21,11 @@ The `smart` command analyzes your task description and automatically selects the
 - **Semantic search** - Finds symbols related to your task using embeddings
 - **Call graph expansion** - Includes callers and callees of matched symbols
 - **Token budgeting** - Fits selection within your token limit
+
+Optional positional patterns scope the entire selection pipeline. Literal
+files, directories, and globs are ORed together; semantic matches and
+call-graph expansion both stay within that scope. With no patterns, `.` selects
+the whole repository.
 
 ## Prerequisites
 
@@ -53,6 +58,9 @@ ctx smart "add user authentication"
 
 # Review files for fixing a bug
 ctx smart "fix the login timeout issue"
+
+# Search and expand only within Rust source and one contract file
+ctx smart "change request validation" "src/**/*.rs" tests/contracts.rs
 ```
 
 ### With Token Budget

--- a/docs/website/docs/cookbook/find-existing-implementations.md
+++ b/docs/website/docs/cookbook/find-existing-implementations.md
@@ -218,9 +218,12 @@ public merely to avoid a local adapter would require contract and SemVer review.
 configuration keys, and prose must be found through `query find`, `search`, or repository text
 search.
 
-The generic CLI help also displays positional file patterns for `similar`, but the current command
-does not apply them. An empirical query followed by `src/harness/` still returned functions from
-`src/rules.rs`, `src/update.rs`, and scripts. Filter the JSON results when necessary:
+The pinned ctx 0.3.5 run exposed a product limitation: generic CLI help displayed positional file
+patterns for `similar`, but that version did not apply them. The query followed by `src/harness/`
+still returned functions from `src/rules.rs`, `src/update.rs`, and scripts. This was fixed after
+0.3.5 in [issue #57](https://github.com/agentis-tools/ctx/issues/57): current builds apply literal
+files, directories, and globs before limiting semantic or keyword results. When reproducing the
+0.3.5 case, filter the JSON results explicitly:
 
 ```bash
 ctx similar \
@@ -230,7 +233,7 @@ ctx similar \
   jq '.data.results[] | select(.symbol.file | startswith("src/harness/"))'
 ```
 
-Do not assume a pattern narrowed the search unless the returned paths prove it.
+For any version, verify the returned paths before treating retrieval scope as evidence.
 
 ## What worked, and what did not
 

--- a/docs/website/docs/cookbook/review-large-branch.md
+++ b/docs/website/docs/cookbook/review-large-branch.md
@@ -213,10 +213,12 @@ Automatic expansion was less useful than `--changes-only` for this branch. Use i
 source, and retain an added file only after its source contains the relationship that led to it.
 Direct queries from distinctive symbols were much cleaner.
 
-:::caution Positional file patterns do not scope `ctx diff` in ctx 0.3.5
-The global help displays positional patterns after the revision, but a verified run with
-`scripts/version.py` still analyzed all 29 files. Use `git diff -- <paths>` for an exact stream and
-use ctx source/query commands to build symbol context within it.
+:::caution Historical ctx 0.3.5 pattern-scoping limitation
+In the pinned 0.3.5 experiment, global help displayed positional patterns after the revision, but a
+verified run with `scripts/version.py` still analyzed all 29 files. This was fixed after 0.3.5 in
+[issue #57](https://github.com/agentis-tools/ctx/issues/57): current builds scope changed files and
+graph expansion, with explicit rename and deletion handling. Use `git diff -- <paths>` when
+reproducing the pinned run exactly.
 :::
 
 ## 8. Review claims against their enforcement

--- a/src/commands/diff_cmd.rs
+++ b/src/commands/diff_cmd.rs
@@ -101,13 +101,6 @@ pub fn run_diff(
             eprintln!("No changes found.");
             std::process::exit(2);
         }
-        // An empty scope is a legitimate answer, not an operational failure:
-        // the revision has changes, the caller just asked about paths none of
-        // them touch. Warn, because it usually means a mistyped pattern.
-        Err(CtxError::NoChangesInScope) => {
-            eprintln!("Warning: no changed files match the requested scope.");
-            std::process::exit(0);
-        }
         Err(CtxError::NotGitRepo) => {
             eprintln!("Error: Not a git repository.");
             std::process::exit(1);
@@ -118,6 +111,14 @@ pub fn run_diff(
         }
         Err(e) => return Err(e),
     };
+
+    // The revision had changes -- `get_changed_files` rejects one that did not --
+    // so an empty list here means the patterns excluded every one of them. That
+    // answers the narrower question rather than failing it, but warn, because in
+    // practice it usually means a mistyped pattern.
+    if result.changed_files.is_empty() {
+        eprintln!("Warning: no changed files match the requested scope.");
+    }
 
     // Show summary if requested
     if summary {

--- a/src/commands/diff_cmd.rs
+++ b/src/commands/diff_cmd.rs
@@ -101,6 +101,13 @@ pub fn run_diff(
             eprintln!("No changes found.");
             std::process::exit(2);
         }
+        // An empty scope is a legitimate answer, not an operational failure:
+        // the revision has changes, the caller just asked about paths none of
+        // them touch. Warn, because it usually means a mistyped pattern.
+        Err(CtxError::NoChangesInScope) => {
+            eprintln!("Warning: no changed files match the requested scope.");
+            std::process::exit(0);
+        }
         Err(CtxError::NotGitRepo) => {
             eprintln!("Error: Not a git repository.");
             std::process::exit(1);

--- a/src/commands/diff_cmd.rs
+++ b/src/commands/diff_cmd.rs
@@ -7,7 +7,9 @@ use std::env;
 use crate::cli::OutputFormat;
 use crate::commands::format_token_count;
 use ctx::analytics;
-use ctx::diff::{self, diff_context, format_pr_header, format_summary, get_pr_info, DiffConfig};
+use ctx::diff::{
+    self, diff_context_filtered, format_pr_header, format_summary, get_pr_info, DiffConfig,
+};
 use ctx::error::{CtxError, Result};
 use ctx::index;
 use ctx::output;
@@ -26,8 +28,11 @@ pub fn run_diff(
     format: OutputFormat,
     show_sizes: bool,
     no_tree: bool,
+    patterns: &[String],
 ) -> Result<()> {
     let root = env::current_dir()?;
+    let filter = walker::FilePatternFilter::new(&root, patterns)
+        .map_err(|error| CtxError::Other(format!("Invalid file pattern: {error}")))?;
 
     // Check if index exists (for context expansion)
     let db = match index::open_database(&root) {
@@ -63,10 +68,12 @@ pub fn run_diff(
 
     // Run diff context analysis
     let result = match (&db, &analytics) {
-        (Some(db), Some(analytics)) => diff_context(revision, db, analytics, config),
+        (Some(db), Some(analytics)) => {
+            diff_context_filtered(revision, db, analytics, config, &filter)
+        }
         _ => {
             // Fallback: just get changed files without context expansion
-            let changed = diff::get_changed_files(revision, staged)?;
+            let changed = diff::get_changed_files_filtered(revision, staged, &filter)?;
             Ok(diff::DiffContext {
                 revision: revision.to_string(),
                 changed_files: changed.clone(),
@@ -206,5 +213,6 @@ pub fn run_review(
         format,
         show_sizes,
         no_tree,
+        &[".".to_string()],
     )
 }

--- a/src/commands/similar.rs
+++ b/src/commands/similar.rs
@@ -14,10 +14,7 @@ use ctx::exit::Outcome;
 use ctx::index;
 use ctx::json::SymbolRef;
 use ctx::utils::{truncate_path, truncate_str};
-
-/// Over-fetch factor: results are requested with `limit * OVERFETCH` and then
-/// filtered down to callable kinds, so kind scoping needs no schema changes.
-const OVERFETCH: usize = 3;
+use ctx::walker::FilePatternFilter;
 
 /// One enriched similarity hit.
 struct Hit {
@@ -38,19 +35,25 @@ pub fn run_similar(
     keyword: bool,
     provider: Provider,
     json: bool,
+    patterns: &[String],
 ) -> Result<Outcome> {
     let root = env::current_dir()?;
     let db = index::open_database(&root)?;
+    let filter = FilePatternFilter::new(&root, patterns)
+        .map_err(|error| CtxError::Other(format!("Invalid file pattern: {error}")))?;
 
     let (hits, mode) = if keyword {
-        (keyword_hits(&db, query, limit)?, "keyword")
+        (keyword_hits(&db, query, limit, &filter)?, "keyword")
     } else {
         ensure_embeddings(&db)?;
         let provider =
             embeddings::build_provider(provider, &ctx::config::CtxConfig::load(&root).embedding)?;
         embeddings::warn_index_mismatch(&db, provider.as_ref());
         let query_embedding = provider.embed(query)?;
-        (semantic_hits(&db, &query_embedding, limit)?, "semantic")
+        (
+            semantic_hits(&db, &query_embedding, limit, &filter)?,
+            "semantic",
+        )
     };
 
     if json {
@@ -86,39 +89,80 @@ fn is_callable(kind: SymbolKind) -> bool {
 }
 
 /// Embedding-based hits, scoped to functions/methods.
-fn semantic_hits(db: &Database, query_embedding: &Embedding, limit: usize) -> Result<Vec<Hit>> {
-    let raw = embeddings::semantic_search(db, query_embedding, limit.saturating_mul(OVERFETCH))?;
-
-    let mut scored: Vec<(Symbol, f64)> = Vec::new();
-    for r in raw {
-        if scored.len() >= limit {
-            break;
-        }
-        if let Some(symbol) = db.get_symbol(&r.symbol_id)? {
-            if is_callable(symbol.kind) {
-                scored.push((symbol, f64::from(r.score)));
-            }
-        }
+fn semantic_hits(
+    db: &Database,
+    query_embedding: &Embedding,
+    limit: usize,
+    filter: &FilePatternFilter,
+) -> Result<Vec<Hit>> {
+    if limit == 0 {
+        return enrich(db, Vec::new());
     }
 
-    enrich(db, scored)
+    let mut fetch = limit.saturating_mul(3).max(limit);
+    loop {
+        let raw = embeddings::semantic_search(db, query_embedding, fetch)?;
+        let exhausted = raw.len() < fetch;
+        let mut scored: Vec<(Symbol, f64)> = Vec::new();
+        for result in raw {
+            if filter.matches(&result.file_path) {
+                if let Some(symbol) = db.get_symbol(&result.symbol_id)? {
+                    if is_callable(symbol.kind) {
+                        scored.push((symbol, f64::from(result.score)));
+                    }
+                }
+            }
+            if scored.len() >= limit {
+                break;
+            }
+        }
+
+        if scored.len() == limit || exhausted {
+            return enrich(db, scored);
+        }
+
+        let next = fetch.saturating_mul(2);
+        if next == fetch {
+            return enrich(db, scored);
+        }
+        fetch = next;
+    }
 }
 
 /// FTS5/keyword hits (no embeddings or API key needed), scoped to
 /// functions/methods. The score is the relevance value returned by
 /// `Database::hybrid_search` (see docs/json-output.md).
-fn keyword_hits(db: &Database, query: &str, limit: usize) -> Result<Vec<Hit>> {
-    let fetch = limit.saturating_mul(OVERFETCH).min(i32::MAX as usize) as i32;
-    let raw = db.hybrid_search(query, fetch)?;
+fn keyword_hits(
+    db: &Database,
+    query: &str,
+    limit: usize,
+    filter: &FilePatternFilter,
+) -> Result<Vec<Hit>> {
+    if limit == 0 {
+        return enrich(db, Vec::new());
+    }
 
-    let mut scored: Vec<(Symbol, f64)> = raw
-        .into_iter()
-        .filter(|(symbol, _, _)| is_callable(symbol.kind))
-        .map(|(symbol, score, _match_type)| (symbol, score))
-        .collect();
-    scored.truncate(limit);
+    let mut fetch = limit.saturating_mul(3).max(limit).min(i32::MAX as usize) as i32;
+    loop {
+        let raw = db.hybrid_search(query, fetch)?;
+        let exhausted = raw.len() < fetch as usize;
+        let scored: Vec<(Symbol, f64)> = raw
+            .into_iter()
+            .filter(|(symbol, _, _)| is_callable(symbol.kind) && filter.matches(&symbol.file_path))
+            .map(|(symbol, score, _match_type)| (symbol, score))
+            .take(limit)
+            .collect();
 
-    enrich(db, scored)
+        if scored.len() == limit || exhausted {
+            return enrich(db, scored);
+        }
+
+        let next = fetch.saturating_mul(2);
+        if next == fetch {
+            return enrich(db, scored);
+        }
+        fetch = next;
+    }
 }
 
 /// Attach fan-in counts (one batched query) and one-line docs to raw hits.
@@ -224,6 +268,10 @@ mod tests {
     use super::*;
     use ctx::db::{Edge, EdgeKind, FileRecord, Visibility};
 
+    fn all_files() -> FilePatternFilter {
+        FilePatternFilter::all(std::path::Path::new("."))
+    }
+
     fn make_symbol(
         name: &str,
         kind: SymbolKind,
@@ -324,7 +372,7 @@ mod tests {
         let db = fixture();
         let query = Embedding::new(vec![1.0, 0.0, 0.0]);
 
-        let hits = semantic_hits(&db, &query, 10).unwrap();
+        let hits = semantic_hits(&db, &query, 10, &all_files()).unwrap();
 
         // The struct is excluded even though its vector matches perfectly.
         assert!(hits.iter().all(|h| is_callable(h.symbol.kind)));
@@ -343,10 +391,47 @@ mod tests {
         let db = fixture();
         let query = Embedding::new(vec![1.0, 0.0, 0.0]);
 
-        let hits = semantic_hits(&db, &query, 2).unwrap();
+        let hits = semantic_hits(&db, &query, 2, &all_files()).unwrap();
         let names: Vec<&str> = hits.iter().map(|h| h.symbol.name.as_str()).collect();
         // The struct occupying an over-fetched slot must not push out beta.
         assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_semantic_hits_overfetches_again_after_path_filtering() {
+        let db = Database::open_in_memory().unwrap();
+        let entries = [
+            ("tests/one.rs", "one", [1.0, 0.0, 0.0]),
+            ("tests/two.rs", "two", [0.99, 0.1, 0.0]),
+            ("tests/three.rs", "three", [0.95, 0.2, 0.0]),
+            ("src/keep.rs", "keep", [0.8, 0.6, 0.0]),
+        ];
+        for (path, name, embedding) in entries {
+            db.upsert_file(
+                &FileRecord {
+                    path: path.to_string(),
+                    content_hash: name.to_string(),
+                    size_bytes: 1,
+                    language: Some("rust".to_string()),
+                    last_indexed: 0,
+                },
+                None,
+            )
+            .unwrap();
+            let mut symbol = make_symbol(name, SymbolKind::Function, None, None);
+            symbol.id = format!("{path}::{name}");
+            symbol.file_path = path.to_string();
+            db.insert_symbol(&symbol).unwrap();
+            db.store_embedding(&symbol.id, "test", "default", &embedding)
+                .unwrap();
+        }
+
+        let filter =
+            FilePatternFilter::new(std::path::Path::new("."), &["src/".to_string()]).unwrap();
+        let hits = semantic_hits(&db, &Embedding::new(vec![1.0, 0.0, 0.0]), 1, &filter).unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].symbol.file_path, "src/keep.rs");
     }
 
     #[test]
@@ -373,7 +458,7 @@ mod tests {
         assert!(deleted > 0);
         assert_eq!(db.count_embeddings().unwrap(), 0);
 
-        let hits = keyword_hits(&db, "alpha", 5).unwrap();
+        let hits = keyword_hits(&db, "alpha", 5, &all_files()).unwrap();
         assert!(!hits.is_empty());
         assert_eq!(hits[0].symbol.name, "alpha");
         assert!(hits.iter().all(|h| is_callable(h.symbol.kind)));
@@ -383,7 +468,7 @@ mod tests {
     fn test_keyword_hits_exclude_non_callable_kinds() {
         let db = fixture();
         // "shape" is a struct; an exact-name keyword query must not return it.
-        let hits = keyword_hits(&db, "shape", 5).unwrap();
+        let hits = keyword_hits(&db, "shape", 5, &all_files()).unwrap();
         assert!(!hits.iter().any(|h| h.symbol.name == "shape"));
     }
 
@@ -392,7 +477,7 @@ mod tests {
         let db = fixture();
         let query = Embedding::new(vec![1.0, 0.0, 0.0]);
 
-        let hits = semantic_hits(&db, &query, 10).unwrap();
+        let hits = semantic_hits(&db, &query, 10, &all_files()).unwrap();
         let get = |name: &str| hits.iter().find(|h| h.symbol.name == name).unwrap();
 
         assert_eq!(get("alpha").fan_in, 2);
@@ -433,7 +518,7 @@ mod tests {
     fn test_similar_data_payload_shape() {
         let db = fixture();
         let query = Embedding::new(vec![1.0, 0.0, 0.0]);
-        let hits = semantic_hits(&db, &query, 10).unwrap();
+        let hits = semantic_hits(&db, &query, 10, &all_files()).unwrap();
 
         let data = similar_data("parse input", "semantic", &hits);
         assert_eq!(data["query"], "parse input");

--- a/src/commands/smart_cmd.rs
+++ b/src/commands/smart_cmd.rs
@@ -11,7 +11,7 @@ use ctx::embeddings::{self, Provider};
 use ctx::error::Result;
 use ctx::index;
 use ctx::output;
-use ctx::smart::{format_dry_run, format_explain, smart_context, SmartConfig};
+use ctx::smart::{format_dry_run, format_explain, smart_context_filtered, SmartConfig};
 use ctx::tokens;
 use ctx::walker;
 
@@ -28,9 +28,12 @@ pub fn run_smart(
     format: OutputFormat,
     show_sizes: bool,
     no_tree: bool,
+    patterns: &[String],
 ) -> Result<()> {
     let root = env::current_dir()?;
     let db = index::open_database(&root)?;
+    let filter = walker::FilePatternFilter::new(&root, patterns)
+        .map_err(|error| ctx::error::CtxError::Other(format!("Invalid file pattern: {error}")))?;
 
     // Check if we have embeddings
     let embedding_count = db.count_embeddings()?;
@@ -63,7 +66,7 @@ pub fn run_smart(
 
     eprintln!("Analyzing task: \"{}\"...", task);
 
-    let result = smart_context(&db, &analytics, provider.as_ref(), task, config)?;
+    let result = smart_context_filtered(&db, &analytics, provider.as_ref(), task, config, &filter)?;
 
     if result.selected_files.is_empty() {
         eprintln!("No relevant files found for: \"{}\"", task);

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -275,6 +275,12 @@ pub fn get_changed_files(revision: &str, staged: bool) -> Result<Vec<ChangedFile
 /// mirroring how users reason about path-limited git diffs. Deleted paths are
 /// retained in the changed-file summary even though they cannot be emitted as
 /// context content.
+///
+/// Returns an empty list when the revision has changes that the scope excludes;
+/// that is a legitimate answer to a narrower question, not a failure. A revision
+/// with no changes at all still fails with [`CtxError::NoChanges`], because
+/// `get_changed_files` rejects it before the scope is applied -- so an empty
+/// list here always means the patterns excluded everything.
 pub fn get_changed_files_filtered(
     revision: &str,
     staged: bool,
@@ -288,9 +294,6 @@ pub fn get_changed_files_filtered(
                 .as_deref()
                 .is_some_and(|path| filter.matches(path))
     });
-    if files.is_empty() {
-        return Err(CtxError::NoChangesInScope);
-    }
     Ok(files)
 }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -289,7 +289,7 @@ pub fn get_changed_files_filtered(
                 .is_some_and(|path| filter.matches(path))
     });
     if files.is_empty() {
-        return Err(CtxError::NoChanges);
+        return Err(CtxError::NoChangesInScope);
     }
     Ok(files)
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -23,6 +23,7 @@ use crate::analytics::Analytics;
 use crate::db::Database;
 use crate::error::{CtxError, Result};
 use crate::tokens::{count_tokens_with_encoding, select_by_token_budget, Encoding, HasTokenCount};
+use crate::walker::FilePatternFilter;
 
 /// Configuration for diff-aware context generation.
 #[derive(Debug, Clone)]
@@ -268,6 +269,31 @@ pub fn get_changed_files(revision: &str, staged: bool) -> Result<Vec<ChangedFile
     Ok(detailed_files)
 }
 
+/// Get changed files restricted to positional file patterns.
+///
+/// A rename is in scope when either its original or destination path matches,
+/// mirroring how users reason about path-limited git diffs. Deleted paths are
+/// retained in the changed-file summary even though they cannot be emitted as
+/// context content.
+pub fn get_changed_files_filtered(
+    revision: &str,
+    staged: bool,
+    filter: &FilePatternFilter,
+) -> Result<Vec<ChangedFile>> {
+    let mut files = get_changed_files(revision, staged)?;
+    files.retain(|file| {
+        filter.matches(&file.path)
+            || file
+                .original_path
+                .as_deref()
+                .is_some_and(|path| filter.matches(path))
+    });
+    if files.is_empty() {
+        return Err(CtxError::NoChanges);
+    }
+    Ok(files)
+}
+
 /// Parse git diff --name-status output.
 pub fn parse_diff_output(output: &str) -> Vec<ChangedFile> {
     let mut files = Vec::new();
@@ -439,8 +465,25 @@ pub fn diff_context(
     analytics: &Analytics,
     config: DiffConfig,
 ) -> Result<DiffContext> {
+    let root = std::env::current_dir().unwrap_or_default();
+    let filter = FilePatternFilter::all(&root);
+    diff_context_filtered(revision, db, analytics, config, &filter)
+}
+
+/// Generate diff-aware context restricted to positional file patterns.
+///
+/// Changed files are filtered before symbol lookup. Directly changed rename
+/// destinations remain context when the original path matched; graph-expanded
+/// files must independently match the filter.
+pub fn diff_context_filtered(
+    revision: &str,
+    db: &Database,
+    analytics: &Analytics,
+    config: DiffConfig,
+    filter: &FilePatternFilter,
+) -> Result<DiffContext> {
     // 1. Get changed files
-    let changed_files = get_changed_files(revision, config.staged)?;
+    let changed_files = get_changed_files_filtered(revision, config.staged, filter)?;
 
     // 2. Find affected symbols
     let mut affected_symbols = Vec::new();
@@ -473,7 +516,7 @@ pub fn diff_context(
     // 4. Expand context using call graph (if not changes_only)
     if !config.changes_only {
         for symbol in &affected_symbols {
-            expand_context_for_symbol(&mut context_files, analytics, symbol, config.depth);
+            expand_context_for_symbol(&mut context_files, analytics, symbol, config.depth, filter);
         }
     }
 
@@ -514,10 +557,14 @@ fn expand_context_for_symbol(
     analytics: &Analytics,
     symbol: &AffectedSymbol,
     depth: i32,
+    filter: &FilePatternFilter,
 ) {
     // Find callers (impact analysis)
     if let Ok(callers) = analytics.impact_analysis(&symbol.name, depth) {
         for caller in callers {
+            if !filter.matches(&caller.file_path) {
+                continue;
+            }
             let priority = 0.8 / (caller.distance as f32).max(1.0);
             add_context_file(
                 context_files,
@@ -534,6 +581,9 @@ fn expand_context_for_symbol(
     // Find callees (call graph)
     if let Ok(callees) = analytics.call_graph(&symbol.name, depth) {
         for callee in callees {
+            if !filter.matches(&callee.file_path) {
+                continue;
+            }
             let priority = 0.6 / (callee.depth as f32).max(1.0);
             add_context_file(
                 context_files,

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,13 +76,6 @@ pub enum CtxError {
     #[error("No changes found")]
     NoChanges,
 
-    /// The revision has changes, but none match the requested path scope.
-    ///
-    /// Distinct from [`CtxError::NoChanges`]: an empty scope is a legitimate
-    /// answer to a narrower question, not a failure to answer it.
-    #[error("No changes found in scope")]
-    NoChangesInScope,
-
     // ========== Business Logic Errors ==========
     /// No relevant files found for smart context.
     #[error("No relevant files found")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,13 @@ pub enum CtxError {
     #[error("No changes found")]
     NoChanges,
 
+    /// The revision has changes, but none match the requested path scope.
+    ///
+    /// Distinct from [`CtxError::NoChanges`]: an empty scope is a legitimate
+    /// answer to a narrower question, not a failure to answer it.
+    #[error("No changes found in scope")]
+    NoChangesInScope,
+
     // ========== Business Logic Errors ==========
     /// No relevant files found for smart context.
     #[error("No relevant files found")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,12 +207,14 @@ pub use error::{CtxError, Result};
 pub mod prelude {
     pub use crate::analytics::Analytics;
     pub use crate::db::{Database, Edge, EdgeKind, FileRecord, ParseResult, Symbol, SymbolKind};
-    pub use crate::diff::{diff_context, DiffConfig, DiffContext};
+    pub use crate::diff::{diff_context, diff_context_filtered, DiffConfig, DiffContext};
     pub use crate::embeddings::{Embedding, EmbeddingProvider, LocalProvider};
     pub use crate::error::{CtxError, Result};
     pub use crate::index::{open_database, IndexResult, Indexer};
     pub use crate::parser::{CodeParser, Language};
-    pub use crate::smart::{smart_context, FileSelection, SmartConfig, SmartContext};
+    pub use crate::smart::{
+        smart_context, smart_context_filtered, FileSelection, SmartConfig, SmartContext,
+    };
     pub use crate::tokens::{count_tokens, Encoding, HasTokenCount, TokenCount};
-    pub use crate::walker::{discover_files, FileEntry, WalkerConfig};
+    pub use crate::walker::{discover_files, FileEntry, FilePatternFilter, WalkerConfig};
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ fn run_main() -> ExitCode {
 fn run(args: Args) -> Result<Outcome> {
     // Global machine-readable output flag (see docs/json-output.md)
     let json = args.json;
+    let patterns = args.patterns.clone();
 
     // Custom --version handling: clap's auto flag is disabled (it would
     // exit before `--check` could run). `ctx --version` prints the same
@@ -186,7 +187,7 @@ fn run(args: Args) -> Result<Outcome> {
             let provider = resolve_embed_provider(provider, openai);
             // `similar` participates in the Outcome convention directly:
             // Clean on success, Err (exit 2) when embeddings are missing.
-            return commands::run_similar(&query, limit, keyword, provider, json);
+            return commands::run_similar(&query, limit, keyword, provider, json, &patterns);
         }
         Some(Command::Complexity {
             threshold,
@@ -251,7 +252,7 @@ fn run(args: Args) -> Result<Outcome> {
             let provider = resolve_embed_provider(provider, openai);
             commands::run_smart(
                 &task, max_tokens, depth, top, explain, dry_run, provider, format, show_sizes,
-                no_tree,
+                no_tree, &patterns,
             )
         }
         Some(Command::Diff {
@@ -274,6 +275,7 @@ fn run(args: Args) -> Result<Outcome> {
             format,
             show_sizes,
             no_tree,
+            &patterns,
         ),
         Some(Command::Review {
             pr,

--- a/src/smart.rs
+++ b/src/smart.rs
@@ -24,6 +24,7 @@ use crate::embeddings::{semantic_search, Embedding, EmbeddingProvider, SearchRes
 use crate::error::{CtxError, Result};
 use crate::tokens::{count_file_tokens, select_by_token_budget, Encoding, HasTokenCount};
 use crate::utils::lexical_tokens;
+use crate::walker::FilePatternFilter;
 
 /// Configuration for smart context selection.
 #[derive(Debug, Clone)]
@@ -237,10 +238,27 @@ pub fn smart_context(
     task: &str,
     config: SmartConfig,
 ) -> Result<SmartContext> {
+    let root = std::env::current_dir().unwrap_or_default();
+    let filter = FilePatternFilter::all(&root);
+    smart_context_filtered(db, analytics, provider, task, config, &filter)
+}
+
+/// Select files relevant to a task, restricted to positional file patterns.
+///
+/// Filtering happens before semantic seeds are limited and is also applied to
+/// every call-graph neighbor, so expansion cannot escape the requested scope.
+pub fn smart_context_filtered(
+    db: &Database,
+    analytics: &Analytics,
+    provider: &dyn EmbeddingProvider,
+    task: &str,
+    config: SmartConfig,
+    filter: &FilePatternFilter,
+) -> Result<SmartContext> {
     // 1. Embed the task description
     let task_embedding = provider.embed(task)?;
 
-    smart_context_with_embedding(db, analytics, task, &task_embedding, config)
+    smart_context_with_embedding_filtered(db, analytics, task, &task_embedding, config, filter)
 }
 
 /// Select files relevant to a task using a pre-computed embedding.
@@ -256,8 +274,22 @@ pub fn smart_context_with_embedding(
     task_embedding: &Embedding,
     config: SmartConfig,
 ) -> Result<SmartContext> {
+    let root = std::env::current_dir().unwrap_or_default();
+    let filter = FilePatternFilter::all(&root);
+    smart_context_with_embedding_filtered(db, analytics, task, task_embedding, config, &filter)
+}
+
+/// Pre-computed-embedding variant of [`smart_context_filtered`].
+pub fn smart_context_with_embedding_filtered(
+    db: &Database,
+    analytics: &Analytics,
+    task: &str,
+    task_embedding: &Embedding,
+    config: SmartConfig,
+    filter: &FilePatternFilter,
+) -> Result<SmartContext> {
     // 2. Semantic search for matching symbols
-    let matches = semantic_search(db, task_embedding, config.top)?;
+    let matches = semantic_matches_in_scope(db, task_embedding, config.top, filter)?;
 
     if matches.is_empty() {
         return Err(CtxError::NoMatches);
@@ -278,7 +310,7 @@ pub fn smart_context_with_embedding(
         );
 
         // Expand call graph
-        expand_symbol(&mut files, analytics, result, config.depth)?;
+        expand_symbol(&mut files, analytics, result, config.depth, filter)?;
     }
 
     // 4. Convert to vector and count tokens
@@ -312,6 +344,40 @@ pub fn smart_context_with_embedding(
         truncated: omitted > 0,
         omitted_count: omitted,
     })
+}
+
+/// Fetch semantic matches in bounded batches until filtering yields `limit`
+/// results or the index is exhausted.
+fn semantic_matches_in_scope(
+    db: &Database,
+    task_embedding: &Embedding,
+    limit: usize,
+    filter: &FilePatternFilter,
+) -> Result<Vec<SearchResult>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut fetch = limit.saturating_mul(3).max(limit);
+    loop {
+        let raw = semantic_search(db, task_embedding, fetch)?;
+        let exhausted = raw.len() < fetch;
+        let matches: Vec<_> = raw
+            .into_iter()
+            .filter(|result| filter.matches(&result.file_path))
+            .take(limit)
+            .collect();
+
+        if matches.len() == limit || exhausted {
+            return Ok(matches);
+        }
+
+        let next = fetch.saturating_mul(2);
+        if next == fetch {
+            return Ok(matches);
+        }
+        fetch = next;
+    }
 }
 
 /// Apply the token budget while guaranteeing the top-ranked file is always
@@ -362,18 +428,23 @@ fn expand_symbol(
     analytics: &Analytics,
     result: &SearchResult,
     depth: i32,
+    filter: &FilePatternFilter,
 ) -> Result<()> {
     // Expand callers (who calls this symbol - impact analysis)
     if let Ok(callers) = analytics.impact_analysis(&result.symbol_id, depth) {
         for caller in callers {
-            add_file_from_impact(files, &caller, &result.name);
+            if filter.matches(&caller.file_path) {
+                add_file_from_impact(files, &caller, &result.name);
+            }
         }
     }
 
     // Expand callees (what does this symbol call - call graph)
     if let Ok(callees) = analytics.call_graph(&result.symbol_id, depth) {
         for callee in callees {
-            add_file_from_call_graph(files, &callee, &result.name);
+            if filter.matches(&callee.file_path) {
+                add_file_from_call_graph(files, &callee, &result.name);
+            }
         }
     }
 

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -18,6 +18,92 @@ use ignore::WalkBuilder;
 
 use crate::default_ignores::DEFAULT_IGNORES;
 
+/// Reusable matcher for positional file and directory patterns.
+///
+/// Patterns are ORed together. Non-glob values match a literal file or every
+/// file below a literal directory, while glob values use the same
+/// separator-aware matching as [`discover_files`]. A missing pattern list or
+/// the conventional `.` pattern matches every repository-relative path.
+#[derive(Debug, Clone)]
+pub struct FilePatternFilter {
+    root: PathBuf,
+    globset: Option<GlobSet>,
+    literal_paths: Vec<PathBuf>,
+    match_all: bool,
+}
+
+impl FilePatternFilter {
+    /// Compile positional patterns relative to `root`.
+    pub fn new(root: &Path, patterns: &[String]) -> io::Result<Self> {
+        let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        let match_all = patterns.is_empty() || patterns.iter().any(|pattern| pattern == ".");
+        let globset = if match_all {
+            None
+        } else {
+            build_include_globset(&root, patterns)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?
+        };
+        let literal_paths = if match_all {
+            Vec::new()
+        } else {
+            get_literal_paths(patterns)
+                .into_iter()
+                .map(|path| normalize_literal(&root, path))
+                .collect()
+        };
+
+        Ok(Self {
+            root,
+            globset,
+            literal_paths,
+            match_all,
+        })
+    }
+
+    /// Build a matcher that accepts every path.
+    pub fn all(root: &Path) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            globset: None,
+            literal_paths: Vec::new(),
+            match_all: true,
+        }
+    }
+
+    /// Return whether a repository-relative or absolute path is in scope.
+    pub fn matches(&self, path: impl AsRef<Path>) -> bool {
+        if self.match_all {
+            return true;
+        }
+
+        let path = path.as_ref();
+        let relative = if path.is_absolute() {
+            match path.strip_prefix(&self.root) {
+                Ok(relative) => relative,
+                Err(_) => return false,
+            }
+        } else {
+            path
+        };
+
+        self.literal_paths
+            .iter()
+            .any(|literal| relative == literal || relative.starts_with(literal))
+            || self
+                .globset
+                .as_ref()
+                .is_some_and(|globset| globset.is_match(relative))
+    }
+}
+
+fn normalize_literal(root: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path.strip_prefix(root).unwrap_or(&path).to_path_buf()
+    } else {
+        path
+    }
+}
+
 /// File filter that can check if individual files should be included.
 /// This is built once and reused for watch mode filtering.
 ///
@@ -765,6 +851,25 @@ mod tests {
 
         // Should NOT match files outside src/
         assert!(!globset.is_match(Path::new("tests/test.rs")));
+    }
+
+    #[test]
+    fn file_pattern_filter_supports_literals_globs_or_and_dot() {
+        let root = Path::new("/project");
+        let filter =
+            FilePatternFilter::new(root, &["src".to_string(), "tests/**/*.rs".to_string()])
+                .unwrap();
+
+        assert!(filter.matches("src/main.rs"));
+        assert!(filter.matches("tests/unit/parser.rs"));
+        assert!(!filter.matches("docs/guide.md"));
+
+        let file = FilePatternFilter::new(root, &["Cargo.toml".to_string()]).unwrap();
+        assert!(file.matches("Cargo.toml"));
+        assert!(!file.matches("Cargo.lock"));
+
+        let all = FilePatternFilter::new(root, &[".".to_string()]).unwrap();
+        assert!(all.matches("any/nested/path.rs"));
     }
 
     #[test]

--- a/tests/pattern_scoping_cli.rs
+++ b/tests/pattern_scoping_cli.rs
@@ -165,11 +165,17 @@ fn diff_scope_matching_no_changes_warns_and_succeeds() {
     assert_success(&ctx(&repo.root, &["index"]));
 
     // Scope that matches changed files: succeeds and reports them.
-    let hit = ctx(&repo.root, &["diff", "HEAD^", "--summary", "--no-tree", "src/"]);
+    let hit = ctx(
+        &repo.root,
+        &["diff", "HEAD^", "--summary", "--no-tree", "src/"],
+    );
     assert_success(&hit);
 
     // Scope that matches nothing: exit 0, warns, and reports no changed file.
-    let miss = ctx(&repo.root, &["diff", "HEAD^", "--summary", "--no-tree", "docs/"]);
+    let miss = ctx(
+        &repo.root,
+        &["diff", "HEAD^", "--summary", "--no-tree", "docs/"],
+    );
     assert_eq!(
         miss.status.code(),
         Some(0),

--- a/tests/pattern_scoping_cli.rs
+++ b/tests/pattern_scoping_cli.rs
@@ -151,3 +151,46 @@ fn diff_scopes_changes_deletions_and_both_sides_of_renames() {
         );
     }
 }
+
+/// An empty scope is a legitimate answer to a narrower question, so it reports
+/// nothing and warns rather than failing. A revision with no changes at all is
+/// still an operational error, as it was before patterns were honored.
+#[test]
+fn diff_scope_matching_no_changes_warns_and_succeeds() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = GitRepo::init(temp.path());
+    repo.commit_file("src/a.rs", "fn a() {}\n", "init");
+    repo.commit_file("docs/b.md", "docs\n", "add docs");
+    repo.commit_file("src/a.rs", "fn a() { let _ = 1; }\n", "change src only");
+    assert_success(&ctx(&repo.root, &["index"]));
+
+    // Scope that matches changed files: succeeds and reports them.
+    let hit = ctx(&repo.root, &["diff", "HEAD^", "--summary", "--no-tree", "src/"]);
+    assert_success(&hit);
+
+    // Scope that matches nothing: exit 0, warns, and reports no changed file.
+    let miss = ctx(&repo.root, &["diff", "HEAD^", "--summary", "--no-tree", "docs/"]);
+    assert_eq!(
+        miss.status.code(),
+        Some(0),
+        "an empty scope must not be an operational error: {}",
+        String::from_utf8_lossy(&miss.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&miss.stderr);
+    assert!(
+        stderr.contains("no changed files match the requested scope"),
+        "an empty scope must warn: {stderr}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&miss.stdout).contains("src/a.rs"),
+        "an empty scope must not fall back to the unscoped result"
+    );
+
+    // No changes at all remains an operational error (pre-existing contract).
+    let none = ctx(&repo.root, &["diff", "HEAD", "--summary", "--no-tree"]);
+    assert_eq!(
+        none.status.code(),
+        Some(2),
+        "a revision with no changes must stay an operational error"
+    );
+}

--- a/tests/pattern_scoping_cli.rs
+++ b/tests/pattern_scoping_cli.rs
@@ -1,0 +1,153 @@
+//! Offline end-to-end coverage for positional pattern scoping on commands
+//! whose help advertises the shared `[PATTERNS]...` arguments.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use ctx::testutil::GitRepo;
+
+fn ctx(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ctx"))
+        .args(args)
+        .current_dir(dir)
+        .env("CTX_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("failed to run ctx")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "ctx failed with {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn similar_keyword_scopes_literal_directory_file_glob_and_or_patterns() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = GitRepo::init(temp.path());
+    repo.write(
+        "src/scoped.rs",
+        "/// reusable checksum helper\nfn reusable_checksum_helper() {}\n",
+    );
+    repo.write(
+        "docs/guide.rs",
+        "/// reusable checksum helper guide\nfn reusable_checksum_helper_guide() {}\n",
+    );
+    repo.write(
+        "tests/outside.rs",
+        "/// reusable checksum helper test\nfn reusable_checksum_helper_test() {}\n",
+    );
+
+    assert_success(&ctx(&repo.root, &["index"]));
+
+    for patterns in [vec!["src/"], vec!["src/**/*.rs"], vec!["src/scoped.rs"]] {
+        let mut args = vec!["similar", "reusable checksum helper", "--keyword", "--json"];
+        args.extend(patterns);
+        let output = ctx(&repo.root, &args);
+        assert_success(&output);
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let paths: Vec<_> = json["data"]["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|hit| hit["symbol"]["file"].as_str().unwrap())
+            .collect();
+        assert_eq!(paths, vec!["src/scoped.rs"], "args: {args:?}");
+    }
+
+    let output = ctx(
+        &repo.root,
+        &[
+            "similar",
+            "reusable checksum helper",
+            "--keyword",
+            "--json",
+            "src/",
+            "docs/guide.rs",
+        ],
+    );
+    assert_success(&output);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let paths: std::collections::BTreeSet<_> = json["data"]["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hit| hit["symbol"]["file"].as_str().unwrap())
+        .collect();
+    assert_eq!(paths, ["docs/guide.rs", "src/scoped.rs"].into());
+
+    let output = ctx(
+        &repo.root,
+        &["similar", "reusable checksum helper", "--keyword", "--json"],
+    );
+    assert_success(&output);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["data"]["results"].as_array().unwrap().len(), 3);
+}
+
+#[test]
+fn diff_scopes_changes_deletions_and_both_sides_of_renames() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = GitRepo::init(temp.path());
+    repo.write("src/changed.rs", "fn changed() {}\n");
+    repo.write("src/deleted.rs", "fn deleted() {}\n");
+    repo.write("src/renamed.rs", "fn renamed() {}\n");
+    repo.write("docs/outside.md", "before\n");
+    repo.write("docs/caller.rs", "fn outside_caller() { changed(); }\n");
+    repo.commit_all("base");
+    assert_success(&ctx(&repo.root, &["index"]));
+
+    repo.write(
+        "src/changed.rs",
+        "fn changed() { println!(\"changed\"); }\n",
+    );
+    std::fs::remove_file(repo.root.join("src/deleted.rs")).unwrap();
+    std::fs::create_dir_all(repo.root.join("docs")).unwrap();
+    let rename = Command::new("git")
+        .args(["mv", "src/renamed.rs", "docs/renamed.rs"])
+        .current_dir(&repo.root)
+        .output()
+        .unwrap();
+    assert_success(&rename);
+    repo.write("docs/outside.md", "after\n");
+
+    let output = ctx(
+        &repo.root,
+        &["diff", "HEAD", "--changes-only", "--summary", "src/"],
+    );
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(stdout.contains("src/changed.rs"), "{stdout}");
+    assert!(stdout.contains("docs/renamed.rs"), "{stdout}");
+    assert!(!stdout.contains("docs/outside.md"), "{stdout}");
+    assert!(stderr.contains("src/deleted.rs"), "{stderr}");
+    assert!(stderr.contains("docs/renamed.rs"), "{stderr}");
+    assert!(!stderr.contains("docs/outside.md"), "{stderr}");
+
+    #[cfg(feature = "duckdb")]
+    {
+        let output = ctx(&repo.root, &["diff", "HEAD", "--summary", "--no-tree", "."]);
+        assert_success(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("docs/caller.rs"),
+            "unfiltered graph expansion should include the indexed caller: {stdout}"
+        );
+
+        let output = ctx(
+            &repo.root,
+            &["diff", "HEAD", "--summary", "--no-tree", "src/"],
+        );
+        assert_success(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("docs/caller.rs"),
+            "scoped graph expansion escaped src/: {stdout}"
+        );
+    }
+}

--- a/tests/smart_relevance.rs
+++ b/tests/smart_relevance.rs
@@ -26,7 +26,10 @@ use std::path::Path;
 use ctx::analytics::Analytics;
 use ctx::db::{Database, Edge, EdgeKind, FileRecord, Symbol, SymbolKind, Visibility};
 use ctx::embeddings::Embedding;
-use ctx::smart::{smart_context_with_embedding, SmartConfig};
+use ctx::smart::{
+    smart_context_with_embedding, smart_context_with_embedding_filtered, SmartConfig,
+};
+use ctx::walker::FilePatternFilter;
 use tempfile::TempDir;
 
 /// One symbol to seed: its file path, symbol name, optional embedding vector
@@ -251,4 +254,66 @@ fn graph_only_path_match_is_promoted() {
         openai < modrs,
         "openai.rs (2 path hits) must outrank embeddings/mod.rs (1 path hit): {paths:?}"
     );
+}
+
+#[test]
+fn patterns_iteratively_overfetch_seeds_and_filter_graph_expansion() {
+    let outside_callee = Symbol::make_id("fixture/docs/outside.rs", "outside_callee", None);
+    let seeds = [
+        Seed {
+            path: "fixture/tests/high_score.rs",
+            name: "high_score",
+            embedding: Some([1.0, 0.0, 0.0, 0.0]),
+            calls: None,
+        },
+        Seed {
+            path: "fixture/tests/high_score_two.rs",
+            name: "high_score_two",
+            embedding: Some([0.99, 0.1, 0.0, 0.0]),
+            calls: None,
+        },
+        Seed {
+            path: "fixture/tests/high_score_three.rs",
+            name: "high_score_three",
+            embedding: Some([0.95, 0.2, 0.0, 0.0]),
+            calls: None,
+        },
+        Seed {
+            path: "fixture/src/in_scope.rs",
+            name: "in_scope",
+            embedding: Some([0.8, 0.6, 0.0, 0.0]),
+            calls: Some(outside_callee),
+        },
+        Seed {
+            path: "fixture/docs/outside.rs",
+            name: "outside_callee",
+            embedding: None,
+            calls: None,
+        },
+    ];
+    let temp = build_fixture(&seeds);
+    let db = Database::open(&temp.path().join(".ctx/codebase.sqlite")).unwrap();
+    let analytics = Analytics::open(temp.path()).unwrap();
+    let filter = FilePatternFilter::new(temp.path(), &["fixture/src".to_string()]).unwrap();
+    let config = SmartConfig {
+        top: 1,
+        ..SmartConfig::default()
+    };
+
+    let result = smart_context_with_embedding_filtered(
+        &db,
+        &analytics,
+        "find scoped code",
+        &Embedding::new(vec![1.0, 0.0, 0.0, 0.0]),
+        config,
+        &filter,
+    )
+    .unwrap();
+    let paths: Vec<_> = result
+        .selected_files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect();
+
+    assert_eq!(paths, vec!["fixture/src/in_scope.rs"]);
 }


### PR DESCRIPTION
## Summary

- honor advertised literal, directory, glob, and multiple positional patterns in `ctx smart`, `ctx similar`, and `ctx diff`
- filter semantic seeds, graph expansion, changed files, renames, and deletions before ranking and budgeting
- use bounded iterative overfetch so path scoping does not underfill results or fetch the whole result space
- preserve existing public configuration structs through additive filtered entry points
- add CLI/offline regressions, command docs, cookbook resolution notes, and an Unreleased fix

Closes #57.

## Validation

- focused all-feature pattern/smart suite: 5/5
- similar unit suite: 12/12 with all and no-default features
- no-default pattern CLI: 2/2
- second-fetch/out-of-scope overfetch regressions
- all-target/all-feature Clippy, rustfmt, diff checks
- full all-feature and no-default suites
- docs typecheck and Docusaurus production build
- governance, versioning, agent-doc, release binary, version and CLI contract checks

## Compatibility

Explicit patterns now narrow output according to the existing advertised contract. Default `.` remains unscoped. No flag, JSON schema, exit-code, version, or lockfile change.

Manual review required before merge. Please apply `contract-review` only after acknowledging the output-scoping correction.