### PR TITLE
fix: honor positional file patterns in ctx index (AGE-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ctx index src/**`), scoping the index exactly like `-p/--pattern`. Previously the
   positional arguments were accepted but silently ignored, so the whole repository was
   indexed at full cost. The indexing banner now echoes the effective scope
-  (`Indexing codebase (scoped to: src)...`), and file discovery warns when include
-  patterns match no files instead of silently producing an empty result.
+  (`Indexing codebase (scoped to: src)...`), file discovery warns when include
+  patterns match no files, and `ctx index` refuses to update the index when an
+  explicit scope matches nothing — previously a mistyped `-p` pattern silently
+  emptied an existing index.
 
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ctx index` now honors positional file patterns and paths (`ctx index src`,
+  `ctx index src/**`), scoping the index exactly like `-p/--pattern`. Previously the
+  positional arguments were accepted but silently ignored, so the whole repository was
+  indexed at full cost. The indexing banner now echoes the effective scope
+  (`Indexing codebase (scoped to: src)...`), and file discovery warns when include
+  patterns match no files instead of silently producing an empty result.
+
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,
   harness regeneration after binary upgrades, and unresolved map focus behavior (#64).

--- a/docs/code-intelligence.md
+++ b/docs/code-intelligence.md
@@ -109,6 +109,9 @@ ctx index -i "tests/" -i "*.generated.ts"
 # Only index specific patterns
 ctx index -p "src/**/*.rs" -p "lib/"
 
+# Positional paths scope the same way (a bare directory means everything under it)
+ctx index src
+
 # Disable gitignore (index gitignored files)
 ctx index --no-gitignore
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -412,6 +412,9 @@ ctx index -p "src/**/*.ts" -p "lib/**/*.ts"
 
 # Mix globs and literal paths
 ctx index -p "src/**/*.rs" -p "Cargo.toml"
+
+# Positional paths scope the same way as -p
+ctx index src
 ```
 
 Include patterns support:

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -51,6 +51,21 @@ impl IndexConfig {
     }
 }
 
+/// Merge the global positional patterns with `-p/--pattern` values into a
+/// single include-pattern list for the walker.
+///
+/// The positional argument defaults to `.` (the whole repository), so a bare
+/// `.` (or `./`) adds no scoping and is dropped; anything else the user typed
+/// (literal paths, directories, globs) scopes the index exactly like `-p`.
+pub fn merge_include_patterns(positional: Vec<String>, flags: Vec<String>) -> Vec<String> {
+    let mut merged: Vec<String> = positional
+        .into_iter()
+        .filter(|p| p.trim_end_matches('/') != "." && !p.is_empty())
+        .collect();
+    merged.extend(flags);
+    merged
+}
+
 /// Run the index command.
 pub fn run_index(config: IndexConfig) -> Result<()> {
     let root = env::current_dir()?;
@@ -72,10 +87,20 @@ pub fn run_index(config: IndexConfig) -> Result<()> {
         }
     }
 
-    if config.serial {
-        eprintln!("Indexing codebase (serial mode)...");
+    // Echo the effective scope so a mistyped pattern is visible before the
+    // (potentially expensive) parse phase rather than after it.
+    let scope = if config.walker.include_patterns.is_empty() {
+        String::new()
     } else {
-        eprintln!("Indexing codebase...");
+        format!(
+            " (scoped to: {})",
+            config.walker.include_patterns.join(", ")
+        )
+    };
+    if config.serial {
+        eprintln!("Indexing codebase (serial mode){}...", scope);
+    } else {
+        eprintln!("Indexing codebase{}...", scope);
     }
 
     let mut indexer = index::Indexer::with_config(&root, config.verbose, config.walker.clone())?;
@@ -112,4 +137,51 @@ pub fn run_index(config: IndexConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_include_patterns;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn default_dot_adds_no_scoping() {
+        assert!(merge_include_patterns(v(&["."]), v(&[])).is_empty());
+        assert!(merge_include_patterns(v(&["./"]), v(&[])).is_empty());
+    }
+
+    #[test]
+    fn positional_paths_scope_the_index() {
+        assert_eq!(merge_include_patterns(v(&["src"]), v(&[])), v(&["src"]));
+        assert_eq!(merge_include_patterns(v(&["src/"]), v(&[])), v(&["src/"]));
+        assert_eq!(
+            merge_include_patterns(v(&["src/**/*.rs"]), v(&[])),
+            v(&["src/**/*.rs"])
+        );
+    }
+
+    #[test]
+    fn positional_and_flag_patterns_are_combined() {
+        assert_eq!(
+            merge_include_patterns(v(&["lib"]), v(&["src/**"])),
+            v(&["lib", "src/**"])
+        );
+        // A stray `.` among real patterns still means "everything is already
+        // included by default" and contributes nothing.
+        assert_eq!(
+            merge_include_patterns(v(&[".", "lib"]), v(&[])),
+            v(&["lib"])
+        );
+    }
+
+    #[test]
+    fn flags_alone_pass_through() {
+        assert_eq!(
+            merge_include_patterns(v(&["."]), v(&["src/**"])),
+            v(&["src/**"])
+        );
+    }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,7 +34,7 @@ pub use embed::{run_embed, run_embed_watch, run_semantic};
 pub use graph::run_graph;
 pub use harness::run_harness;
 pub use hotspots::run_hotspots;
-pub use index::{run_index, IndexConfig};
+pub use index::{merge_include_patterns, run_index, IndexConfig};
 #[cfg(feature = "mcp")]
 pub use interactive::run_serve;
 pub use interactive::run_shell;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -19,7 +19,7 @@ use sha2::{Digest, Sha256};
 
 use crate::db::{Database, FileRecord, ParseResult};
 use crate::parser::CodeParser;
-use crate::walker::{discover_files, WalkerConfig};
+use crate::walker::{discover_files, FileEntry, WalkerConfig};
 
 // --- Helper functions for store_file ---
 
@@ -135,12 +135,30 @@ impl Indexer {
         })
     }
 
+    /// Refuse to proceed when explicit include patterns matched nothing.
+    /// Indexing an empty discovery set would treat every previously indexed
+    /// file as deleted and wipe an existing index over what is almost always
+    /// a mistyped pattern.
+    fn check_scoped_discovery(&self, entries: &[FileEntry]) -> io::Result<()> {
+        if entries.is_empty() && self.walker_config.has_scoping_includes() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "include patterns matched no files ({}); refusing to update the index",
+                    self.walker_config.include_patterns.join(", ")
+                ),
+            ));
+        }
+        Ok(())
+    }
+
     /// Index the codebase.
     pub fn index(&mut self) -> io::Result<IndexResult> {
         let start = Instant::now();
 
         // Discover files using the configured walker
         let entries = discover_files(&self.root, &self.walker_config)?;
+        self.check_scoped_discovery(&entries)?;
 
         let mut result = IndexResult {
             files_indexed: 0,
@@ -266,6 +284,7 @@ impl Indexer {
 
         // Discover files using the configured walker
         let entries = discover_files(&self.root, &self.walker_config)?;
+        self.check_scoped_discovery(&entries)?;
 
         // Counters for statistics (atomic for parallel access)
         let files_skipped = AtomicUsize::new(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,10 @@ fn run(args: Args) -> Result<Outcome> {
             ignore_patterns,
             include_patterns,
         }) => {
+            // The global positional patterns (`ctx index src`) scope the
+            // index just like `-p`; a bare `.` is the unscoped default.
+            let include_patterns =
+                commands::merge_include_patterns(args.patterns, include_patterns);
             let config = commands::IndexConfig::new(
                 watch,
                 verbose,

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -450,6 +450,16 @@ pub struct WalkerConfig {
     pub include_patterns: Vec<String>,
 }
 
+impl WalkerConfig {
+    /// Whether the include patterns actually narrow the walk. A lone `.`
+    /// (or `./`) is the CLI's "whole repository" default, not a scope.
+    pub fn has_scoping_includes(&self) -> bool {
+        self.include_patterns
+            .iter()
+            .any(|p| p.trim_end_matches('/') != ".")
+    }
+}
+
 impl Default for WalkerConfig {
     fn default() -> Self {
         Self {
@@ -679,7 +689,7 @@ pub fn discover_files(root: &Path, config: &WalkerConfig) -> io::Result<Vec<File
 
     // A scoped run that selects nothing is almost always a mistyped pattern;
     // say so instead of silently producing an empty result.
-    if entries.is_empty() && !config.include_patterns.is_empty() {
+    if entries.is_empty() && config.has_scoping_includes() {
         eprintln!(
             "Warning: include patterns matched no files: {}",
             config.include_patterns.join(", ")

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -677,6 +677,15 @@ pub fn discover_files(root: &Path, config: &WalkerConfig) -> io::Result<Vec<File
     // Remove duplicates (can happen with overlapping patterns)
     entries.dedup_by(|a, b| a.absolute_path == b.absolute_path);
 
+    // A scoped run that selects nothing is almost always a mistyped pattern;
+    // say so instead of silently producing an empty result.
+    if entries.is_empty() && !config.include_patterns.is_empty() {
+        eprintln!(
+            "Warning: include patterns matched no files: {}",
+            config.include_patterns.join(", ")
+        );
+    }
+
     Ok(entries)
 }
 
@@ -853,6 +862,40 @@ mod tests {
         assert!(!should_include_file(
             root,
             Path::new("/project/tests/test.rs"),
+            &config
+        ));
+        assert!(!should_include_file(
+            root,
+            Path::new("/project/build.rs"),
+            &config
+        ));
+    }
+
+    #[test]
+    fn test_should_include_file_literal_directory() {
+        // A bare directory path (no glob syntax) scopes like `<dir>/**`
+        let root = Path::new("/project");
+        let config = WalkerConfig {
+            use_gitignore: true,
+            use_default_ignores: true,
+            custom_ignores: vec![],
+            include_patterns: vec!["src".to_string()],
+        };
+
+        assert!(should_include_file(
+            root,
+            Path::new("/project/src/main.rs"),
+            &config
+        ));
+        assert!(should_include_file(
+            root,
+            Path::new("/project/src/db/mod.rs"),
+            &config
+        ));
+
+        assert!(!should_include_file(
+            root,
+            Path::new("/project/lib/util.rs"),
             &config
         ));
         assert!(!should_include_file(

--- a/tests/index_cli.rs
+++ b/tests/index_cli.rs
@@ -119,12 +119,51 @@ fn explicit_dot_is_unscoped() {
 }
 
 #[test]
-fn zero_match_pattern_warns() {
+fn zero_match_pattern_errors_on_fresh_index() {
     let temp = fixture();
     let out = ctx(temp.path(), &["index", "nomatch/**"]);
-    assert!(out.status.success());
+    assert!(!out.status.success());
 
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("matched no files"), "stderr: {}", stderr);
-    assert!(stderr.contains("Indexed 0 files"), "stderr: {}", stderr);
+}
+
+#[test]
+fn zero_match_pattern_does_not_wipe_existing_index() {
+    let temp = fixture();
+    let (_, files) = index_and_list(temp.path(), &["index"]);
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+
+    // A typo'd scope must refuse to update rather than treating every
+    // previously indexed file as deleted.
+    let out = ctx(temp.path(), &["index", "nomatch/**"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("refusing to update the index"),
+        "stderr: {}",
+        stderr
+    );
+
+    let list = ctx(temp.path(), &["query", "files"]);
+    assert!(list.status.success());
+    let files = String::from_utf8_lossy(&list.stdout);
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(files.contains("lib/c.rs"), "files: {}", files);
+}
+
+#[test]
+fn default_context_command_does_not_warn_in_empty_repo() {
+    // The default `ctx` command always passes the `.` positional default;
+    // an empty repository must not trigger the scoped zero-match warning.
+    let temp = TempDir::new().expect("create temp dir");
+    GitRepo::init(temp.path());
+
+    let out = ctx(temp.path(), &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("include patterns matched no files"),
+        "stderr: {}",
+        stderr
+    );
 }

--- a/tests/index_cli.rs
+++ b/tests/index_cli.rs
@@ -1,0 +1,130 @@
+//! End-to-end CLI tests for `ctx index` scoping via positional patterns
+//! and `-p/--pattern` (see Linear AGE-13: positional paths were silently
+//! ignored and the whole repository was indexed).
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use ctx::testutil::GitRepo;
+use tempfile::TempDir;
+
+fn ctx(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ctx"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run ctx binary")
+}
+
+/// A repo with Rust files in two top-level directories, so scoping to one
+/// of them is observable in the index contents.
+fn fixture() -> TempDir {
+    let temp = TempDir::new().expect("create temp dir");
+    let repo = GitRepo::init(temp.path());
+    repo.write("src/a.rs", "pub fn alpha() {}\n");
+    repo.write("src/nested/b.rs", "pub fn beta() {}\n");
+    repo.write("lib/c.rs", "pub fn gamma() {}\n");
+    temp
+}
+
+/// Index with the given arguments, then return the `ctx query files` listing.
+fn index_and_list(dir: &Path, index_args: &[&str]) -> (Output, String) {
+    let index_out = ctx(dir, index_args);
+    assert!(
+        index_out.status.success(),
+        "`ctx {}` failed: {}",
+        index_args.join(" "),
+        String::from_utf8_lossy(&index_out.stderr)
+    );
+    let list = ctx(dir, &["query", "files"]);
+    assert!(list.status.success());
+    (index_out, String::from_utf8_lossy(&list.stdout).to_string())
+}
+
+#[test]
+fn positional_directory_scopes_index() {
+    let temp = fixture();
+    let (index_out, files) = index_and_list(temp.path(), &["index", "src"]);
+
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(files.contains("src/nested/b.rs"), "files: {}", files);
+    assert!(!files.contains("lib/c.rs"), "files: {}", files);
+
+    // The banner echoes the effective scope before parsing starts.
+    let stderr = String::from_utf8_lossy(&index_out.stderr);
+    assert!(stderr.contains("scoped to: src"), "stderr: {}", stderr);
+}
+
+#[test]
+fn positional_directory_with_trailing_slash_scopes_index() {
+    let temp = fixture();
+    let (_, files) = index_and_list(temp.path(), &["index", "src/"]);
+
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(!files.contains("lib/c.rs"), "files: {}", files);
+}
+
+#[test]
+fn positional_glob_scopes_index() {
+    let temp = fixture();
+    let (_, files) = index_and_list(temp.path(), &["index", "src/**"]);
+
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(files.contains("src/nested/b.rs"), "files: {}", files);
+    assert!(!files.contains("lib/c.rs"), "files: {}", files);
+}
+
+#[test]
+fn pattern_flag_literal_directory_scopes_index() {
+    let temp = fixture();
+    let (_, files) = index_and_list(temp.path(), &["index", "-p", "src"]);
+
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(files.contains("src/nested/b.rs"), "files: {}", files);
+    assert!(!files.contains("lib/c.rs"), "files: {}", files);
+}
+
+#[test]
+fn positional_and_flag_patterns_combine() {
+    let temp = fixture();
+    let (_, files) = index_and_list(temp.path(), &["index", "lib", "-p", "src/**"]);
+
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(files.contains("src/nested/b.rs"), "files: {}", files);
+    assert!(files.contains("lib/c.rs"), "files: {}", files);
+}
+
+#[test]
+fn no_patterns_index_everything() {
+    let temp = fixture();
+    let (index_out, files) = index_and_list(temp.path(), &["index"]);
+
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(files.contains("lib/c.rs"), "files: {}", files);
+
+    let stderr = String::from_utf8_lossy(&index_out.stderr);
+    assert!(!stderr.contains("scoped to"), "stderr: {}", stderr);
+}
+
+#[test]
+fn explicit_dot_is_unscoped() {
+    let temp = fixture();
+    let (index_out, files) = index_and_list(temp.path(), &["index", "."]);
+
+    assert!(files.contains("src/a.rs"), "files: {}", files);
+    assert!(files.contains("lib/c.rs"), "files: {}", files);
+
+    let stderr = String::from_utf8_lossy(&index_out.stderr);
+    assert!(!stderr.contains("scoped to"), "stderr: {}", stderr);
+}
+
+#[test]
+fn zero_match_pattern_warns() {
+    let temp = fixture();
+    let out = ctx(temp.path(), &["index", "nomatch/**"]);
+    assert!(out.status.success());
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("matched no files"), "stderr: {}", stderr);
+    assert!(stderr.contains("Indexed 0 files"), "stderr: {}", stderr);
+}


### PR DESCRIPTION
Fixes Linear [AGE-13](https://linear.app/itkonsult/issue/AGE-13/ctx-index-bare-p-src-positional-src-silently-indexes-the-whole-repo): `ctx index src` silently indexed the whole repository.

## Root cause

The global positional `patterns` argument (`#[arg(default_value = ".", global = true)]`) parses `ctx index src` without error, but the `Command::Index` dispatch never forwarded `args.patterns` — only `-p/--pattern` reached the walker. With an empty include list, `discover_files` takes its walk-everything branch. This is the same "positional patterns accepted but ignored" family as #57 (that issue's `smart`/`similar`/`diff` handlers remain out of scope here).

Note: the issue also reports `ctx index -p src` indexing everything. That does not reproduce against 0.3.5 or main — literal directory paths already scope correctly through the walker's literal-path branch (verified empirically with both binaries). Only the positional form was broken.

## Changes

- **Positional patterns now scope the index** exactly like `-p`: `merge_include_patterns` combines both, treating the bare `.` default (and `./`) as unscoped.
- **The indexing banner echoes the effective scope** (`Indexing codebase (scoped to: src)...`) so a mis-scoped run is visible before the expensive parse phase.
- **File discovery warns when scoping patterns match zero files** (the issue's second proposed remedy). The lone-`.` default used by the context command and MCP file tools does not trigger it.
- **Zero-match scopes refuse to update the index** (operational error, exit 2). Found during adversarial review of this change: proceeding with an empty discovery set treats every previously indexed file as deleted, so a typo like `ctx index sr` (or pre-existing `-p typo/**`) silently emptied an existing index with exit 0.

## Compatibility

- No CLI surface change: `governance/contracts/cli.json` snapshot unchanged (verified by `check-contracts.py`). No version bump per policy.
- Human-readable stderr additions only; no JSON output changes.
- Behavioral: `ctx index <zero-match-scope>` previously exited 0 with an emptied index; it now exits 2 without touching the database. Exit-code meanings are unchanged (2 = operational error), but this success→failure transition is why the `contract-review` label is applied — it needs a human SemVer judgment, which the snapshot check cannot make.
- Changelog: categorized entry added under Unreleased → Fixed.

## Tests

- 10 new end-to-end CLI tests (`tests/index_cli.rs`): literal dir, trailing slash, glob, `-p` literal, positional+flag merge, unscoped defaults, zero-match error, index-wipe protection, no spurious warning from the default command.
- Unit tests for `merge_include_patterns` and literal-directory `FileFilter` scoping.
- `scripts/ci.sh` passes end-to-end (governance, versioning tests, fmt, clippy all-features, both test suites, release build, version + contract checks, publish dry-runs).

## Remaining human review

- Confirm the zero-match refusal semantics (error vs. warn-and-proceed) — deliberate choice to protect existing indexes.
- Docs note: scoped indexing prunes out-of-scope files from an existing index (pre-existing `-p` semantic, now easier to reach); called out here rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)