### PR TITLE
fix: honor query traversal depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `ctx query callers` and `ctx query deps` now honor `--depth` with cycle-safe breadth-first
+  traversal, shortest-distance identity deduplication, explicit JSON distances, and distance-grouped
+  human output while keeping unresolved relationships as non-recursive evidence leaves (#58).
 - Caller lookup now reports only resolved `calls` edges to the selected symbol, while preserving
   conservative same-language unresolved evidence in a separate section instead of mixing in
   cross-language or same-name false positives (#61).

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -301,6 +301,8 @@ Output:
 ```
 Functions that call 'authenticate':
 ------------------------------------------------------------
+
+Distance 1:
   handleLogin (src/auth/login.ts:45)
     > authenticate(username, password)
   validateSession (src/auth/session.ts:23)
@@ -310,10 +312,13 @@ Functions that call 'authenticate':
 ```
 
 Resolved callers are identity-based: ctx includes only `calls` edges resolved to the selected
-symbol ID. Potentially useful same-language name matches that could not be resolved are shown under
-`Unresolved same-language call evidence` (and as `unresolved_callers` in JSON). Verify that evidence
+symbol ID, then follows resolved callers breadth-first up to `--depth`. Cycles and diamonds are
+deduplicated by symbol ID at the shortest distance, and the root is excluded. `--file` selects only
+the root; callers in other files remain eligible. Potentially useful same-language name matches
+that could not be resolved are shown under `Unresolved same-language call evidence` (and as
+`unresolved_callers` in JSON) at distance 1 only and are never traversed. Verify that evidence
 against source; cross-language matches, qualified calls without matching qualified context, and
-edges resolved to another same-named symbol are excluded.
+edges resolved to another same-named symbol are excluded. JSON entries include numeric `distance`.
 
 ### Dependencies (What Does This Call?)
 
@@ -328,11 +333,19 @@ Output:
 ```
 Dependencies of 'handleRequest':
 ------------------------------------------------------------
+
+Distance 1:
   calls validateInput (line 12)
   calls processData (line 18)
   calls sendResponse (line 25)
   imports Logger (line 3)
 ```
+
+Dependency traversal follows resolved targets breadth-first across all outgoing relationship kinds
+up to `--depth`. Direct edge kinds are preserved, unresolved references remain visible leaves, and
+resolved symbols are deduplicated at their shortest distance with the root excluded. `--file` and
+`--kind` select only the root. Human output groups results by distance; JSON entries include numeric
+`distance`.
 
 ### Call Graph
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -164,7 +164,7 @@ Exit codes: running without `--keyword` when no embeddings have been generated i
 
 ### `query.callers`
 
-`ctx query callers <FUNCTION> [--file F] --json`
+`ctx query callers <FUNCTION> [--depth N] [--file F] --json`
 
 ```json
 {
@@ -173,25 +173,29 @@ Exit codes: running without `--keyword` when no embeddings have been generated i
     {
       "symbol": { "name": "run_search", "qualified_name": null, "kind": "function", "file": "src/commands/search.rs", "line_start": 14, "line_end": 41 },
       "line": 16,
-      "context": "index::open_database(&root)?"
+      "context": "index::open_database(&root)?",
+      "distance": 1
     }
   ],
   "unresolved_callers": [
     {
       "symbol": { "name": "retry_open", "qualified_name": null, "kind": "function", "file": "src/retry.rs", "line_start": 20, "line_end": 27 },
       "line": 22,
-      "context": "open_database(path)?"
+      "context": "open_database(path)?",
+      "distance": 1
     }
   ],
   "ambiguous": []
 }
 ```
 
-`callers` contains only resolved `calls` edges whose target ID is the selected symbol. It never
-contains an edge resolved to another same-named symbol. `unresolved_callers` preserves conservative
-name-based evidence separately: the source must use the target's language, and qualified symbols
-require matching qualified call context. Treat these entries as leads to verify in source, not as
-resolved relationships.
+`callers` traverses only resolved `calls` edges whose target ID matches the symbol at the preceding
+distance. Results are deduplicated by symbol ID at their shortest distance, exclude the root, and
+are ordered by distance, file, line, name, and ID. The `--file` filter disambiguates only the root;
+it does not hide callers in other files. `unresolved_callers` preserves conservative name-based
+evidence from the root at distance 1 only: the source must use the target's language, and qualified
+symbols require matching qualified call context. Unresolved evidence is never recursively
+traversed. Treat these entries as leads to verify in source, not as resolved relationships.
 
 Disambiguation: when several symbols match the name and no `--file` filter is given, `target` is
 `null`, `callers` and `unresolved_callers` are empty, and `ambiguous` lists the candidate
@@ -199,7 +203,7 @@ SymbolRefs. When the symbol is not found at all, all three arrays are empty and 
 
 ### `query.deps`
 
-`ctx query deps <SYMBOL> [--file F] [--kind K] --json`
+`ctx query deps <SYMBOL> [--depth N] [--file F] [--kind K] --json`
 
 ```json
 {
@@ -209,14 +213,19 @@ SymbolRefs. When the symbol is not found at all, all three arrays are empty and 
       "kind": "calls",
       "target_name": "open_database",
       "line": 16,
-      "resolved": { "name": "open_database", "qualified_name": null, "kind": "function", "file": "src/index/mod.rs", "line_start": 637, "line_end": 652 }
+      "resolved": { "name": "open_database", "qualified_name": null, "kind": "function", "file": "src/index/mod.rs", "line_start": 637, "line_end": 652 },
+      "distance": 1
     }
   ],
   "ambiguous": []
 }
 ```
 
-`resolved` is `null` for unresolved (e.g. external) references. Ambiguity is reported like `query.callers`.
+Resolved targets are traversed breadth-first through every outgoing relationship kind. Results are
+deduplicated by symbol ID at their shortest distance, exclude the root, and retain the relationship
+kind that reached each target. `resolved` is `null` for unresolved (for example, external)
+references; those entries remain visible leaves and are never traversed. The `--file` and `--kind`
+filters disambiguate only the root. Ambiguity is reported like `query.callers`.
 
 ### `query.graph`
 

--- a/docs/website/docs/code-intelligence.md
+++ b/docs/website/docs/code-intelligence.md
@@ -323,6 +323,8 @@ Output:
 ```
 Functions that call 'authenticate':
 ------------------------------------------------------------
+
+Distance 1:
   handleLogin (src/auth/login.ts:45)
     > authenticate(username, password)
   validateSession (src/auth/session.ts:23)
@@ -332,10 +334,13 @@ Functions that call 'authenticate':
 ```
 
 Resolved callers are identity-based: ctx includes only `calls` edges resolved to the selected
-symbol ID. Potentially useful same-language name matches that could not be resolved are shown under
-`Unresolved same-language call evidence` (and as `unresolved_callers` in JSON). Verify that evidence
+symbol ID, then follows resolved callers breadth-first up to `--depth`. Cycles and diamonds are
+deduplicated by symbol ID at the shortest distance, and the root is excluded. `--file` selects only
+the root; callers in other files remain eligible. Potentially useful same-language name matches
+that could not be resolved are shown under `Unresolved same-language call evidence` (and as
+`unresolved_callers` in JSON) at distance 1 only and are never traversed. Verify that evidence
 against source; cross-language matches, qualified calls without matching qualified context, and
-edges resolved to another same-named symbol are excluded.
+edges resolved to another same-named symbol are excluded. JSON entries include numeric `distance`.
 
 ### Dependencies (What Does This Call?)
 
@@ -350,11 +355,19 @@ Output:
 ```
 Dependencies of 'handleRequest':
 ------------------------------------------------------------
+
+Distance 1:
   calls validateInput (line 12)
   calls processData (line 18)
   calls sendResponse (line 25)
   imports Logger (line 3)
 ```
+
+Dependency traversal follows resolved targets breadth-first across all outgoing relationship kinds
+up to `--depth`. Direct edge kinds are preserved, unresolved references remain visible leaves, and
+resolved symbols are deduplicated at their shortest distance with the root excluded. `--file` and
+`--kind` select only the root. Human output groups results by distance; JSON entries include numeric
+`distance`.
 
 ### Call Graph
 

--- a/docs/website/docs/cookbook/blast-radius.md
+++ b/docs/website/docs/cookbook/blast-radius.md
@@ -115,10 +115,14 @@ unrelated functions. Use deep impact as a list of hypotheses, not a transitive p
 a branch when its source does not contain the preceding call.
 :::
 
-In ctx 0.3.5, the `--depth` option accepted by `query callers` and `query deps` is not applied; both
-commands return direct relationships. Use `query impact` or `query graph` for recursive traversal,
-with the source-verification rule above. Current impact and graph JSON also report zero source-line
-positions for traversed nodes, so use the returned file and name to retrieve source.
+The ctx 0.3.5 limitation where `query callers` and `query deps` ignored `--depth` has been resolved.
+Both commands now traverse resolved symbol IDs breadth-first, report shortest numeric distances,
+and stop safely at cycles; unresolved relationships remain non-recursive evidence leaves. Root
+filters such as `--file` disambiguate the starting symbol only, so transitive results can cross file
+boundaries. Continue verifying every reported step against source: resolution precision, rather
+than traversal depth, remains the limiting factor. `query impact` and `query graph` remain useful
+alternative projections; their JSON reports zero source-line positions for traversed nodes, so use
+the returned file and name to retrieve source.
 
 ## 4. Search exact references and persisted names
 

--- a/docs/website/docs/cookbook/debug-failing-test.md
+++ b/docs/website/docs/cookbook/debug-failing-test.md
@@ -122,8 +122,12 @@ second file to be omitted when the running total was 100 and the budget was 300.
 one. That was useful confirmation, but recursive expansion added nothing. A small direct path is a
 reason to stop, not a reason to request a deeper graph.
 
-In ctx 0.3.5, `--depth` on `query deps` and `query callers` is accepted but does not expand beyond
-direct relationships. Use impact or graph when recursion is actually needed.
+The ctx 0.3.5 limitation where `--depth` did not expand `query deps` and `query callers` has been
+resolved. These commands now traverse resolved symbol IDs breadth-first and expose shortest
+distances, while unresolved references remain leaves. Keep the requested depth proportional to the
+hypothesis, and verify each transitive step in source; a working traversal does not make every
+resolved edge conclusive. Use impact or graph when their alternate projection better fits the
+investigation.
 :::
 
 ## 4. Compare neighboring behavior

--- a/docs/website/docs/json-output.md
+++ b/docs/website/docs/json-output.md
@@ -141,7 +141,7 @@ If no embeddings have been generated yet, `results` is empty and a hint is print
 
 ### `query.callers`
 
-`ctx query callers <FUNCTION> [--file F] --json`
+`ctx query callers <FUNCTION> [--depth N] [--file F] --json`
 
 ```json
 {
@@ -150,25 +150,29 @@ If no embeddings have been generated yet, `results` is empty and a hint is print
     {
       "symbol": { "name": "run_search", "qualified_name": null, "kind": "function", "file": "src/commands/search.rs", "line_start": 14, "line_end": 41 },
       "line": 16,
-      "context": "index::open_database(&root)?"
+      "context": "index::open_database(&root)?",
+      "distance": 1
     }
   ],
   "unresolved_callers": [
     {
       "symbol": { "name": "retry_open", "qualified_name": null, "kind": "function", "file": "src/retry.rs", "line_start": 20, "line_end": 27 },
       "line": 22,
-      "context": "open_database(path)?"
+      "context": "open_database(path)?",
+      "distance": 1
     }
   ],
   "ambiguous": []
 }
 ```
 
-`callers` contains only resolved `calls` edges whose target ID is the selected symbol. It never
-contains an edge resolved to another same-named symbol. `unresolved_callers` preserves conservative
-name-based evidence separately: the source must use the target's language, and qualified symbols
-require matching qualified call context. Treat these entries as leads to verify in source, not as
-resolved relationships.
+`callers` traverses only resolved `calls` edges whose target ID matches the symbol at the preceding
+distance. Results are deduplicated by symbol ID at their shortest distance, exclude the root, and
+are ordered by distance, file, line, name, and ID. The `--file` filter disambiguates only the root;
+it does not hide callers in other files. `unresolved_callers` preserves conservative name-based
+evidence from the root at distance 1 only: the source must use the target's language, and qualified
+symbols require matching qualified call context. Unresolved evidence is never recursively
+traversed. Treat these entries as leads to verify in source, not as resolved relationships.
 
 Disambiguation: when several symbols match the name and no `--file` filter is given, `target` is
 `null`, `callers` and `unresolved_callers` are empty, and `ambiguous` lists the candidate
@@ -176,7 +180,7 @@ SymbolRefs. When the symbol is not found at all, all three arrays are empty and 
 
 ### `query.deps`
 
-`ctx query deps <SYMBOL> [--file F] [--kind K] --json`
+`ctx query deps <SYMBOL> [--depth N] [--file F] [--kind K] --json`
 
 ```json
 {
@@ -186,14 +190,19 @@ SymbolRefs. When the symbol is not found at all, all three arrays are empty and 
       "kind": "calls",
       "target_name": "open_database",
       "line": 16,
-      "resolved": { "name": "open_database", "qualified_name": null, "kind": "function", "file": "src/index/mod.rs", "line_start": 637, "line_end": 652 }
+      "resolved": { "name": "open_database", "qualified_name": null, "kind": "function", "file": "src/index/mod.rs", "line_start": 637, "line_end": 652 },
+      "distance": 1
     }
   ],
   "ambiguous": []
 }
 ```
 
-`resolved` is `null` for unresolved (e.g. external) references. Ambiguity is reported like `query.callers`.
+Resolved targets are traversed breadth-first through every outgoing relationship kind. Results are
+deduplicated by symbol ID at their shortest distance, exclude the root, and retain the relationship
+kind that reached each target. `resolved` is `null` for unresolved (for example, external)
+references; those entries remain visible leaves and are never traversed. The `--file` and `--kind`
+filters disambiguate only the root. Ambiguity is reported like `query.callers`.
 
 ### `query.graph`
 

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -2,6 +2,7 @@
 //!
 //! Handles codebase queries: find symbols, callers, dependencies, graph traversal.
 
+use std::collections::{HashSet, VecDeque};
 use std::env;
 
 use crate::cli::QueryCommand;
@@ -87,6 +88,7 @@ struct CallerEntry {
     symbol: db::Symbol,
     line: Option<u32>,
     context: Option<String>,
+    distance: u32,
 }
 
 /// Result of looking up the callers of a symbol.
@@ -130,12 +132,16 @@ fn unresolved_context_matches(target: &db::Symbol, context: Option<&str>) -> boo
 
 fn sort_caller_entries(entries: &mut [CallerEntry]) {
     entries.sort_by(|left, right| {
-        left.symbol
-            .file_path
-            .cmp(&right.symbol.file_path)
-            .then_with(|| left.symbol.line_start.cmp(&right.symbol.line_start))
+        left.distance
+            .cmp(&right.distance)
+            .then_with(|| left.symbol.file_path.cmp(&right.symbol.file_path))
+            .then_with(|| {
+                left.line
+                    .unwrap_or(left.symbol.line_start)
+                    .cmp(&right.line.unwrap_or(right.symbol.line_start))
+            })
+            .then_with(|| left.symbol.name.cmp(&right.symbol.name))
             .then_with(|| left.symbol.id.cmp(&right.symbol.id))
-            .then_with(|| left.line.cmp(&right.line))
             .then_with(|| left.context.cmp(&right.context))
     });
 }
@@ -145,6 +151,7 @@ fn collect_callers(
     db: &db::Database,
     function: &str,
     file_pattern: Option<&str>,
+    depth: i32,
 ) -> Result<CallersOutcome> {
     // First, find the symbol(s) matching the function name with optional file filter
     let symbols = db.find_symbols_filtered(function, 100, file_pattern, None)?;
@@ -160,19 +167,41 @@ fn collect_callers(
 
     let sym = &symbols[0];
 
-    // Ordinary caller results are identity-based: only resolved call edges to
-    // the selected symbol may appear here.
+    // Traverse resolved call edges breadth-first. Identity-based visitation
+    // makes cycles safe and keeps the shortest distance through diamonds.
     let mut callers = Vec::new();
-    for edge in db.get_incoming_edges(&sym.id)? {
-        if edge.kind != db::EdgeKind::Calls || edge.target_id.as_deref() != Some(sym.id.as_str()) {
+    let mut visited = HashSet::from([sym.id.clone()]);
+    let mut queue = VecDeque::from([(sym.id.clone(), 0_u32)]);
+    let max_depth = u32::try_from(depth).unwrap_or(0);
+
+    while let Some((target_id, parent_distance)) = queue.pop_front() {
+        if parent_distance >= max_depth {
             continue;
         }
-        if let Some(s) = db.get_symbol(&edge.source_id)? {
-            callers.push(CallerEntry {
-                symbol: s,
-                line: edge.line,
-                context: edge.context,
-            });
+        let distance = parent_distance + 1;
+        let mut edges = db.get_incoming_edges(&target_id)?;
+        edges.sort_by(|left, right| {
+            left.source_id
+                .cmp(&right.source_id)
+                .then_with(|| left.line.cmp(&right.line))
+                .then_with(|| left.context.cmp(&right.context))
+        });
+        for edge in edges {
+            if edge.kind != db::EdgeKind::Calls
+                || edge.target_id.as_deref() != Some(target_id.as_str())
+                || !visited.insert(edge.source_id.clone())
+            {
+                continue;
+            }
+            if let Some(source) = db.get_symbol(&edge.source_id)? {
+                queue.push_back((source.id.clone(), distance));
+                callers.push(CallerEntry {
+                    symbol: source,
+                    line: edge.line,
+                    context: edge.context,
+                    distance,
+                });
+            }
         }
     }
     sort_caller_entries(&mut callers);
@@ -181,12 +210,21 @@ fn collect_callers(
     // Cross-language edges and edges resolved to any symbol are excluded.
     let target_language = db.get_file_language(&sym.file_path)?;
     let mut unresolved_callers = Vec::new();
-    if target_language.is_some() {
-        for edge in db.get_incoming_edges(&sym.name)? {
+    let mut unresolved_sources = HashSet::new();
+    if max_depth > 0 && target_language.is_some() {
+        let mut edges = db.get_incoming_edges(&sym.name)?;
+        edges.sort_by(|left, right| {
+            left.source_id
+                .cmp(&right.source_id)
+                .then_with(|| left.line.cmp(&right.line))
+                .then_with(|| left.context.cmp(&right.context))
+        });
+        for edge in edges {
             if edge.kind != db::EdgeKind::Calls
                 || edge.target_id.is_some()
                 || edge.target_name != sym.name
                 || !unresolved_context_matches(sym, edge.context.as_deref())
+                || !unresolved_sources.insert(edge.source_id.clone())
             {
                 continue;
             }
@@ -198,6 +236,7 @@ fn collect_callers(
                     symbol: source,
                     line: edge.line,
                     context: edge.context,
+                    distance: 1,
                 });
             }
         }
@@ -238,6 +277,7 @@ fn callers_data(outcome: &CallersOutcome) -> serde_json::Value {
                     "symbol": SymbolRef::from(&c.symbol),
                     "line": c.line,
                     "context": c.context,
+                    "distance": c.distance,
                 }))
                 .collect::<Vec<_>>(),
             "unresolved_callers": unresolved_callers
@@ -246,6 +286,7 @@ fn callers_data(outcome: &CallersOutcome) -> serde_json::Value {
                     "symbol": SymbolRef::from(&c.symbol),
                     "line": c.line,
                     "context": c.context,
+                    "distance": c.distance,
                 }))
                 .collect::<Vec<_>>(),
             "ambiguous": [],
@@ -258,9 +299,10 @@ fn query_callers(
     db: &db::Database,
     function: &str,
     file_pattern: Option<&str>,
+    depth: i32,
     json: bool,
 ) -> Result<()> {
-    let outcome = collect_callers(db, function, file_pattern)?;
+    let outcome = collect_callers(db, function, file_pattern, depth)?;
 
     if json {
         return ctx::json::emit("query.callers", callers_data(&outcome));
@@ -304,7 +346,12 @@ fn query_callers(
                 );
                 println!("{}", "-".repeat(60));
 
+                let mut current_distance = 0;
                 for entry in callers {
+                    if entry.distance != current_distance {
+                        current_distance = entry.distance;
+                        println!("\nDistance {}:", current_distance);
+                    }
                     println!(
                         "  {} ({}:{})",
                         entry.symbol.name,
@@ -325,6 +372,7 @@ fn query_callers(
             if !unresolved_callers.is_empty() {
                 println!("\nUnresolved same-language call evidence:");
                 println!("{}", "-".repeat(60));
+                println!("\nDistance 1:");
                 for entry in unresolved_callers {
                     println!(
                         "  {} ({}:{})",
@@ -348,9 +396,56 @@ enum DepsOutcome {
     Ambiguous(Vec<db::Symbol>),
     Found {
         target: Box<db::Symbol>,
-        /// Outgoing edges with the resolved target symbol (if any).
-        deps: Vec<(db::Edge, Option<db::Symbol>)>,
+        deps: Vec<DependencyEntry>,
     },
+}
+
+/// One outgoing dependency reached during breadth-first traversal.
+struct DependencyEntry {
+    edge: db::Edge,
+    resolved: Option<db::Symbol>,
+    source_file: String,
+    distance: u32,
+}
+
+fn sort_dependency_entries(entries: &mut [DependencyEntry]) {
+    entries.sort_by(|left, right| {
+        let left_file = left
+            .resolved
+            .as_ref()
+            .map_or(left.source_file.as_str(), |symbol| {
+                symbol.file_path.as_str()
+            });
+        let right_file = right
+            .resolved
+            .as_ref()
+            .map_or(right.source_file.as_str(), |symbol| {
+                symbol.file_path.as_str()
+            });
+        let left_name = left
+            .resolved
+            .as_ref()
+            .map_or(left.edge.target_name.as_str(), |symbol| {
+                symbol.name.as_str()
+            });
+        let right_name = right
+            .resolved
+            .as_ref()
+            .map_or(right.edge.target_name.as_str(), |symbol| {
+                symbol.name.as_str()
+            });
+        let left_id = left.edge.target_id.as_deref().unwrap_or("");
+        let right_id = right.edge.target_id.as_deref().unwrap_or("");
+
+        left.distance
+            .cmp(&right.distance)
+            .then_with(|| left_file.cmp(right_file))
+            .then_with(|| left.edge.line.cmp(&right.edge.line))
+            .then_with(|| left_name.cmp(right_name))
+            .then_with(|| left_id.cmp(right_id))
+            .then_with(|| left.edge.kind.as_str().cmp(right.edge.kind.as_str()))
+            .then_with(|| left.edge.context.cmp(&right.edge.context))
+    });
 }
 
 /// Look up the dependencies of `symbol`, without printing anything.
@@ -359,6 +454,7 @@ fn collect_deps(
     symbol: &str,
     file_pattern: Option<&str>,
     kind_filter: Option<&str>,
+    depth: i32,
 ) -> Result<DepsOutcome> {
     let symbols = db.find_symbols_filtered(symbol, 100, file_pattern, kind_filter)?;
 
@@ -371,16 +467,54 @@ fn collect_deps(
     }
 
     let sym = symbols.into_iter().next().expect("checked non-empty");
-    let edges = db.get_outgoing_edges(&sym.id)?;
-
     let mut deps = Vec::new();
-    for edge in edges {
-        let resolved = match &edge.target_id {
-            Some(id) => db.get_symbol(id)?,
-            None => None,
-        };
-        deps.push((edge, resolved));
+    let max_depth = u32::try_from(depth).unwrap_or(0);
+    let mut visited = HashSet::from([sym.id.clone()]);
+    let mut queue = VecDeque::from([(sym.clone(), 0_u32)]);
+
+    while let Some((source, parent_distance)) = queue.pop_front() {
+        if parent_distance >= max_depth {
+            continue;
+        }
+        let distance = parent_distance + 1;
+        let mut edges = db.get_outgoing_edges(&source.id)?;
+        edges.sort_by(|left, right| {
+            left.line
+                .cmp(&right.line)
+                .then_with(|| left.target_name.cmp(&right.target_name))
+                .then_with(|| left.target_id.cmp(&right.target_id))
+                .then_with(|| left.kind.as_str().cmp(right.kind.as_str()))
+        });
+        for edge in edges {
+            let resolved = match &edge.target_id {
+                Some(id) => db.get_symbol(id)?,
+                None => None,
+            };
+
+            if let Some(target) = resolved {
+                if !visited.insert(target.id.clone()) {
+                    continue;
+                }
+                queue.push_back((target.clone(), distance));
+                deps.push(DependencyEntry {
+                    edge,
+                    resolved: Some(target),
+                    source_file: source.file_path.clone(),
+                    distance,
+                });
+            } else {
+                // Unresolved relationships are useful evidence but cannot be
+                // traversed safely, so they are always leaves.
+                deps.push(DependencyEntry {
+                    edge,
+                    resolved: None,
+                    source_file: source.file_path.clone(),
+                    distance,
+                });
+            }
+        }
     }
+    sort_dependency_entries(&mut deps);
 
     Ok(DepsOutcome::Found {
         target: Box::new(sym),
@@ -405,11 +539,12 @@ fn deps_data(outcome: &DepsOutcome) -> serde_json::Value {
             "target": SymbolRef::from(target.as_ref()),
             "dependencies": deps
                 .iter()
-                .map(|(edge, resolved)| serde_json::json!({
-                    "kind": edge.kind.as_str(),
-                    "target_name": edge.target_name,
-                    "line": edge.line,
-                    "resolved": resolved.as_ref().map(SymbolRef::from),
+                .map(|entry| serde_json::json!({
+                    "kind": entry.edge.kind.as_str(),
+                    "target_name": entry.edge.target_name,
+                    "line": entry.edge.line,
+                    "resolved": entry.resolved.as_ref().map(SymbolRef::from),
+                    "distance": entry.distance,
                 }))
                 .collect::<Vec<_>>(),
             "ambiguous": [],
@@ -423,9 +558,10 @@ fn query_deps(
     symbol: &str,
     file_pattern: Option<&str>,
     kind_filter: Option<&str>,
+    depth: i32,
     json: bool,
 ) -> Result<()> {
-    let outcome = collect_deps(db, symbol, file_pattern, kind_filter)?;
+    let outcome = collect_deps(db, symbol, file_pattern, kind_filter, depth)?;
 
     if json {
         return ctx::json::emit("query.deps", deps_data(&outcome));
@@ -464,12 +600,17 @@ fn query_deps(
             println!("Dependencies of '{}' ({}):", target.name, target.file_path);
             println!("{}", "-".repeat(60));
 
-            for (edge, _) in deps {
+            let mut current_distance = 0;
+            for entry in deps {
+                if entry.distance != current_distance {
+                    current_distance = entry.distance;
+                    println!("\nDistance {}:", current_distance);
+                }
                 println!(
                     "  {} {} (line {})",
-                    edge.kind.as_str(),
-                    edge.target_name,
-                    edge.line.unwrap_or(0)
+                    entry.edge.kind.as_str(),
+                    entry.edge.target_name,
+                    entry.edge.line.unwrap_or(0)
                 );
             }
         }
@@ -596,15 +737,15 @@ pub fn run_query(query: QueryCommand, json: bool) -> Result<()> {
         } => query_find(&db, &pattern, limit, kind, file, json),
         QueryCommand::Callers {
             function,
-            depth: _,
+            depth,
             file,
-        } => query_callers(&db, &function, file.as_deref(), json),
+        } => query_callers(&db, &function, file.as_deref(), depth, json),
         QueryCommand::Deps {
             symbol,
-            depth: _,
+            depth,
             file,
             kind,
-        } => query_deps(&db, &symbol, file.as_deref(), kind.as_deref(), json),
+        } => query_deps(&db, &symbol, file.as_deref(), kind.as_deref(), depth, json),
         QueryCommand::Graph {
             start,
             depth,
@@ -846,6 +987,90 @@ mod tests {
         db
     }
 
+    fn traversal_db(include_caller_cycle: bool) -> Database {
+        let db = Database::open_in_memory().unwrap();
+        let symbols = [
+            ("src/root.rs::root", "root", "src/root.rs", 1),
+            ("a/alpha.rs::alpha", "alpha", "a/alpha.rs", 20),
+            ("z/zed.rs::zed", "zed", "z/zed.rs", 30),
+            ("m/mid.rs::mid", "mid", "m/mid.rs", 10),
+            ("d/deep.rs::deep", "deep", "d/deep.rs", 40),
+            ("u/probe.rs::probe", "probe", "u/probe.rs", 50),
+            (
+                "u/indirect.rs::indirect_probe",
+                "indirect_probe",
+                "u/indirect.rs",
+                60,
+            ),
+            ("vendor/ext.rs::external", "external", "vendor/ext.rs", 1),
+            ("vendor/ghost.rs::ghost", "ghost", "vendor/ghost.rs", 1),
+        ];
+        for (_, _, file, _) in symbols {
+            db.upsert_file(
+                &FileRecord {
+                    path: file.to_string(),
+                    content_hash: format!("hash-{file}"),
+                    size_bytes: 1,
+                    language: Some("rust".to_string()),
+                    last_indexed: 0,
+                },
+                None,
+            )
+            .unwrap();
+        }
+        for (id, name, file, line) in symbols {
+            db.insert_symbol(&make_symbol(id, name, file, line))
+                .unwrap();
+        }
+
+        let resolved_call = |source: &str, target: &str, name: &str, line: u32| Edge {
+            source_id: source.to_string(),
+            target_id: Some(target.to_string()),
+            target_name: name.to_string(),
+            kind: EdgeKind::Calls,
+            line: Some(line),
+            col: None,
+            context: Some(format!("{name}()")),
+        };
+        for edge in [
+            // Insert reverse lexical order to exercise stable result sorting.
+            resolved_call("z/zed.rs::zed", "src/root.rs::root", "root", 31),
+            resolved_call("a/alpha.rs::alpha", "src/root.rs::root", "root", 21),
+            // Diamond: mid reaches the root through both direct callers.
+            resolved_call("m/mid.rs::mid", "z/zed.rs::zed", "zed", 12),
+            resolved_call("m/mid.rs::mid", "a/alpha.rs::alpha", "alpha", 11),
+            resolved_call("d/deep.rs::deep", "m/mid.rs::mid", "mid", 41),
+        ] {
+            db.insert_edge(&edge).unwrap();
+        }
+        if include_caller_cycle {
+            // Cycle back to the root; the root must never be emitted.
+            db.insert_edge(&resolved_call(
+                "src/root.rs::root",
+                "d/deep.rs::deep",
+                "deep",
+                3,
+            ))
+            .unwrap();
+        }
+        for (source, target, line) in [
+            ("u/probe.rs::probe", "root", 51),
+            ("u/indirect.rs::indirect_probe", "alpha", 61),
+        ] {
+            db.insert_edge(&Edge {
+                source_id: source.to_string(),
+                target_id: None,
+                target_name: target.to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(line),
+                col: None,
+                context: Some(format!("{target}()")),
+            })
+            .unwrap();
+        }
+        db
+    }
+
     #[test]
     fn test_find_data_payload() {
         let db = seeded_db();
@@ -875,7 +1100,7 @@ mod tests {
     #[test]
     fn test_callers_data_found() {
         let db = seeded_db();
-        let outcome = collect_callers(&db, "targetfn", None).unwrap();
+        let outcome = collect_callers(&db, "targetfn", None, 3).unwrap();
         let data = callers_data(&outcome);
 
         assert_eq!(data["target"]["name"], "targetfn");
@@ -886,13 +1111,53 @@ mod tests {
         assert_eq!(callers[0]["symbol"]["name"], "callerfn");
         assert_eq!(callers[0]["line"], 12);
         assert_eq!(callers[0]["context"], "targetfn()");
+        assert_eq!(callers[0]["distance"], 1);
         assert_eq!(data["unresolved_callers"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_callers_bfs_depth_cycle_diamond_and_unresolved_root_only() {
+        let db = traversal_db(true);
+
+        let depth_one = callers_data(&collect_callers(&db, "root", None, 1).unwrap());
+        let callers = depth_one["callers"].as_array().unwrap();
+        assert_eq!(callers.len(), 2);
+        assert_eq!(callers[0]["symbol"]["name"], "alpha");
+        assert_eq!(callers[1]["symbol"]["name"], "zed");
+        assert!(callers.iter().all(|entry| entry["distance"] == 1));
+        let unresolved = depth_one["unresolved_callers"].as_array().unwrap();
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0]["symbol"]["name"], "probe");
+        assert_eq!(unresolved[0]["distance"], 1);
+
+        let depth_three = callers_data(&collect_callers(&db, "root", None, 3).unwrap());
+        let callers = depth_three["callers"].as_array().unwrap();
+        let names_and_distances = callers
+            .iter()
+            .map(|entry| {
+                (
+                    entry["symbol"]["name"].as_str().unwrap(),
+                    entry["distance"].as_u64().unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names_and_distances,
+            vec![("alpha", 1), ("zed", 1), ("mid", 2), ("deep", 3)]
+        );
+        assert!(!serde_json::to_string(&depth_three)
+            .unwrap()
+            .contains("indirect_probe"));
+
+        let depth_zero = callers_data(&collect_callers(&db, "root", None, 0).unwrap());
+        assert_eq!(depth_zero["callers"], serde_json::json!([]));
+        assert_eq!(depth_zero["unresolved_callers"], serde_json::json!([]));
     }
 
     #[test]
     fn test_callers_data_not_found() {
         let db = seeded_db();
-        let outcome = collect_callers(&db, "missingfn", None).unwrap();
+        let outcome = collect_callers(&db, "missingfn", None, 3).unwrap();
         let data = callers_data(&outcome);
 
         assert!(data["target"].is_null());
@@ -924,7 +1189,7 @@ mod tests {
         ))
         .unwrap();
 
-        let outcome = collect_callers(&db, "targetfn", None).unwrap();
+        let outcome = collect_callers(&db, "targetfn", None, 3).unwrap();
         let data = callers_data(&outcome);
 
         assert!(data["target"].is_null());
@@ -1037,7 +1302,7 @@ mod tests {
             db.insert_edge(&edge).unwrap();
         }
 
-        let outcome = collect_callers(&db, "targetfn", Some("src/x.rs")).unwrap();
+        let outcome = collect_callers(&db, "targetfn", Some("src/x.rs"), 3).unwrap();
         let data = callers_data(&outcome);
 
         let callers = data["callers"].as_array().unwrap();
@@ -1071,7 +1336,7 @@ mod tests {
             .unwrap();
         }
 
-        let outcome = collect_callers(&db, "run", Some("src/x.rs")).unwrap();
+        let outcome = collect_callers(&db, "run", Some("src/x.rs"), 3).unwrap();
         let data = callers_data(&outcome);
         assert_eq!(data["callers"], serde_json::json!([]));
         let unresolved = data["unresolved_callers"].as_array().unwrap();
@@ -1083,7 +1348,7 @@ mod tests {
     #[test]
     fn test_deps_data_found() {
         let db = seeded_db();
-        let outcome = collect_deps(&db, "callerfn", None, None).unwrap();
+        let outcome = collect_deps(&db, "callerfn", None, None, 3).unwrap();
         let data = deps_data(&outcome);
 
         assert_eq!(data["target"]["name"], "callerfn");
@@ -1094,6 +1359,114 @@ mod tests {
         assert_eq!(deps[0]["line"], 12);
         assert_eq!(deps[0]["resolved"]["name"], "targetfn");
         assert_eq!(deps[0]["resolved"]["file"], "src/x.rs");
+        assert_eq!(deps[0]["distance"], 1);
+    }
+
+    #[test]
+    fn test_deps_bfs_depth_cycle_diamond_kinds_and_unresolved_leaves() {
+        let db = traversal_db(false);
+        for edge in [
+            Edge {
+                source_id: "src/root.rs::root".to_string(),
+                target_id: Some("a/alpha.rs::alpha".to_string()),
+                target_name: "alpha".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(70),
+                col: None,
+                context: None,
+            },
+            Edge {
+                source_id: "src/root.rs::root".to_string(),
+                target_id: Some("z/zed.rs::zed".to_string()),
+                target_name: "zed".to_string(),
+                kind: EdgeKind::Uses,
+                line: Some(71),
+                col: None,
+                context: None,
+            },
+            Edge {
+                source_id: "src/root.rs::root".to_string(),
+                target_id: None,
+                target_name: "external".to_string(),
+                kind: EdgeKind::Imports,
+                line: Some(72),
+                col: None,
+                context: None,
+            },
+            Edge {
+                source_id: "a/alpha.rs::alpha".to_string(),
+                target_id: Some("m/mid.rs::mid".to_string()),
+                target_name: "mid".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(22),
+                col: None,
+                context: None,
+            },
+            Edge {
+                source_id: "z/zed.rs::zed".to_string(),
+                target_id: Some("m/mid.rs::mid".to_string()),
+                target_name: "mid".to_string(),
+                kind: EdgeKind::Uses,
+                line: Some(32),
+                col: None,
+                context: None,
+            },
+            Edge {
+                source_id: "m/mid.rs::mid".to_string(),
+                target_id: Some("d/deep.rs::deep".to_string()),
+                target_name: "deep".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(13),
+                col: None,
+                context: None,
+            },
+            Edge {
+                source_id: "d/deep.rs::deep".to_string(),
+                target_id: Some("src/root.rs::root".to_string()),
+                target_name: "root".to_string(),
+                kind: EdgeKind::Calls,
+                line: Some(42),
+                col: None,
+                context: None,
+            },
+            Edge {
+                source_id: "vendor/ext.rs::external".to_string(),
+                target_id: Some("vendor/ghost.rs::ghost".to_string()),
+                target_name: "ghost".to_string(),
+                kind: EdgeKind::Uses,
+                line: Some(2),
+                col: None,
+                context: None,
+            },
+        ] {
+            db.insert_edge(&edge).unwrap();
+        }
+
+        let depth_one = deps_data(&collect_deps(&db, "root", None, None, 1).unwrap());
+        let deps = depth_one["dependencies"].as_array().unwrap();
+        assert_eq!(deps.len(), 3);
+        assert_eq!(deps[0]["target_name"], "alpha");
+        assert_eq!(deps[0]["kind"], "calls");
+        assert_eq!(deps[1]["target_name"], "external");
+        assert!(deps[1]["resolved"].is_null());
+        assert_eq!(deps[2]["target_name"], "zed");
+        assert_eq!(deps[2]["kind"], "uses");
+        assert!(deps.iter().all(|entry| entry["distance"] == 1));
+
+        let depth_three = deps_data(&collect_deps(&db, "root", None, None, 3).unwrap());
+        let serialized = serde_json::to_string(&depth_three).unwrap();
+        let deps = depth_three["dependencies"].as_array().unwrap();
+        assert_eq!(
+            deps.iter()
+                .filter(|entry| entry["target_name"] == "mid")
+                .count(),
+            1
+        );
+        assert!(deps
+            .iter()
+            .any(|entry| entry["target_name"] == "deep" && entry["distance"] == 3));
+        assert!(!serialized.contains("ghost"));
+        assert!(!deps.iter().any(|entry| entry["resolved"]["name"] == "root"));
     }
 
     #[test]

--- a/tests/query_callers_cli.rs
+++ b/tests/query_callers_cli.rs
@@ -91,9 +91,12 @@ fn callers_are_resolved_to_the_selected_id_and_unresolved_evidence_is_separate()
     assert_eq!(data["target"]["file"], "src/main.rs");
 
     let callers = data["callers"].as_array().expect("callers array");
-    assert_eq!(callers.len(), 1);
+    assert_eq!(callers.len(), 2);
     assert_eq!(callers[0]["symbol"]["name"], "run_main");
     assert_eq!(callers[0]["symbol"]["file"], "src/main.rs");
+    assert_eq!(callers[0]["distance"], 1);
+    assert_eq!(callers[1]["symbol"]["name"], "main");
+    assert_eq!(callers[1]["distance"], 2);
 
     let unresolved = data["unresolved_callers"]
         .as_array()
@@ -101,9 +104,102 @@ fn callers_are_resolved_to_the_selected_id_and_unresolved_evidence_is_separate()
     assert_eq!(unresolved.len(), 1);
     assert_eq!(unresolved[0]["symbol"]["name"], "rust_probe");
     assert_eq!(unresolved[0]["symbol"]["file"], "src/unresolved.rs");
+    assert_eq!(unresolved[0]["distance"], 1);
 
     let serialized = serde_json::to_string(data).unwrap();
     assert!(!serialized.contains("python_probe"));
     assert!(!serialized.contains("calls_other_run"));
     assert!(!serialized.contains("subprocess.run"));
+}
+
+#[test]
+fn callers_and_deps_honor_requested_depth() {
+    let temp = indexed_mixed_language_fixture();
+
+    let query = |args: &[&str]| {
+        let output = Command::cargo_bin("ctx")
+            .unwrap()
+            .current_dir(temp.path())
+            .args(args)
+            .output()
+            .expect("query JSON");
+        assert!(
+            output.status.success(),
+            "query failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let envelope: Value = serde_json::from_slice(&output.stdout).expect("valid JSON envelope");
+        envelope["data"].clone()
+    };
+
+    let callers_one = query(&[
+        "--json",
+        "query",
+        "callers",
+        "run",
+        "--file",
+        "src/main.rs",
+        "--depth",
+        "1",
+    ]);
+    assert_eq!(callers_one["callers"].as_array().unwrap().len(), 1);
+    assert_eq!(callers_one["callers"][0]["distance"], 1);
+
+    let callers_three = query(&[
+        "--json",
+        "query",
+        "callers",
+        "run",
+        "--file",
+        "src/main.rs",
+        "--depth",
+        "3",
+    ]);
+    assert_eq!(callers_three["callers"].as_array().unwrap().len(), 2);
+    assert_eq!(callers_three["callers"][1]["distance"], 2);
+
+    let deps_one = query(&[
+        "--json",
+        "query",
+        "deps",
+        "main",
+        "--file",
+        "src/main.rs",
+        "--depth",
+        "1",
+    ]);
+    assert_eq!(deps_one["dependencies"].as_array().unwrap().len(), 1);
+    assert_eq!(deps_one["dependencies"][0]["target_name"], "run_main");
+    assert_eq!(deps_one["dependencies"][0]["distance"], 1);
+
+    let deps_three = query(&[
+        "--json",
+        "query",
+        "deps",
+        "main",
+        "--file",
+        "src/main.rs",
+        "--depth",
+        "3",
+    ]);
+    assert_eq!(deps_three["dependencies"].as_array().unwrap().len(), 2);
+    assert_eq!(deps_three["dependencies"][1]["target_name"], "run");
+    assert_eq!(deps_three["dependencies"][1]["distance"], 2);
+
+    Command::cargo_bin("ctx")
+        .unwrap()
+        .current_dir(temp.path())
+        .args([
+            "query",
+            "callers",
+            "run",
+            "--file",
+            "src/main.rs",
+            "--depth",
+            "3",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Distance 1:"))
+        .stdout(predicates::str::contains("Distance 2:"));
 }


### PR DESCRIPTION
## Summary

- honor `--depth` for `query callers` and `query deps` with cycle-safe breadth-first traversal
- report shortest numeric `distance` while preserving direct relationship kinds
- keep unresolved caller evidence at distance 1 without traversing ambiguous names
- document traversal semantics and add chain, cycle, diamond, and CLI regression coverage

## Stack

This PR is stacked on #66 and targets `fix/61-caller-resolution`. Review #66 first; after it lands, this PR can be rebased or retargeted to `main`.

## Validation

- focused query unit and CLI tests
- `cargo test --locked --all-features`
- `cargo test --locked --no-default-features`
- `cargo fmt` and clippy with warnings denied
- governance, versioning, contract, and docs checks
- clean-tree `scripts/ci.sh`, including both package dry-runs

No version bump. The `contract-review` label is intentionally withheld pending manual review.

Closes #58
