### PR TITLE
fix: report impact source locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `ctx query impact --json` now reports indexed qualified names and source line ranges while
+  keeping same-named symbols distinct by identity (#63).
 - `ctx query callers` and `ctx query deps` now honor `--depth` with cycle-safe breadth-first
   traversal, shortest-distance identity deduplication, explicit JSON distances, and distance-grouped
   human output while keeping unresolved relationships as non-recursive evidence leaves (#58).

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -65,7 +65,11 @@ Wherever a symbol appears in a payload, it is a **SymbolRef object** (never a ba
 
 `qualified_name` is `null` when not known. Some commands attach extra fields alongside or inside a SymbolRef (e.g. `visibility` in `query.find`); additions are backwards-compatible, removals or renames are not.
 
-Note: `query.graph` and `query.impact` nodes come from graph traversal, which does not track line numbers; their SymbolRefs have `line_start`/`line_end` of `0` and `qualified_name` of `null`.
+Note: `query.graph` nodes come from graph traversal that does not carry source
+locations, so their SymbolRefs have `line_start`/`line_end` of `0` and
+`qualified_name` of `null`. `query.impact` nodes include the indexed qualified
+name and source range; legacy or malformed indexes can still report `0` for a
+missing bound.
 
 ## Commands
 
@@ -254,7 +258,7 @@ filters disambiguate only the root. Ambiguity is reported like `query.callers`.
   "depth": 5,
   "impacted": [
     {
-      "symbol": { "name": "run_search", "qualified_name": null, "kind": "function", "file": "src/commands/search.rs", "line_start": 0, "line_end": 0 },
+      "symbol": { "name": "run_search", "qualified_name": "commands::search::run_search", "kind": "function", "file": "src/commands/search.rs", "line_start": 14, "line_end": 41 },
       "distance": 1
     }
   ],

--- a/docs/website/docs/cookbook/blast-radius.md
+++ b/docs/website/docs/cookbook/blast-radius.md
@@ -121,8 +121,9 @@ and stop safely at cycles; unresolved relationships remain non-recursive evidenc
 filters such as `--file` disambiguate the starting symbol only, so transitive results can cross file
 boundaries. Continue verifying every reported step against source: resolution precision, rather
 than traversal depth, remains the limiting factor. `query impact` and `query graph` remain useful
-alternative projections; their JSON reports zero source-line positions for traversed nodes, so use
-the returned file and name to retrieve source.
+alternative projections. Impact JSON now includes each indexed symbol's qualified name and source
+range, which makes source verification direct; graph JSON still reports zero source-line positions,
+so use its returned file and name to retrieve source.
 
 ## 4. Search exact references and persisted names
 
@@ -256,7 +257,7 @@ real blast radius.
 |---|---|---|
 | Disambiguated source and explain | Established the target's actual semantics | Does not reveal persisted or external contracts |
 | Direct callers and dependencies | Identified the main behavioral branches and helpers | Missed closure and several test references |
-| `impact --depth 1` | Produced a useful first-layer checklist | JSON line positions were zero |
+| `impact --depth 1` | Produced a useful first-layer checklist with source locations | Graph edges still require source verification |
 | Deep impact | Surfaced possible transitive paths quickly | Generic names caused rapid false-positive expansion |
 | Exact repository search | Found lock writes, generated markers, tests, and docs | Text matches still need classification by role |
 | Similar implementation search | Distinguished specialized ownership hashing from index hashing | Similar mechanics were not interchangeable |

--- a/docs/website/docs/json-output.md
+++ b/docs/website/docs/json-output.md
@@ -71,7 +71,11 @@ Wherever a symbol appears in a payload, it is a **SymbolRef object** (never a ba
 
 `qualified_name` is `null` when not known. Some commands attach extra fields alongside or inside a SymbolRef (e.g. `visibility` in `query.find`); additions are backwards-compatible, removals or renames are not.
 
-Note: `query.graph` and `query.impact` nodes come from graph traversal, which does not track line numbers; their SymbolRefs have `line_start`/`line_end` of `0` and `qualified_name` of `null`.
+Note: `query.graph` nodes come from graph traversal that does not carry source
+locations, so their SymbolRefs have `line_start`/`line_end` of `0` and
+`qualified_name` of `null`. `query.impact` nodes include the indexed qualified
+name and source range; legacy or malformed indexes can still report `0` for a
+missing bound.
 
 ## Commands
 
@@ -231,7 +235,7 @@ filters disambiguate only the root. Ambiguity is reported like `query.callers`.
   "depth": 5,
   "impacted": [
     {
-      "symbol": { "name": "run_search", "qualified_name": null, "kind": "function", "file": "src/commands/search.rs", "line_start": 0, "line_end": 0 },
+      "symbol": { "name": "run_search", "qualified_name": "commands::search::run_search", "kind": "function", "file": "src/commands/search.rs", "line_start": 14, "line_end": 41 },
       "distance": 1
     }
   ],

--- a/src/analytics/duckdb_impl.rs
+++ b/src/analytics/duckdb_impl.rs
@@ -6,13 +6,14 @@
 //! - Module dependency analysis
 //! - Codebase statistics aggregations
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
 use duckdb::types::ValueRef;
 use duckdb::{params, Connection, InterruptHandle, Result};
 
-use super::{CallGraphNode, ComplexityResult, FileStats, ImpactNode};
+use super::{CallGraphNode, ComplexityResult, FileStats, ImpactNode, LocatedImpactNode};
 use crate::index::{CTX_DIR, DB_FILE};
 
 /// DuckDB analytics engine for code intelligence.
@@ -175,6 +176,32 @@ impl Analytics {
     /// - A qualified name like "LocalProvider::new"
     /// - A full ID like "src/embeddings/local.rs::LocalProvider::new@20"
     pub fn impact_analysis(&self, target_name: &str, max_depth: i32) -> Result<Vec<ImpactNode>> {
+        let mut seen = HashSet::new();
+        Ok(self
+            .impact_analysis_located(target_name, max_depth)?
+            .into_iter()
+            .filter(|node| {
+                seen.insert((node.name.clone(), node.file_path.clone(), node.kind.clone()))
+            })
+            .map(|node| ImpactNode {
+                name: node.name,
+                file_path: node.file_path,
+                kind: node.kind,
+                distance: node.distance,
+            })
+            .collect())
+    }
+
+    /// Impact analysis with stable symbol identities and indexed source locations.
+    ///
+    /// The `target_name` accepts the same ID, qualified-name, and simple-name forms
+    /// as [`Self::impact_analysis`]. Legacy indexes with missing line values report
+    /// `0` for the corresponding bound.
+    pub fn impact_analysis_located(
+        &self,
+        target_name: &str,
+        max_depth: i32,
+    ) -> Result<Vec<LocatedImpactNode>> {
         let mut stmt = self.conn.prepare(
             r#"
             WITH RECURSIVE target_symbol AS (
@@ -193,9 +220,13 @@ impl Analytics {
             impact AS (
                 -- Base case: find direct callers of the specific target symbol
                 SELECT 
+                    s.id,
                     s.name,
+                    s.qualified_name,
                     s.file_path,
                     s.kind,
+                    s.line_start,
+                    s.line_end,
                     1 as distance,
                     s.id as current_id
                 FROM code.edges e
@@ -209,9 +240,13 @@ impl Analytics {
                 
                 -- Recursive case: find callers of callers (reverse traversal)
                 SELECT 
+                    s.id,
                     s.name,
+                    s.qualified_name,
                     s.file_path,
                     s.kind,
+                    s.line_start,
+                    s.line_end,
                     i.distance + 1 as distance,
                     s.id as current_id
                 FROM impact i
@@ -222,10 +257,11 @@ impl Analytics {
                 WHERE i.distance < ?
                   AND e.kind = 'calls'
             )
-            SELECT DISTINCT name, file_path, kind, MIN(distance) as distance
+            SELECT current_id, name, qualified_name, file_path, kind,
+                   line_start, line_end, MIN(distance) as distance
             FROM impact
-            GROUP BY name, file_path, kind
-            ORDER BY distance, name
+            GROUP BY current_id, name, qualified_name, file_path, kind, line_start, line_end
+            ORDER BY distance, name, current_id
             "#,
         )?;
 
@@ -239,11 +275,15 @@ impl Analytics {
                 max_depth
             ],
             |row| {
-                Ok(ImpactNode {
-                    name: row.get(0)?,
-                    file_path: row.get(1)?,
-                    kind: row.get(2)?,
-                    distance: row.get(3)?,
+                Ok(LocatedImpactNode {
+                    symbol_id: row.get(0)?,
+                    name: row.get(1)?,
+                    qualified_name: row.get(2)?,
+                    file_path: row.get(3)?,
+                    kind: row.get(4)?,
+                    line_start: row.get::<_, Option<i64>>(5)?.unwrap_or(0),
+                    line_end: row.get::<_, Option<i64>>(6)?.unwrap_or(0),
+                    distance: row.get(7)?,
                 })
             },
         )?;
@@ -930,8 +970,8 @@ mod tests {
                 qualified_name TEXT,
                 kind TEXT NOT NULL,
                 file_path TEXT NOT NULL,
-                line_start INTEGER NOT NULL,
-                line_end INTEGER NOT NULL,
+                line_start INTEGER,
+                line_end INTEGER,
                 visibility TEXT
             );
             
@@ -995,6 +1035,98 @@ mod tests {
         // main calls run which calls helper (distance 2)
         assert!(nodes.iter().any(|n| n.name == "run" && n.distance == 1));
         assert!(nodes.iter().any(|n| n.name == "main" && n.distance == 2));
+    }
+
+    #[test]
+    fn test_located_impact_preserves_locations_and_deduplicates_by_symbol_id() {
+        let conn = setup_test_db().expect("Failed to setup test db");
+        conn.execute_batch(
+            r#"
+            INSERT INTO code.symbols VALUES
+                ('other.rs::run@40', 'run', 'Worker::run', 'function', 'other.rs', 40, 52, 'private'),
+                ('test.rs::run@40', 'run', 'Duplicate::run', 'function', 'test.rs', 40, 52, 'private');
+            INSERT INTO code.edges VALUES
+                ('other.rs::run@40', 'helper@21', 'helper', 'calls', NULL),
+                ('other.rs::run@40', 'helper@21', 'helper', 'calls', NULL),
+                ('test.rs::run@40', 'helper@21', 'helper', 'calls', NULL);
+            "#,
+        )
+        .unwrap();
+        let analytics = Analytics { conn };
+
+        let nodes = analytics.impact_analysis_located("helper", 1).unwrap();
+
+        assert_eq!(nodes.len(), 3);
+        let located = nodes
+            .iter()
+            .find(|node| node.symbol_id == "other.rs::run@40")
+            .unwrap();
+        assert_eq!(located.name, "run");
+        assert_eq!(located.qualified_name.as_deref(), Some("Worker::run"));
+        assert_eq!(located.file_path, "other.rs");
+        assert_eq!(located.line_start, 40);
+        assert_eq!(located.line_end, 52);
+        assert_eq!(located.distance, 1);
+
+        let legacy = analytics.impact_analysis("helper", 1).unwrap();
+        assert_eq!(legacy.len(), 2);
+        assert_eq!(
+            legacy
+                .iter()
+                .filter(|node| node.name == "run" && node.file_path == "test.rs")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_located_impact_depth_preserves_locations() {
+        let conn = setup_test_db().expect("Failed to setup test db");
+        let analytics = Analytics { conn };
+
+        let depth_one = analytics.impact_analysis_located("helper", 1).unwrap();
+        assert_eq!(depth_one.len(), 1);
+        assert_eq!(depth_one[0].symbol_id, "run@11");
+        assert_eq!((depth_one[0].line_start, depth_one[0].line_end), (11, 20));
+        assert_eq!(depth_one[0].distance, 1);
+
+        let depth_two = analytics.impact_analysis_located("helper", 2).unwrap();
+        assert_eq!(depth_two.len(), 2);
+        let run = depth_two
+            .iter()
+            .find(|node| node.symbol_id == "run@11")
+            .unwrap();
+        assert_eq!((run.line_start, run.line_end), (11, 20));
+        assert_eq!(run.distance, 1);
+        let main = depth_two
+            .iter()
+            .find(|node| node.symbol_id == "main@1")
+            .unwrap();
+        assert_eq!((main.line_start, main.line_end), (1, 10));
+        assert_eq!(main.distance, 2);
+    }
+
+    #[test]
+    fn test_located_impact_missing_legacy_lines_fall_back_to_zero() {
+        let conn = setup_test_db().expect("Failed to setup test db");
+        conn.execute_batch(
+            r#"
+            INSERT INTO code.symbols VALUES
+                ('legacy@31', 'legacy_caller', NULL, 'function', 'legacy.rs', NULL, NULL, 'private');
+            INSERT INTO code.edges VALUES
+                ('legacy@31', 'helper@21', 'helper', 'calls', NULL);
+            "#,
+        )
+        .unwrap();
+        let analytics = Analytics { conn };
+
+        let nodes = analytics.impact_analysis_located("helper", 1).unwrap();
+        let legacy = nodes
+            .iter()
+            .find(|node| node.symbol_id == "legacy@31")
+            .unwrap();
+        assert_eq!(legacy.line_start, 0);
+        assert_eq!(legacy.line_end, 0);
     }
 
     #[test]

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -29,6 +29,21 @@ pub struct ImpactNode {
     pub distance: i32,
 }
 
+/// A node in impact analysis with its indexed source location.
+///
+/// This complements [`ImpactNode`] without changing that existing public type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocatedImpactNode {
+    pub symbol_id: String,
+    pub name: String,
+    pub qualified_name: Option<String>,
+    pub file_path: String,
+    pub kind: String,
+    pub line_start: i64,
+    pub line_end: i64,
+    pub distance: i32,
+}
+
 /// Complexity analysis result for a function.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComplexityResult {

--- a/src/analytics/stub.rs
+++ b/src/analytics/stub.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use super::{CallGraphNode, ComplexityResult, FileStats, ImpactNode};
+use super::{CallGraphNode, ComplexityResult, FileStats, ImpactNode, LocatedImpactNode};
 use crate::error::Result;
 
 /// Stub analytics engine that returns empty results.
@@ -25,6 +25,15 @@ impl Analytics {
 
     /// Impact analysis: returns empty list.
     pub fn impact_analysis(&self, _target_name: &str, _max_depth: i32) -> Result<Vec<ImpactNode>> {
+        Ok(Vec::new())
+    }
+
+    /// Located impact analysis: returns empty list.
+    pub fn impact_analysis_located(
+        &self,
+        _target_name: &str,
+        _max_depth: i32,
+    ) -> Result<Vec<LocatedImpactNode>> {
         Ok(Vec::new())
     }
 
@@ -72,5 +81,19 @@ impl Analytics {
         _max_depth: i32,
     ) -> Result<Vec<(String, String, String, String)>> {
         Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn located_impact_analysis_returns_empty_data() {
+        let analytics = Analytics::open(Path::new(".")).unwrap();
+        assert!(analytics
+            .impact_analysis_located("anything", 5)
+            .unwrap()
+            .is_empty());
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -641,7 +641,7 @@ fn print_disambiguation(symbols: &[db::Symbol], name: &str, filters: &str, examp
     eprintln!("\nExample: {}", example);
 }
 
-/// Build a SymbolRef-shaped value from a call-graph/impact node.
+/// Build a SymbolRef-shaped value from a call-graph node.
 ///
 /// Graph traversal results don't carry line information, so `line_start` and
 /// `line_end` are 0.
@@ -672,14 +672,25 @@ fn graph_data(root: &str, depth: i32, nodes: &[analytics::CallGraphNode]) -> ser
 }
 
 /// Build the `query.impact` JSON payload.
-fn impact_data(target: &str, depth: i32, impacts: &[analytics::ImpactNode]) -> serde_json::Value {
+fn impact_data(
+    target: &str,
+    depth: i32,
+    impacts: &[analytics::LocatedImpactNode],
+) -> serde_json::Value {
     serde_json::json!({
         "target": target,
         "depth": depth,
         "impacted": impacts
             .iter()
             .map(|n| serde_json::json!({
-                "symbol": node_symbol(&n.name, &n.file_path, &n.kind),
+                "symbol": {
+                    "name": n.name,
+                    "qualified_name": n.qualified_name,
+                    "kind": n.kind,
+                    "file": n.file_path,
+                    "line_start": n.line_start,
+                    "line_end": n.line_end,
+                },
                 "distance": n.distance,
             }))
             .collect::<Vec<_>>(),
@@ -809,7 +820,7 @@ pub fn run_query(query: QueryCommand, json: bool) -> Result<()> {
             // Use DuckDB analytics for recursive impact analysis
             let analytics = analytics::Analytics::open(&root)?;
 
-            let impacts = analytics.impact_analysis(&symbol, depth)?;
+            let impacts = analytics.impact_analysis_located(&symbol, depth)?;
 
             if json {
                 return ctx::json::emit("query.impact", impact_data(&symbol, depth, &impacts));
@@ -1483,16 +1494,26 @@ mod tests {
         assert_eq!(data["nodes"][0]["symbol"]["name"], "helper");
         assert_eq!(data["nodes"][0]["depth"], 1);
 
-        let impacts = vec![analytics::ImpactNode {
+        let impacts = vec![analytics::LocatedImpactNode {
+            symbol_id: "src/x.rs::caller@17".to_string(),
             name: "caller".to_string(),
+            qualified_name: Some("Worker::caller".to_string()),
             file_path: "src/x.rs".to_string(),
             kind: "function".to_string(),
+            line_start: 17,
+            line_end: 29,
             distance: 2,
         }];
         let data = impact_data("main", 5, &impacts);
         assert_eq!(data["target"], "main");
         assert_eq!(data["total"], 1);
         assert_eq!(data["impacted"][0]["symbol"]["name"], "caller");
+        assert_eq!(
+            data["impacted"][0]["symbol"]["qualified_name"],
+            "Worker::caller"
+        );
+        assert_eq!(data["impacted"][0]["symbol"]["line_start"], 17);
+        assert_eq!(data["impacted"][0]["symbol"]["line_end"], 29);
         assert_eq!(data["impacted"][0]["distance"], 2);
     }
 

--- a/tests/query_impact_cli.rs
+++ b/tests/query_impact_cli.rs
@@ -1,0 +1,76 @@
+//! End-to-end coverage for source locations in `ctx query impact --json`.
+
+#![cfg(feature = "duckdb")]
+
+use assert_cmd::Command;
+use serde_json::Value;
+
+#[test]
+fn impact_json_reports_indexed_source_locations() {
+    let temp = tempfile::tempdir().expect("create fixture");
+    let src = temp.path().join("src");
+    std::fs::create_dir_all(&src).expect("create source directory");
+    std::fs::write(
+        src.join("main.rs"),
+        r#"fn helper() {}
+
+fn caller() {
+    helper();
+}
+
+fn main() {
+    caller();
+}
+"#,
+    )
+    .expect("write fixture");
+
+    Command::cargo_bin("ctx")
+        .unwrap()
+        .current_dir(temp.path())
+        .arg("index")
+        .assert()
+        .success();
+
+    let query = |depth: &str| {
+        let output = Command::cargo_bin("ctx")
+            .unwrap()
+            .current_dir(temp.path())
+            .args(["--json", "query", "impact", "helper", "--depth", depth])
+            .output()
+            .expect("query impact JSON");
+        assert!(
+            output.status.success(),
+            "query failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice::<Value>(&output.stdout).expect("valid JSON envelope")
+    };
+
+    let depth_one = query("1");
+    let impacted = depth_one["data"]["impacted"]
+        .as_array()
+        .expect("impacted array");
+    assert_eq!(impacted.len(), 1);
+    let symbol = &impacted[0]["symbol"];
+    assert_eq!(symbol["name"], "caller");
+    assert_eq!(symbol["file"], "src/main.rs");
+    let line_start = symbol["line_start"].as_i64().expect("numeric start line");
+    let line_end = symbol["line_end"].as_i64().expect("numeric end line");
+    assert_eq!((line_start, line_end), (3, 5));
+    assert_eq!(impacted[0]["distance"], 1);
+
+    let depth_two = query("2");
+    let impacted = depth_two["data"]["impacted"]
+        .as_array()
+        .expect("impacted array");
+    assert_eq!(impacted.len(), 2);
+    assert_eq!(impacted[0]["symbol"]["name"], "caller");
+    assert_eq!(impacted[0]["symbol"]["line_start"], 3);
+    assert_eq!(impacted[0]["symbol"]["line_end"], 5);
+    assert_eq!(impacted[0]["distance"], 1);
+    assert_eq!(impacted[1]["symbol"]["name"], "main");
+    assert_eq!(impacted[1]["symbol"]["line_start"], 7);
+    assert_eq!(impacted[1]["symbol"]["line_end"], 9);
+    assert_eq!(impacted[1]["distance"], 2);
+}


### PR DESCRIPTION
## Summary

- add an identity-preserving `LocatedImpactNode` API without changing the existing public `ImpactNode`
- hydrate impact results with symbol ID, qualified name, and indexed line ranges
- make `ctx query impact --json` emit navigable source locations
- preserve the legacy API's prior deduplication and minimum-distance behavior
- cover multiple traversal depths, duplicate display identities, nullable legacy lines, CLI JSON, and no-default stubs

## Stack

This PR is stacked on #68 and targets `fix/58-query-depth`. Review #66 and #68 first; after they land, this PR can be rebased or retargeted to `main`.

## Validation

- focused analytics, CLI JSON, depth, compatibility, and stub tests
- `cargo test --locked --all-features`
- `cargo test --locked --no-default-features`
- `cargo fmt` and clippy with warnings denied
- governance, versioning, release build, CLI contracts, and Docusaurus production build
- both clean-tree package dry-runs; GitHub CI will independently verify after retargeting to `main`

No version bump. The `contract-review` label is intentionally withheld pending manual review.

Closes #63
