### PR TITLE
feat: index Rust function references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Rust indexing now records statically resolvable bare or module-qualified free functions passed as
+  callback values (such as `spawn(worker::run_main)` and `.map(transform)`) as `uses` relationships
+  without treating them as calls; rebuild existing indexes with `ctx index --force` to apply the
+  new parser semantics (#62).
+
 ### Fixed
 - `ctx query callers` and `ctx query deps` now honor `--depth` with cycle-safe breadth-first
   traversal, shortest-distance identity deduplication, explicit JSON distances, and distance-grouped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server failures never fail an indexing run.
 - Rust indexing now records statically resolvable bare or module-qualified free functions passed as
   callback values (such as `spawn(worker::run_main)` and `.map(transform)`) as `uses` relationships
-  without treating them as calls (#62).
+  without treating them as calls (#62). A reference resolves only when exactly one Rust free
+  function matches; references that stay unresolved are discarded rather than kept as unverified
+  evidence, because nothing in the syntax distinguishes a function value from a constant or unit
+  variant in the same position.
 
 ### Fixed
 - Made `ctx diff` and `ctx review` token-budget selection deterministic by ordering equally ranked
@@ -45,6 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relationships only. The documented default of 3 now takes effect: existing invocations that pass
   no flags return transitive results grouped under new `Distance N:` headings, where they
   previously returned direct relationships. Pass `--depth 1` to retain the old output.
+- BREAKING: `ctx explain` now separates calls from other relationships for every language, not only
+  Rust (#62). `Calls (N)` previously counted and listed every outgoing edge, so an import or a trait
+  implementation was reported under a heading that said "Calls"; `extends`, `implements`, `imports`,
+  and `uses` edges now appear under a new `Relationships (N)` section and `Calls (N)` counts calls
+  alone. The documented `callers_count` JSON field narrows in the same way as `ctx query callers`
+  (#61): it now counts only callers resolved by symbol identity, not bare name matches.
+- BREAKING: The index schema version is now 3 (#62). No table changed, but the Rust parser emits
+  `uses` edges an older index does not contain, and content hashing would otherwise let unchanged
+  files keep a stale edge set indefinitely. Existing indexes report the usual schema mismatch and
+  are rebuilt with `ctx index --force`.
 
 ### Documentation
 - Documented the pluggable LSP support: a `ctx lsp` command reference

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -53,6 +53,11 @@ ctx index  # Only processes modified files
 
 This makes re-indexing fast even for large codebases.
 
+After upgrading ctx to a version with changed parser semantics, run `ctx index
+--force` once. Content hashes cannot tell that unchanged source files need to
+be parsed again, so an older index will not contain newly recognized
+relationships such as Rust function-item `uses` edges.
+
 ### Force Full Reindex
 
 When you update `.contextignore` or want a clean slate:
@@ -345,7 +350,11 @@ Dependency traversal follows resolved targets breadth-first across all outgoing 
 up to `--depth`. Direct edge kinds are preserved, unresolved references remain visible leaves, and
 resolved symbols are deduplicated at their shortest distance with the root excluded. `--file` and
 `--kind` select only the root. Human output groups results by distance; JSON entries include numeric
-`distance`.
+`distance`. For Rust, a bare or module-qualified free function passed as a value (for example,
+`spawn(worker::run_main)` or `.map(transform)`) appears as `uses`, not `calls`, when exactly one
+Rust function item matches.
+Ambiguous matches remain unresolved evidence. These references appear in `query deps` and
+`explain`, but do not become callers or affect call graphs, impact analysis, fan-in, or fan-out.
 
 ### Call Graph
 

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -455,15 +455,17 @@ user.validate();  // We don't know user is User
 
 ### Indirect Calls
 
-Calls through variables, callbacks, or higher-order functions are not tracked:
+Calls through variables, closures, or arbitrary dynamic dispatch are not
+tracked as calls. Rust free-function items passed directly as callback values
+are recorded separately as `uses` when exactly one Rust function matches:
 
-```javascript
-// Not tracked
-const callback = processData;
+```rust
+// Dynamic invocation through a variable is not tracked
+let callback = process_data;
 callback(input);
 
-// Not tracked
-[1, 2, 3].map(transform);
+// A direct Rust function item is a `uses` edge, not a call
+[1, 2, 3].into_iter().map(transform);
 ```
 
 ## Adding Language Support

--- a/docs/website/docs/code-intelligence.md
+++ b/docs/website/docs/code-intelligence.md
@@ -59,6 +59,11 @@ ctx index  # Only processes modified files
 
 This makes re-indexing fast even for large codebases.
 
+After upgrading ctx to a version with changed parser semantics, run `ctx index
+--force` once. Content hashes cannot tell that unchanged source files need to
+be parsed again, so an older index will not contain newly recognized
+relationships such as Rust function-item `uses` edges.
+
 ### Force Full Reindex
 
 When you update `.contextignore` or want a clean slate:
@@ -367,7 +372,11 @@ Dependency traversal follows resolved targets breadth-first across all outgoing 
 up to `--depth`. Direct edge kinds are preserved, unresolved references remain visible leaves, and
 resolved symbols are deduplicated at their shortest distance with the root excluded. `--file` and
 `--kind` select only the root. Human output groups results by distance; JSON entries include numeric
-`distance`.
+`distance`. For Rust, a bare or module-qualified free function passed as a value (for example,
+`spawn(worker::run_main)` or `.map(transform)`) appears as `uses`, not `calls`, when exactly one
+Rust function item matches.
+Ambiguous matches remain unresolved evidence. These references appear in `query deps` and
+`explain`, but do not become callers or affect call graphs, impact analysis, fan-in, or fan-out.
 
 ### Call Graph
 

--- a/docs/website/docs/cookbook/unfamiliar-codebase.md
+++ b/docs/website/docs/cookbook/unfamiliar-codebase.md
@@ -103,10 +103,12 @@ Apply the same principle in other ecosystems: inspect `package.json`, `pyproject
 service manifests, deployment configuration, or framework registration before declaring a symbol
 to be an entry point.
 
-Read the entry-point source even when `explain` succeeds. In this repository, `ctx explain main
---file src/main.rs` listed thread-builder calls but did not connect `main` to `run_main`, because
-`run_main` is passed as a function value to `spawn` rather than called with ordinary call syntax.
-`ctx source` made that transition obvious.
+Read the entry-point source even when `explain` succeeds. Current ctx indexes record the direct
+Rust function item in `spawn(run_main)` as a `uses` relationship rather than claiming it is a call.
+That evidence appears in `ctx explain main --file src/main.rs` and `ctx query deps main --file
+src/main.rs`, while callers, impact, and call-graph results remain limited to actual `calls` edges.
+Indexes created before this parser capability need one `ctx index --force` rebuild. `ctx source`
+still establishes the thread boundary and execution semantics that the relationship alone cannot.
 
 ## 4. Trace one distinctive execution path
 
@@ -129,11 +131,12 @@ The source adds meaning that the edge list cannot: `main` creates a larger-stack
 `run_main` initializes the Rayon pool and parses arguments, and `run` dispatches subcommands while
 preserving exit-code behavior.
 
-Graph results are hypotheses to check, especially for generic names. Although `--file
-src/main.rs` selected the intended Rust `run` symbol, its reported callers included unrelated
-Python `subprocess.run` calls and test helpers also named `run`. Static indexing may also miss or
-approximate macros, callbacks, function pointers, reflection, dynamic dispatch, generated code,
-and runtime registration.
+Graph results are hypotheses to check, especially for generic names. Resolved callers are tied to
+the selected symbol identity, while unresolved same-language call evidence is reported separately
+and should be checked against source. Static indexing may also miss or approximate macros, closure
+variables, function pointers, reflection, dynamic dispatch, generated code, and runtime
+registration. Direct Rust free-function callbacks are resolved only when exactly one Rust function
+item matches; ambiguous names remain unresolved `uses` evidence.
 
 Use the call snippet and source location to accept or reject each important relationship. A result
 that merely shares a name is not evidence of a real call path.

--- a/docs/website/docs/language-support.md
+++ b/docs/website/docs/language-support.md
@@ -523,15 +523,17 @@ user.validate();  // We don't know user is User
 
 ### Indirect Calls
 
-Calls through variables, callbacks, or higher-order functions are not tracked:
+Calls through variables, closures, or arbitrary dynamic dispatch are not
+tracked as calls. Rust free-function items passed directly as callback values
+are recorded separately as `uses` when exactly one Rust function matches:
 
-```javascript
-// Not tracked
-const callback = processData;
+```rust
+// Dynamic invocation through a variable is not tracked
+let callback = process_data;
 callback(input);
 
-// Not tracked
-[1, 2, 3].map(transform);
+// A direct Rust function item is a `uses` edge, not a call
+[1, 2, 3].into_iter().map(transform);
 ```
 
 ## Adding Language Support

--- a/docs/website/docs/sql-schema.md
+++ b/docs/website/docs/sql-schema.md
@@ -51,7 +51,7 @@ the physical index. Query `v1.*` — not the underlying tables.
 | `target_id`   | VARCHAR | `id` of the target symbol; NULL when unresolved         |
 | `target_name` | VARCHAR | Name of the target; retained even when unresolved       |
 | `target_file` | VARCHAR | File of the target symbol; NULL when unresolved         |
-| `kind`        | VARCHAR | `calls`, `extends`, `implements`, or `imports`          |
+| `kind`        | VARCHAR | Relationship kind, including `calls`, `uses`, `extends`, `implements`, or `imports` |
 | `line`        | BIGINT  | Line of the reference in the source file                |
 
 ### `v1.files` — one row per indexed file
@@ -97,6 +97,16 @@ SELECT name, file
 FROM v1.symbols
 WHERE kind IN ('function', 'method') AND is_public AND fan_in = 0
 ORDER BY file, name;
+```
+
+Rust function items passed directly as callback values are exposed as `uses`
+edges. They are intentionally excluded from `fan_in`, `fan_out`, call graphs,
+and impact analysis:
+
+```sql
+SELECT source_name, target_name, target_file
+FROM v1.edges
+WHERE kind = 'uses';
 ```
 
 ## Snapshot tables (`snap.*`) — only with `--snapshots`

--- a/src/commands/sql_schema.md
+++ b/src/commands/sql_schema.md
@@ -45,7 +45,7 @@ the physical index. Query `v1.*` — not the underlying tables.
 | `target_id`   | VARCHAR | `id` of the target symbol; NULL when unresolved         |
 | `target_name` | VARCHAR | Name of the target; retained even when unresolved       |
 | `target_file` | VARCHAR | File of the target symbol; NULL when unresolved         |
-| `kind`        | VARCHAR | `calls`, `extends`, `implements`, or `imports`          |
+| `kind`        | VARCHAR | Relationship kind, including `calls`, `uses`, `extends`, `implements`, or `imports` |
 | `line`        | BIGINT  | Line of the reference in the source file                |
 
 ### `v1.files` — one row per indexed file
@@ -91,6 +91,16 @@ SELECT name, file
 FROM v1.symbols
 WHERE kind IN ('function', 'method') AND is_public AND fan_in = 0
 ORDER BY file, name;
+```
+
+Rust function items passed directly as callback values are exposed as `uses`
+edges. They are intentionally excluded from `fan_in`, `fan_out`, call graphs,
+and impact analysis:
+
+```sql
+SELECT source_name, target_name, target_file
+FROM v1.edges
+WHERE kind = 'uses';
 ```
 
 ## Snapshot tables (`snap.*`) — only with `--snapshots`

--- a/src/commands/symbol.rs
+++ b/src/commands/symbol.rs
@@ -137,7 +137,7 @@ pub fn run_explain(
     let sym = &symbols[0];
 
     if json {
-        let callers = db.get_incoming_edges(&sym.name)?;
+        let callers = resolved_callers(&db, sym)?;
         let deps = db.get_outgoing_edges(&sym.id)?;
         return ctx::json::emit("explain", explain_data(sym, callers.len(), deps.len()));
     }
@@ -159,7 +159,7 @@ pub fn run_explain(
     }
 
     // Show callers
-    let callers = db.get_incoming_edges(&sym.name)?;
+    let callers = resolved_callers(&db, sym)?;
     if !callers.is_empty() {
         println!("\nCalled by ({}):", callers.len());
         for edge in callers.iter().take(10) {
@@ -179,17 +179,44 @@ pub fn run_explain(
 
     // Show dependencies
     let deps = db.get_outgoing_edges(&sym.id)?;
-    if !deps.is_empty() {
-        println!("\nCalls ({}):", deps.len());
-        for edge in deps.iter().take(10) {
+    let (calls, relationships): (Vec<_>, Vec<_>) = deps
+        .iter()
+        .partition(|edge| edge.kind == ctx::db::EdgeKind::Calls);
+    if !calls.is_empty() {
+        println!("\nCalls ({}):", calls.len());
+        for edge in calls.iter().take(10) {
             println!("  {} [{}]", edge.target_name, edge.kind.as_str());
         }
-        if deps.len() > 10 {
-            println!("  ... and {} more", deps.len() - 10);
+        if calls.len() > 10 {
+            println!("  ... and {} more", calls.len() - 10);
+        }
+    }
+    if !relationships.is_empty() {
+        println!("\nRelationships ({}):", relationships.len());
+        for edge in relationships.iter().take(10) {
+            println!("  {} [{}]", edge.target_name, edge.kind.as_str());
+        }
+        if relationships.len() > 10 {
+            println!("  ... and {} more", relationships.len() - 10);
         }
     }
 
     Ok(())
+}
+
+/// Return only actual, resolved call edges to the selected symbol.
+///
+/// Other incoming relationships, including function-item `uses` references,
+/// are evidence but are not callers.
+fn resolved_callers(db: &ctx::db::Database, sym: &ctx::db::Symbol) -> Result<Vec<ctx::db::Edge>> {
+    Ok(db
+        .get_incoming_edges(&sym.id)?
+        .into_iter()
+        .filter(|edge| {
+            edge.kind == ctx::db::EdgeKind::Calls
+                && edge.target_id.as_deref() == Some(sym.id.as_str())
+        })
+        .collect())
 }
 
 /// Build the `explain` JSON payload for a resolved symbol.

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1619,7 +1619,9 @@ impl Database {
     /// Resolve target_id for edges that only have target_name.
     ///
     /// This performs cross-file symbol resolution by matching target_name to symbols
-    /// in the database. Resolution priority:
+    /// in the database. Rust `uses` edges for function-value arguments resolve
+    /// only when exactly one Rust free-function item matches. Other relationship
+    /// kinds use the existing resolution priority:
     /// 0. Qualified match: the edge `context` equals a symbol's `qualified_name`
     ///    exactly (e.g., "ChessPureLib.isKingInCheck"), disambiguating a bare name
     ///    shared across files/languages.
@@ -1632,6 +1634,68 @@ impl Database {
     ///
     /// Returns the number of edges that were resolved.
     pub fn resolve_edge_targets(&self) -> Result<usize> {
+        let rust_function_references = {
+            let mut stmt = self.conn.prepare(
+                r#"
+                SELECT edges.id, edges.target_name, edges.context
+                FROM edges
+                JOIN symbols source ON source.id = edges.source_id
+                JOIN files source_file ON source_file.path = source.file_path
+                WHERE edges.target_id IS NULL
+                  AND edges.kind = 'uses'
+                  AND edges.context LIKE 'rust-function-item:%'
+                  AND source_file.language = 'rust'
+                "#,
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        let rust_functions = {
+            let mut stmt = self.conn.prepare(
+                r#"
+                SELECT symbols.id, symbols.name, symbols.file_path
+                FROM symbols
+                JOIN files ON files.path = symbols.file_path
+                WHERE symbols.kind = 'function'
+                  AND files.language = 'rust'
+                "#,
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()?
+        };
+
+        let mut rust_function_references_resolved = 0;
+        for (edge_id, target_name, context) in rust_function_references {
+            let reference_path = context
+                .strip_prefix("rust-function-item:")
+                .unwrap_or(target_name.as_str());
+            let matches: Vec<_> = rust_functions
+                .iter()
+                .filter(|(_, name, file_path)| {
+                    name == &target_name
+                        && rust_function_item_path_matches(file_path, name, reference_path)
+                })
+                .collect();
+            if let [target] = matches.as_slice() {
+                rust_function_references_resolved += self.conn.execute(
+                    "UPDATE edges SET target_id = ?1 WHERE id = ?2 AND target_id IS NULL",
+                    params![target.0, edge_id],
+                )?;
+            }
+        }
+
         // Step 0: Resolve edges whose `context` holds a fully qualified name by an
         // EXACT match on a symbol's `qualified_name` (e.g. Solidity qualified calls
         // like `ChessPureLib.isKingInCheck`). This must run BEFORE the substring
@@ -1648,6 +1712,11 @@ impl Database {
                 LIMIT 1
             )
             WHERE target_id IS NULL
+              AND (
+                edges.kind != 'uses'
+                OR edges.context IS NULL
+                OR edges.context NOT LIKE 'rust-function-item:%'
+              )
               AND context IS NOT NULL
               AND (
                 SELECT COUNT(*) FROM symbols
@@ -1673,6 +1742,11 @@ impl Database {
                   AND edges.context LIKE '%' || t.qualified_name || '%'
             )
             WHERE target_id IS NULL
+              AND (
+                edges.kind != 'uses'
+                OR edges.context IS NULL
+                OR edges.context NOT LIKE 'rust-function-item:%'
+              )
               AND context IS NOT NULL
               AND (
                 SELECT COUNT(*)
@@ -1696,6 +1770,11 @@ impl Database {
                   AND kind IN ('function', 'method')
             )
             WHERE target_id IS NULL
+              AND (
+                edges.kind != 'uses'
+                OR edges.context IS NULL
+                OR edges.context NOT LIKE 'rust-function-item:%'
+              )
               AND (
                 SELECT COUNT(*) FROM symbols
                 WHERE name = edges.target_name
@@ -1723,6 +1802,11 @@ impl Database {
                   AND t.kind IN ('function', 'method')
             )
             WHERE target_id IS NULL
+              AND (
+                edges.kind != 'uses'
+                OR edges.context IS NULL
+                OR edges.context NOT LIKE 'rust-function-item:%'
+              )
               AND (
                 SELECT COUNT(*)
                 FROM symbols t
@@ -1754,7 +1838,11 @@ impl Database {
             [],
         )?;
 
-        Ok(qualified_resolved + context_resolved + unique_resolved + same_file_unique)
+        Ok(rust_function_references_resolved
+            + qualified_resolved
+            + context_resolved
+            + unique_resolved
+            + same_file_unique)
     }
 
     /// Insert (or replace) a batch of MinHash fingerprints in one transaction.
@@ -1907,6 +1995,31 @@ fn preprocess_search_query(query: &str) -> Vec<String> {
             format!("{}*", s)
         })
         .collect()
+}
+
+/// Match a parsed Rust function-item path against the defining file.
+///
+/// Bare names deliberately match every Rust free function with that name, so
+/// the caller resolves only a globally unique item. Qualified paths use the
+/// module-like file suffix (`worker::run` -> `worker.rs` or `worker/mod.rs`) to
+/// disambiguate without guessing about imports or dynamic values.
+fn rust_function_item_path_matches(file_path: &str, name: &str, reference_path: &str) -> bool {
+    if !reference_path.contains("::") {
+        return reference_path == name;
+    }
+
+    let reference_path = reference_path
+        .strip_prefix("crate::")
+        .or_else(|| reference_path.strip_prefix("self::"))
+        .unwrap_or(reference_path);
+    let module_path = file_path
+        .strip_suffix("/mod.rs")
+        .or_else(|| file_path.strip_suffix(".rs"))
+        .unwrap_or(file_path)
+        .replace(['/', '\\'], "::");
+    let defined_path = format!("{}::{}", module_path, name);
+
+    defined_path == reference_path || defined_path.ends_with(&format!("::{}", reference_path))
 }
 
 /// Helper to convert a row to a Symbol.
@@ -2228,6 +2341,54 @@ mod tests {
             parent_id: None,
             source: None,
         }
+    }
+
+    #[test]
+    fn solidity_uses_edges_keep_existing_target_resolution() {
+        let db = Database::open_in_memory().unwrap();
+        db.upsert_file(
+            &FileRecord {
+                path: "src/example.sol".to_string(),
+                content_hash: "solidity".to_string(),
+                size_bytes: 100,
+                language: Some("solidity".to_string()),
+                last_indexed: 0,
+            },
+            None,
+        )
+        .unwrap();
+        db.insert_symbol(&make_fn_symbol(
+            "src/example.sol::source",
+            "source",
+            "src/example.sol",
+            1,
+        ))
+        .unwrap();
+        db.insert_symbol(&make_fn_symbol(
+            "src/example.sol::target",
+            "target",
+            "src/example.sol",
+            10,
+        ))
+        .unwrap();
+        db.insert_edge(&Edge {
+            source_id: "src/example.sol::source".to_string(),
+            target_id: None,
+            target_name: "target".to_string(),
+            kind: EdgeKind::Uses,
+            line: Some(2),
+            col: None,
+            context: None,
+        })
+        .unwrap();
+
+        assert_eq!(db.resolve_edge_targets().unwrap(), 1);
+        let edge = db
+            .get_outgoing_edges("src/example.sol::source")
+            .unwrap()
+            .pop()
+            .expect("uses edge");
+        assert_eq!(edge.target_id.as_deref(), Some("src/example.sol::target"));
     }
 
     /// Build a 'calls' edge for metrics tests.

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -23,7 +23,12 @@ use super::models::*;
 /// History:
 /// - v1: initial versioned schema
 /// - v2: adds `symbol_fingerprints` (MinHash near-duplicate detection)
-pub const SCHEMA_VERSION: i64 = 2;
+/// - v3: Rust function-value arguments recorded as `uses` edges. The tables are
+///   unchanged, but the parser now emits edges an older index does not contain,
+///   and content hashes would otherwise let unchanged files keep their stale
+///   edge set forever. The bump turns that silent staleness into the existing
+///   rebuild prompt.
+pub const SCHEMA_VERSION: i64 = 3;
 
 /// Default embedding dimension for vector search.
 /// This matches OpenAI text-embedding-ada-002 (1536) and text-embedding-3-small (1536).
@@ -1688,11 +1693,33 @@ impl Database {
                         && rust_function_item_path_matches(file_path, name, reference_path)
                 })
                 .collect();
-            if let [target] = matches.as_slice() {
-                rust_function_references_resolved += self.conn.execute(
-                    "UPDATE edges SET target_id = ?1 WHERE id = ?2 AND target_id IS NULL",
-                    params![target.0, edge_id],
-                )?;
+            // The capture takes every bare identifier in argument position,
+            // because nothing in the syntax separates `spawn(run_main)` from
+            // `retry(MAX_RETRIES)`; constants, statics, and unit variants all
+            // arrive here too. Candidate count is what tells them apart:
+            //
+            // - exactly one match: resolve it.
+            // - several matches: leave unresolved. The identifier does name a
+            //   function, we just cannot say which one, and that is real
+            //   evidence worth keeping as a leaf.
+            // - no match at all: the identifier names no function in the index,
+            //   so the edge asserts precisely what we failed to establish. Drop
+            //   it rather than leave a reference to a constant sitting in the
+            //   graph as an unresolved dependency.
+            match matches.as_slice() {
+                [target] => {
+                    rust_function_references_resolved += self.conn.execute(
+                        "UPDATE edges SET target_id = ?1 WHERE id = ?2 AND target_id IS NULL",
+                        params![target.0, edge_id],
+                    )?;
+                }
+                [] => {
+                    self.conn.execute(
+                        "DELETE FROM edges WHERE id = ?1 AND target_id IS NULL",
+                        params![edge_id],
+                    )?;
+                }
+                _ => {}
             }
         }
 

--- a/src/parser/rust.rs
+++ b/src/parser/rust.rs
@@ -174,7 +174,7 @@ impl RustParser {
         // for example `spawn(run_main)` or `.map(transform)`. Resolution is
         // deliberately deferred until the complete index is available.
         let function_references_query = Query::new(
-            language,
+            &language,
             r#"
             (arguments
                 (identifier) @reference.name
@@ -373,14 +373,13 @@ impl RustParser {
             .collect();
 
         let mut cursor = QueryCursor::new();
-        for query_match in cursor.matches(&self.function_references_query, *root, source.as_bytes())
-        {
+        let mut matches = cursor.matches(&self.function_references_query, *root, source.as_bytes());
+
+        while let Some(query_match) = matches.next() {
             let mut name_node = None;
             let mut path_node = None;
             for capture in query_match.captures {
-                match self.function_references_query.capture_names()[capture.index as usize]
-                    .as_str()
-                {
+                match self.function_references_query.capture_names()[capture.index as usize] {
                     "reference.name" => {
                         name_node = Some(capture.node);
                         path_node = Some(capture.node);

--- a/src/parser/rust.rs
+++ b/src/parser/rust.rs
@@ -8,6 +8,10 @@ use crate::parser::{
     SymbolKindMapping,
 };
 
+/// Internal marker used to distinguish Rust function-item candidates from
+/// pre-existing `uses` relationships in other language parsers.
+const FUNCTION_ITEM_CONTEXT_PREFIX: &str = "rust-function-item:";
+
 /// Symbol kind mappings for Rust capture names.
 const RUST_SYMBOL_MAPPINGS: &[SymbolKindMapping] = &[
     SymbolKindMapping::new("func", SymbolKind::Function),
@@ -27,6 +31,7 @@ pub struct RustParser {
     parser: Parser,
     symbols_query: Query,
     calls_query: Query,
+    function_references_query: Query,
     impl_query: Query,
 }
 
@@ -165,10 +170,30 @@ impl RustParser {
         )
         .expect("Invalid calls query");
 
+        // Direct identifier arguments can denote function items passed as values,
+        // for example `spawn(run_main)` or `.map(transform)`. Resolution is
+        // deliberately deferred until the complete index is available.
+        let function_references_query = Query::new(
+            language,
+            r#"
+            (arguments
+                (identifier) @reference.name
+            )
+
+            (arguments
+                (scoped_identifier
+                    name: (identifier) @qualified_reference.name
+                ) @qualified_reference.path
+            )
+            "#,
+        )
+        .expect("Invalid function references query");
+
         Self {
             parser,
             symbols_query,
             calls_query,
+            function_references_query,
             impl_query,
         }
     }
@@ -193,8 +218,9 @@ impl RustParser {
             &mut exports,
         );
 
-        // Extract edges (calls, uses)
+        // Extract call and function-value reference edges.
         self.extract_edges(&root, file_path, source, &symbols, &mut edges);
+        self.extract_function_reference_edges(&root, source, &symbols, &mut edges);
 
         // Extract trait implementation edges
         self.extract_impl_edges(&root, file_path, source, &symbols, &mut edges);
@@ -326,6 +352,78 @@ impl RustParser {
         );
     }
 
+    /// Extract bare or module-qualified function items passed as call arguments.
+    ///
+    /// The parser emits conservative `uses` candidates and leaves `target_id`
+    /// unset. Cross-file resolution later accepts only a globally unique Rust
+    /// free-function item. Bare identifiers bound by Rust patterns are local
+    /// values (including closure variables), so they are not function-item
+    /// evidence even if a function elsewhere happens to share their name.
+    fn extract_function_reference_edges(
+        &self,
+        root: &Node,
+        source: &str,
+        symbols: &[Symbol],
+        edges: &mut Vec<Edge>,
+    ) {
+        let func_ranges: Vec<_> = symbols
+            .iter()
+            .filter(|symbol| matches!(symbol.kind, SymbolKind::Function | SymbolKind::Method))
+            .map(|symbol| (symbol.line_start, symbol.line_end, symbol.id.clone()))
+            .collect();
+
+        let mut cursor = QueryCursor::new();
+        for query_match in cursor.matches(&self.function_references_query, *root, source.as_bytes())
+        {
+            let mut name_node = None;
+            let mut path_node = None;
+            for capture in query_match.captures {
+                match self.function_references_query.capture_names()[capture.index as usize]
+                    .as_str()
+                {
+                    "reference.name" => {
+                        name_node = Some(capture.node);
+                        path_node = Some(capture.node);
+                    }
+                    "qualified_reference.name" => name_node = Some(capture.node),
+                    "qualified_reference.path" => path_node = Some(capture.node),
+                    _ => {}
+                }
+            }
+
+            let (Some(node), Some(path_node)) = (name_node, path_node) else {
+                continue;
+            };
+            let name = node.utf8_text(source.as_bytes()).unwrap_or("");
+            let reference_path = path_node.utf8_text(source.as_bytes()).unwrap_or(name);
+            if name.is_empty() || (reference_path == name && is_locally_bound(node, name, source)) {
+                continue;
+            }
+
+            let line = node.start_position().row as u32 + 1;
+            let Some(source_id) = func_ranges
+                .iter()
+                .find(|(start, end, _)| line >= *start && line <= *end)
+                .map(|(_, _, id)| id.clone())
+            else {
+                continue;
+            };
+
+            edges.push(Edge {
+                source_id,
+                target_id: None,
+                target_name: name.to_string(),
+                kind: EdgeKind::Uses,
+                line: Some(line),
+                col: Some(node.start_position().column as u32),
+                context: Some(format!(
+                    "{}{}",
+                    FUNCTION_ITEM_CONTEXT_PREFIX, reference_path
+                )),
+            });
+        }
+    }
+
     /// Extract trait implementation edges from the AST.
     fn extract_impl_edges(
         &self,
@@ -399,6 +497,59 @@ impl RustParser {
             }
         }
     }
+}
+
+/// Return whether `name` is pattern-bound in the containing function.
+///
+/// This intentionally errs on the side of not inventing a static function-item
+/// relationship for a locally bound value.
+fn is_locally_bound(node: Node<'_>, name: &str, source: &str) -> bool {
+    let mut ancestor = node.parent();
+    let function = loop {
+        let Some(current) = ancestor else {
+            return false;
+        };
+        if current.kind() == "function_item" {
+            break current;
+        }
+        ancestor = current.parent();
+    };
+
+    let mut stack = vec![function];
+    while let Some(current) = stack.pop() {
+        if current.kind() == "closure_parameters"
+            && descendant_identifier_matches(current, name, source)
+        {
+            return true;
+        }
+        if matches!(
+            current.kind(),
+            "parameter" | "let_declaration" | "for_expression" | "match_arm" | "let_condition"
+        ) {
+            if let Some(pattern) = current.child_by_field_name("pattern") {
+                if descendant_identifier_matches(pattern, name, source) {
+                    return true;
+                }
+            }
+        }
+
+        let mut cursor = current.walk();
+        stack.extend(current.children(&mut cursor));
+    }
+    false
+}
+
+fn descendant_identifier_matches(node: Node<'_>, name: &str, source: &str) -> bool {
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        if current.kind() == "identifier" && current.utf8_text(source.as_bytes()).ok() == Some(name)
+        {
+            return true;
+        }
+        let mut cursor = current.walk();
+        stack.extend(current.children(&mut cursor));
+    }
+    false
 }
 
 /// Extract visibility from a node.
@@ -669,6 +820,94 @@ fn baz() {}
         assert_eq!(calls.len(), 2);
         assert!(calls.iter().any(|e| e.target_name == "bar"));
         assert!(calls.iter().any(|e| e.target_name == "baz"));
+    }
+
+    #[test]
+    fn test_extract_function_items_passed_as_values() {
+        let mut parser = RustParser::new();
+        let source = r#"
+fn run_main() {}
+fn transform(value: i32) -> i32 { value + 1 }
+
+fn main() {
+    spawn(run_main);
+    values.into_iter().map(transform);
+    spawn(worker::run_main);
+}
+
+fn shadowed() {
+    let run_main = || {};
+    spawn(worker::run_main);
+}
+"#;
+
+        let result = parser.parse("test.rs", source).unwrap();
+        let uses: Vec<_> = result
+            .edges
+            .iter()
+            .filter(|edge| edge.kind == EdgeKind::Uses)
+            .collect();
+
+        assert_eq!(uses.len(), 4);
+        assert!(uses.iter().any(|edge| {
+            edge.source_id.contains("main")
+                && edge.target_name == "run_main"
+                && edge.target_id.is_none()
+                && edge.context.as_deref() == Some("rust-function-item:run_main")
+        }));
+        assert!(uses.iter().any(|edge| {
+            edge.source_id.contains("main")
+                && edge.target_name == "transform"
+                && edge.target_id.is_none()
+        }));
+        assert!(uses.iter().any(|edge| {
+            edge.target_name == "run_main"
+                && edge.context.as_deref() == Some("rust-function-item:worker::run_main")
+        }));
+        assert!(uses.iter().any(|edge| {
+            edge.source_id.contains("shadowed")
+                && edge.context.as_deref() == Some("rust-function-item:worker::run_main")
+        }));
+    }
+
+    #[test]
+    fn test_function_value_candidates_exclude_calls_closures_and_local_bindings() {
+        let mut parser = RustParser::new();
+        let source = r#"
+fn transform(value: i32) -> i32 { value + 1 }
+
+fn apply(parameter_callback: fn(i32) -> i32) {
+    let closure_callback = |value| value + 1;
+    consume(transform(1));
+    consume(|value| transform(value));
+    consume(parameter_callback);
+    consume(closure_callback);
+    for transform in callbacks {
+        consume(transform);
+    }
+    if let Some(transform) = optional_callback {
+        consume(transform);
+    }
+    while let Some(transform) = callback_queue.pop() {
+        consume(transform);
+    }
+    match callback_result {
+        Ok(transform) => consume(transform),
+        Err(_) => {}
+    }
+}
+"#;
+
+        let result = parser.parse("test.rs", source).unwrap();
+        assert!(
+            result.edges.iter().all(|edge| edge.kind != EdgeKind::Uses),
+            "unexpected uses edges: {:?}",
+            result.edges
+        );
+        assert!(result
+            .edges
+            .iter()
+            .any(|edge| { edge.kind == EdgeKind::Calls && edge.target_name == "transform" }));
     }
 
     #[test]

--- a/tests/function_references_cli.rs
+++ b/tests/function_references_cli.rs
@@ -200,3 +200,58 @@ fn main() { spawn(run_main); }
     );
     assert_eq!(impact["data"]["total"], 0);
 }
+
+/// Nothing in the syntax separates a function value from a constant in argument
+/// position, so the capture takes both. An identifier that names no function in
+/// the index is not a function value, and must not survive as an unresolved
+/// dependency leaf -- unlike an ambiguous name, which is genuine evidence.
+#[test]
+fn non_function_arguments_do_not_become_reference_edges() {
+    let temp = index_fixture(&[(
+        "src/main.rs",
+        r#"
+const MAX_RETRIES: i32 = 3;
+static GREETING: &str = "hi";
+
+fn retry(_limit: i32) {}
+fn announce(_text: &str) {}
+fn consume<T>(_callback: T) {}
+fn worker() {}
+
+fn main() {
+    retry(MAX_RETRIES);
+    announce(GREETING);
+    consume(worker);
+}
+"#,
+    )]);
+
+    let deps = json_command(
+        &temp,
+        &["--json", "query", "deps", "main", "--file", "src/main.rs"],
+    );
+    let references: Vec<_> = deps["data"]["dependencies"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|dependency| dependency["kind"] == "uses")
+        .collect();
+
+    let names: Vec<_> = references
+        .iter()
+        .map(|reference| reference["target_name"].as_str().unwrap_or_default())
+        .collect();
+    assert!(
+        !names.contains(&"MAX_RETRIES"),
+        "a constant must not become a function reference: {names:?}"
+    );
+    assert!(
+        !names.contains(&"GREETING"),
+        "a static must not become a function reference: {names:?}"
+    );
+    assert!(
+        names.contains(&"worker"),
+        "a real function value must still be recorded: {names:?}"
+    );
+    assert_eq!(references.len(), 1, "unexpected references: {names:?}");
+}

--- a/tests/function_references_cli.rs
+++ b/tests/function_references_cli.rs
@@ -1,0 +1,202 @@
+//! End-to-end coverage for Rust function-item `uses` relationships.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn index_fixture(files: &[(&str, &str)]) -> TempDir {
+    let temp = TempDir::new().expect("create fixture");
+    for (path, source) in files {
+        let path = temp.path().join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).expect("create fixture directory");
+        std::fs::write(path, source).expect("write fixture source");
+    }
+
+    Command::cargo_bin("ctx")
+        .unwrap()
+        .current_dir(temp.path())
+        .arg("index")
+        .assert()
+        .success();
+    temp
+}
+
+fn json_command(temp: &TempDir, args: &[&str]) -> Value {
+    let output = Command::cargo_bin("ctx")
+        .unwrap()
+        .current_dir(temp.path())
+        .args(args)
+        .output()
+        .expect("run ctx command");
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("valid JSON envelope")
+}
+
+#[test]
+fn references_surface_in_deps_and_explain_but_not_callers() {
+    let temp = index_fixture(&[
+        (
+            "src/main.rs",
+            r#"
+mod callbacks;
+
+fn spawn<T>(_callback: T) {}
+fn transform(value: i32) -> i32 { value + 1 }
+fn direct() {}
+
+fn main() {
+    spawn(callbacks::run_main);
+    [1, 2].into_iter().map(transform);
+    direct();
+}
+"#,
+        ),
+        ("src/callbacks.rs", "pub fn run_main() {}\n"),
+    ]);
+
+    let deps = json_command(
+        &temp,
+        &["--json", "query", "deps", "main", "--file", "src/main.rs"],
+    );
+    let dependencies = deps["data"]["dependencies"]
+        .as_array()
+        .expect("dependencies array");
+    for target in ["run_main", "transform"] {
+        let reference = dependencies
+            .iter()
+            .find(|dependency| dependency["kind"] == "uses" && dependency["target_name"] == target)
+            .unwrap_or_else(|| panic!("missing uses edge to {target}"));
+        assert_eq!(reference["distance"], 1);
+        assert_eq!(reference["resolved"]["kind"], "function");
+    }
+    assert!(!dependencies
+        .iter()
+        .any(|dependency| dependency["kind"] == "calls"
+            && matches!(
+                dependency["target_name"].as_str(),
+                Some("run_main" | "transform")
+            )));
+
+    Command::cargo_bin("ctx")
+        .unwrap()
+        .current_dir(temp.path())
+        .args(["explain", "main", "--file", "src/main.rs"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Relationships"))
+        .stdout(predicates::str::contains("run_main [uses]"))
+        .stdout(predicates::str::contains("transform [uses]"));
+
+    let callers = json_command(
+        &temp,
+        &[
+            "--json",
+            "query",
+            "callers",
+            "run_main",
+            "--file",
+            "src/callbacks.rs",
+        ],
+    );
+    assert!(callers["data"]["callers"].as_array().unwrap().is_empty());
+    assert!(callers["data"]["unresolved_callers"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    let explained = json_command(
+        &temp,
+        &[
+            "--json",
+            "explain",
+            "run_main",
+            "--file",
+            "src/callbacks.rs",
+        ],
+    );
+    assert_eq!(explained["data"]["callers_count"], 0);
+}
+
+#[test]
+fn ambiguous_rust_function_items_remain_unresolved() {
+    let temp = index_fixture(&[
+        (
+            "src/main.rs",
+            r#"
+fn consume<T>(_callback: T) {}
+mod first;
+fn main() {
+    consume(transform);
+    consume(first::transform);
+}
+"#,
+        ),
+        (
+            "src/first.rs",
+            "fn transform(value: i32) -> i32 { value }\n",
+        ),
+        (
+            "src/second.rs",
+            "fn transform(value: i32) -> i32 { value + 1 }\n",
+        ),
+    ]);
+
+    let deps = json_command(
+        &temp,
+        &["--json", "query", "deps", "main", "--file", "src/main.rs"],
+    );
+    let references: Vec<_> = deps["data"]["dependencies"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|dependency| dependency["kind"] == "uses")
+        .collect();
+    assert_eq!(references.len(), 2);
+    assert!(references.iter().any(|reference| {
+        reference["target_name"] == "transform" && reference["resolved"].is_null()
+    }));
+    assert!(references.iter().any(|reference| {
+        reference["resolved"]["file"] == "src/first.rs"
+            && reference["resolved"]["name"] == "transform"
+    }));
+}
+
+#[cfg(feature = "duckdb")]
+#[test]
+fn references_are_queryable_but_do_not_change_call_metrics_or_call_graph() {
+    let temp = index_fixture(&[(
+        "src/main.rs",
+        r#"
+fn spawn<T>(_callback: T) {}
+fn run_main() {}
+fn main() { spawn(run_main); }
+"#,
+    )]);
+
+    let sql = json_command(
+        &temp,
+        &[
+            "sql",
+            "--json",
+            "SELECT e.kind, s.fan_out FROM v1.edges e JOIN v1.symbols s ON s.id = e.source_id WHERE e.source_name = 'main' ORDER BY e.kind",
+        ],
+    );
+    let rows = sql["data"]["rows"].as_array().expect("SQL rows");
+    assert!(rows.iter().any(|row| row[0] == "uses"));
+    assert!(rows.iter().all(|row| row[1] == 1));
+
+    let graph = json_command(&temp, &["--json", "query", "graph", "main", "--depth", "2"]);
+    let serialized = serde_json::to_string(&graph["data"]).unwrap();
+    assert!(serialized.contains("spawn"));
+    assert!(!serialized.contains("run_main"));
+
+    let impact = json_command(
+        &temp,
+        &["--json", "query", "impact", "run_main", "--depth", "2"],
+    );
+    assert_eq!(impact["data"]["total"], 0);
+}


### PR DESCRIPTION
## Summary

- index statically resolvable Rust function items passed as callback values as `uses` relationships, without claiming they are calls
- support bare and qualified callback paths with conservative singleton resolution
- exclude parameters, closures, `let`, `for`, `match`, `if let`, and `while let` pattern bindings from callback inference
- keep callers, impact, fan metrics, and call graphs restricted to real `calls` edges
- surface callback relationships in deps, explain, and SQL, with reindex guidance and end-to-end coverage
- preserve existing non-Rust `uses` resolution behavior

## Stack

This PR is stacked on #68 and targets `fix/58-query-depth`. Review #66 and #68 first; after they land, this PR can be rebased or retargeted to `main`.

## Validation

- focused parser, resolver, Solidity compatibility, and CLI tests
- `cargo test --locked --all-features`
- `cargo test --locked --no-default-features`
- `cargo fmt` and clippy with warnings denied
- governance, versioning, release build, CLI contracts, and Docusaurus production build
- both clean-tree package dry-runs; GitHub CI will independently verify after retargeting to `main`

Existing indexes must be rebuilt to gain the new parser relationships. No version bump. The `contract-review` label is intentionally withheld pending manual review.

Closes #62
