### PR TITLE
feat: add LSP registry client and config writer (AGE-10 groundwork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Completed the first cookbook set with a release-health reporting workflow that combines immutable comparisons, provenance, normalized metrics, focused investigations, uncertainty, and owned actions.
 
 ### Internal
+- Added an internal LSP registry client (`lsp_registry`) and a format-preserving
+  `.ctx/config.toml` writer (`config_edit`) as groundwork for the future `ctx lsp`
+  commands. Internal only: no CLI surface, config contract, or documented behavior
+  changes yet.
 - Made the local CI and canonical plugin lockstep checks honor Cargo's configured target directory while validating the standalone downloadable ctx skill against its harness template.
 - Constrained fastembed to the last ONNX Runtime dependency line that still publishes Intel macOS binaries.
 - Supplied the Debian source stanza required for release-package dependency discovery.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "toml",
+ "toml_edit",
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-javascript",
@@ -4747,6 +4748,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ solang-parser = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"
+# Format-preserving edits to .ctx/config.toml (already in the dependency
+# graph transitively via toml)
+toml_edit = "0.25"
 
 # RFC3339 timestamps for JSON output envelopes
 time = { version = "0.3", features = ["formatting", "parsing"] }

--- a/perf/Cargo.lock
+++ b/perf/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "notify",
  "notify-debouncer-mini",
  "rayon",
- "reqwest",
+ "reqwest 0.13.4",
  "rusqlite",
  "rustyline",
  "semver",
@@ -31,18 +31,19 @@ dependencies = [
  "solang-parser",
  "sqlite-vec",
  "tar",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tiktoken-rs",
  "time",
  "tokio",
  "toml",
+ "toml_edit",
  "tree-sitter",
  "tree-sitter-go",
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "zerocopy 0.7.35",
+ "zerocopy",
  "zip",
 ]
 
@@ -57,7 +58,7 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
- "zerocopy 0.8.54",
+ "zerocopy",
 ]
 
 [[package]]
@@ -95,6 +96,12 @@ checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -163,9 +170,6 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -258,6 +262,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,7 +308,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -291,16 +327,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -319,11 +355,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -390,13 +426,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -410,6 +447,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ciborium"
@@ -488,6 +536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +555,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -516,15 +583,49 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -555,9 +656,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -607,15 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,12 +740,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -728,17 +819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,11 +851,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -833,6 +914,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "endian-type"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "equator"
@@ -929,7 +1025,7 @@ dependencies = [
  "num-complex",
  "pulp",
  "rayon-core",
- "smallvec 1.15.2",
+ "smallvec",
  "zune-inflate",
 ]
 
@@ -947,26 +1043,28 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
 
 [[package]]
 name = "fastembed"
-version = "5.4.0"
+version = "5.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d719825156b62586040fd0e5653a4f7bc0ad9caf6c7ec38cb18f1a08ee0384"
+checksum = "545e4fb17fc48768ff36c2a3854aa5b0b809d0ed595ab5530fa8ac94f31bd0ea"
 dependencies = [
  "anyhow",
  "hf-hub",
  "image",
  "ndarray",
  "ort",
+ "safetensors",
+ "serde",
  "serde_json",
  "tokenizers",
 ]
@@ -982,17 +1080,6 @@ name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fdeflate"
@@ -1012,6 +1099,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1037,6 +1130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1158,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1131,24 +1236,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1170,8 +1267,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1224,7 +1324,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.54",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1234,6 +1334,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1259,9 +1372,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
  "http",
@@ -1270,13 +1383,19 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq 2.12.1",
- "windows-sys 0.60.2",
+ "ureq",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "home"
@@ -1327,6 +1446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,7 +1470,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec 1.15.2",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -1440,7 +1568,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.2",
+ "smallvec",
  "zerovec",
 ]
 
@@ -1498,7 +1626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.2",
+ "smallvec",
  "utf8_iter",
 ]
 
@@ -1580,24 +1708,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -1677,6 +1805,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,7 +1890,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "libc",
 ]
 
@@ -1724,7 +1901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
@@ -1814,6 +1991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +2019,18 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1903,23 +2098,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1975,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -2000,16 +2184,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "smallvec 1.15.2",
+ "smallvec",
 ]
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2051,32 +2235,41 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.0",
- "crossbeam-channel",
- "filetime",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "notify-debouncer-mini"
-version = "0.4.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
 dependencies = [
- "crossbeam-channel",
  "log",
  "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2146,12 +2339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,7 +2356,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2197,7 +2384,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2242,27 +2429,26 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "ndarray",
  "ort-sys",
- "smallvec 2.0.0-alpha.10",
+ "smallvec",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
- "flate2",
- "pkg-config",
- "sha2",
- "tar",
- "ureq 3.3.0",
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
 ]
 
 [[package]]
@@ -2294,7 +2480,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.2",
+ "smallvec",
  "windows-link",
 ]
 
@@ -2423,7 +2609,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2466,7 +2652,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.54",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2548,6 +2734,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,9 +2813,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radix_trie"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
  "endian-type",
  "nibble_vec",
@@ -2598,6 +2841,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2874,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2678,7 +2947,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2730,7 +2999,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2793,7 +3062,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -2829,6 +3097,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,19 +3164,28 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cdbe9230a57259b37f7257d0aff38b8c9dbda3513edba2105e59b130189d82f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec 1.15.2",
+ "smallvec",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2874,7 +3193,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2887,6 +3206,7 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2897,13 +3217,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2911,6 +3271,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2924,14 +3285,13 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustyline"
-version = "17.0.2"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "clipboard-win",
- "fd-lock",
  "home",
  "libc",
  "log",
@@ -2941,7 +3301,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2949,6 +3309,19 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "same-file"
@@ -2980,7 +3353,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3039,6 +3412,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3048,11 +3422,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3069,9 +3443,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3079,10 +3453,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -3092,6 +3482,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3110,12 +3506,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "smallvec"
-version = "2.0.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
 
 [[package]]
 name = "socket2"
@@ -3186,6 +3576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,7 +3642,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3279,7 +3675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3352,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3425,6 +3821,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,7 +3876,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.1",
+ "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -3518,44 +3929,55 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3578,7 +4000,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -3623,62 +4045,72 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.20.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.20.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d015c02ea98b62c806f7329ff71c383286dfc3a7a7da0cc484f6e42922f73c2c"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-python"
-version = "0.20.4"
+name = "tree-sitter-language"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c93b1b1fbd0d399db3445f51fd3058e43d0b4dcff62ddbdb46e66550978aa5"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.20.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -3686,6 +4118,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -3705,7 +4143,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
- "smallvec 1.15.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -3733,30 +4171,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "native-tls",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.11",
-]
 
 [[package]]
 name = "ureq"
@@ -3765,15 +4189,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "der",
+ "flate2",
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "socks",
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3974,15 +4404,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
@@ -4064,27 +4485,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4105,21 +4508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4157,12 +4545,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4175,12 +4557,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4190,12 +4566,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4223,12 +4593,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4238,12 +4602,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4259,12 +4617,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4274,12 +4626,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4295,9 +4641,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -4355,32 +4701,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
- "zerocopy-derive 0.8.54",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4456,15 +4781,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "6.0.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
  "flate2",
  "indexmap",
  "memchr",
+ "typed-path",
  "zopfli",
 ]
 

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -1,0 +1,390 @@
+//! Format-preserving writes to `.ctx/config.toml`.
+//!
+//! [`crate::config`] *reads* the project config with plain serde; this module
+//! *writes* it using `toml_edit` so comments, formatting, and unknown keys the
+//! current binary does not understand all survive round-trips.
+//!
+//! The only writer today manages `[lsp.<lang>]` tables installed from the
+//! community LSP registry ([`crate::lsp_registry`]). Registry-owned tables are
+//! marked with `source = "registry"` / `source_server = "<name>"` provenance
+//! keys so a future `ctx lsp update` can tell curated entries apart from
+//! hand-written ones.
+//!
+//! This module is internal groundwork for the future `ctx lsp` commands; it
+//! has no CLI surface yet.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use toml_edit::{value, Array, DocumentMut, Item, Table};
+
+use crate::config::CONFIG_FILE;
+use crate::error::{CtxError, Result};
+use crate::index::CTX_DIR;
+use crate::lsp_registry::{LanguageEntry, ServerSpec};
+
+/// Provenance value marking a `[lsp.<lang>]` table as registry-managed.
+pub const SOURCE_REGISTRY: &str = "registry";
+
+/// One `[lsp.<lang>]` table as written to `.ctx/config.toml`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LspConfigEntry {
+    /// Language-server executable.
+    pub command: String,
+    /// Arguments passed to the command.
+    pub args: Vec<String>,
+    /// File extensions (without dots) the server applies to.
+    pub extensions: Vec<String>,
+    /// Project-root marker files.
+    pub root_markers: Vec<String>,
+    /// LSP capabilities ctx relies on.
+    pub capabilities: Vec<String>,
+    /// Intelligence backend; defaults to `"hybrid"` (tree-sitter + LSP).
+    pub backend: String,
+    /// Provenance: `"registry"` for registry-installed entries.
+    pub source: String,
+    /// Provenance: registry server name the entry was installed from.
+    pub source_server: String,
+}
+
+impl Default for LspConfigEntry {
+    fn default() -> Self {
+        LspConfigEntry {
+            command: String::new(),
+            args: Vec::new(),
+            extensions: Vec::new(),
+            root_markers: Vec::new(),
+            capabilities: Vec::new(),
+            backend: "hybrid".to_string(),
+            source: String::new(),
+            source_server: String::new(),
+        }
+    }
+}
+
+/// Map a registry language entry + chosen server to a config entry
+/// (backend `"hybrid"`, provenance `source = "registry"`).
+pub fn from_registry(entry: &LanguageEntry, server: &ServerSpec) -> LspConfigEntry {
+    LspConfigEntry {
+        command: server.command.clone(),
+        args: server.args.clone(),
+        extensions: entry.extensions.clone(),
+        root_markers: entry.root_markers.clone(),
+        capabilities: server.capabilities.clone(),
+        backend: "hybrid".to_string(),
+        source: SOURCE_REGISTRY.to_string(),
+        source_server: server.name.clone(),
+    }
+}
+
+/// Insert or replace `[lsp.<lang>]` in `<root>/.ctx/config.toml`.
+///
+/// Creates `.ctx/` and the config file when absent. Everything outside the
+/// touched table — comments, formatting, unknown keys, other `[lsp.*]`
+/// tables — is preserved byte-for-byte. The file is written atomically
+/// (temp file in `.ctx/` + rename).
+pub fn upsert_lsp_entry(root: &Path, lang: &str, entry: &LspConfigEntry) -> Result<()> {
+    let path = config_path(root);
+    fs::create_dir_all(path.parent().expect("config path has a parent"))?;
+    let mut doc = load_document(&path)?;
+
+    let lsp = lsp_table_mut(&mut doc, &path)?;
+    lsp.insert(lang, Item::Table(entry_table(entry)));
+
+    write_atomic(&path, doc.to_string().as_bytes())
+}
+
+/// Remove `[lsp.<lang>]` from `<root>/.ctx/config.toml` if present.
+/// Returns `true` when an entry was removed. A missing file is a no-op.
+pub fn remove_lsp_entry(root: &Path, lang: &str) -> Result<bool> {
+    let path = config_path(root);
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut doc = load_document(&path)?;
+    let removed = match doc.get_mut("lsp").and_then(Item::as_table_mut) {
+        Some(lsp) => lsp.remove(lang).is_some(),
+        None => false,
+    };
+    if removed {
+        write_atomic(&path, doc.to_string().as_bytes())?;
+    }
+    Ok(removed)
+}
+
+/// Languages under `[lsp]` whose tables are registry-managed
+/// (`source = "registry"`), in file order. Missing file yields an empty list.
+pub fn registry_owned_languages(root: &Path) -> Result<Vec<String>> {
+    let path = config_path(root);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let doc = load_document(&path)?;
+    let mut owned = Vec::new();
+    if let Some(lsp) = doc.get("lsp").and_then(Item::as_table) {
+        for (lang, item) in lsp.iter() {
+            let source = item
+                .as_table_like()
+                .and_then(|t| t.get("source"))
+                .and_then(Item::as_str);
+            if source == Some(SOURCE_REGISTRY) {
+                owned.push(lang.to_string());
+            }
+        }
+    }
+    Ok(owned)
+}
+
+fn config_path(root: &Path) -> PathBuf {
+    root.join(CTX_DIR).join(CONFIG_FILE)
+}
+
+fn load_document(path: &Path) -> Result<DocumentMut> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e.into()),
+    };
+    text.parse::<DocumentMut>().map_err(|e| {
+        CtxError::Other(format!(
+            "cannot edit {}: file is not valid TOML ({e})",
+            path.display()
+        ))
+    })
+}
+
+/// Get (or create) the `[lsp]` table, kept implicit so only `[lsp.<lang>]`
+/// headers appear in the file.
+fn lsp_table_mut<'a>(doc: &'a mut DocumentMut, path: &Path) -> Result<&'a mut Table> {
+    let item = doc.entry("lsp").or_insert(Item::Table(Table::new()));
+    let table = item.as_table_mut().ok_or_else(|| {
+        CtxError::Other(format!(
+            "cannot edit {}: existing 'lsp' key is not a table",
+            path.display()
+        ))
+    })?;
+    table.set_implicit(true);
+    Ok(table)
+}
+
+/// Build the `[lsp.<lang>]` table with the canonical key order.
+fn entry_table(entry: &LspConfigEntry) -> Table {
+    let mut table = Table::new();
+    table["command"] = value(&entry.command);
+    table["args"] = string_array(&entry.args);
+    table["extensions"] = string_array(&entry.extensions);
+    table["root_markers"] = string_array(&entry.root_markers);
+    table["capabilities"] = string_array(&entry.capabilities);
+    table["backend"] = value(&entry.backend);
+    table["source"] = value(&entry.source);
+    table["source_server"] = value(&entry.source_server);
+    table
+}
+
+fn string_array(items: &[String]) -> Item {
+    let mut array = Array::new();
+    for item in items {
+        array.push(item.as_str());
+    }
+    value(array)
+}
+
+/// Atomically replace `path` with `data`: write to a temp file in the same
+/// directory, then rename over the target (pattern shared with the
+/// self-update binary swap).
+fn write_atomic(path: &Path, data: &[u8]) -> Result<()> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| CtxError::Other("config path has no parent directory".to_string()))?;
+    let staged = dir.join(format!(".config-toml-staged-{}", std::process::id()));
+    if let Err(e) = fs::write(&staged, data) {
+        let _ = fs::remove_file(&staged);
+        return Err(e.into());
+    }
+    // On Windows, rename cannot replace an existing file.
+    if cfg!(windows) && path.exists() {
+        let _ = fs::remove_file(path);
+    }
+    if let Err(e) = fs::rename(&staged, path) {
+        let _ = fs::remove_file(&staged);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry() -> LspConfigEntry {
+        LspConfigEntry {
+            command: "pyright-langserver".to_string(),
+            args: vec!["--stdio".to_string()],
+            extensions: vec!["py".to_string(), "pyi".to_string()],
+            root_markers: vec!["pyproject.toml".to_string(), ".git".to_string()],
+            capabilities: vec!["documentSymbol".to_string(), "references".to_string()],
+            source_server: "pyright".to_string(),
+            source: SOURCE_REGISTRY.to_string(),
+            ..LspConfigEntry::default()
+        }
+    }
+
+    const PYTHON_TABLE: &str = r#"[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+extensions = ["py", "pyi"]
+root_markers = ["pyproject.toml", ".git"]
+capabilities = ["documentSymbol", "references"]
+backend = "hybrid"
+source = "registry"
+source_server = "pyright"
+"#;
+
+    #[test]
+    fn creates_config_from_scratch() {
+        let dir = tempfile::tempdir().unwrap();
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        let text = fs::read_to_string(config_path(dir.path())).unwrap();
+        assert_eq!(text, PYTHON_TABLE);
+    }
+
+    #[test]
+    fn preserves_comments_and_unrelated_tables() {
+        let existing = r#"# Team defaults — do not remove.
+[embedding]
+provider = "ollama"   # local | openai | ollama
+model = "qwen3-embedding:8b"
+
+[future_section]
+whatever = true
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, existing).unwrap();
+
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        // Everything outside the touched table is preserved byte-for-byte.
+        assert_eq!(text, format!("{existing}\n{PYTHON_TABLE}"));
+    }
+
+    #[test]
+    fn overwrites_existing_entry_with_canonical_key_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "[lsp.python]\nsource = \"registry\"\ncommand = \"old-server\"\nstale_key = 1\n",
+        )
+        .unwrap();
+
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        assert_eq!(text, PYTHON_TABLE);
+        assert!(!text.contains("old-server"));
+        assert!(!text.contains("stale_key"));
+    }
+
+    #[test]
+    fn upsert_keeps_other_lsp_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut go = sample_entry();
+        go.command = "gopls".to_string();
+        go.args = vec![];
+        go.source_server = "gopls".to_string();
+        upsert_lsp_entry(dir.path(), "go", &go).unwrap();
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+
+        let text = fs::read_to_string(config_path(dir.path())).unwrap();
+        assert!(text.contains("[lsp.go]"));
+        assert!(text.contains("[lsp.python]"));
+        // No explicit bare [lsp] header is emitted.
+        assert!(!text.contains("[lsp]\n"));
+    }
+
+    #[test]
+    fn registry_owned_languages_filters_on_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"[lsp.python]
+command = "pyright-langserver"
+source = "registry"
+
+[lsp.go]
+command = "gopls"
+
+[lsp.rust]
+command = "rust-analyzer"
+source = "manual"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(registry_owned_languages(dir.path()).unwrap(), ["python"]);
+    }
+
+    #[test]
+    fn registry_owned_languages_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(registry_owned_languages(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn remove_lsp_entry_removes_and_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        assert!(remove_lsp_entry(dir.path(), "python").unwrap());
+        assert!(!remove_lsp_entry(dir.path(), "python").unwrap());
+        let text = fs::read_to_string(config_path(dir.path())).unwrap();
+        assert!(!text.contains("[lsp.python]"));
+        // Missing file is a no-op.
+        let empty = tempfile::tempdir().unwrap();
+        assert!(!remove_lsp_entry(empty.path(), "python").unwrap());
+    }
+
+    #[test]
+    fn write_is_atomic_no_temp_file_left_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        let ctx_dir = dir.path().join(CTX_DIR);
+        let leftovers: Vec<_> = fs::read_dir(&ctx_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(".config-toml-staged-"))
+            .collect();
+        assert!(leftovers.is_empty(), "staged files left: {leftovers:?}");
+        assert!(ctx_dir.join(CONFIG_FILE).exists());
+    }
+
+    #[test]
+    fn malformed_existing_config_is_an_error_not_a_clobber() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "this is not : valid toml : :").unwrap();
+
+        let err = upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap_err();
+        assert!(err.to_string().contains("not valid TOML"), "{err}");
+        // Original contents untouched.
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "this is not : valid toml : :"
+        );
+    }
+
+    #[test]
+    fn non_table_lsp_key_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "lsp = 3\n").unwrap();
+
+        let err = upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap_err();
+        assert!(err.to_string().contains("not a table"), "{err}");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,12 @@ pub mod tree;
 // Project configuration (.ctx/config.toml)
 pub mod config;
 
+// Format-preserving writes to .ctx/config.toml (toml_edit)
+pub mod config_edit;
+
+// Community LSP server registry client (groundwork for `ctx lsp`)
+pub mod lsp_registry;
+
 // Architecture rules (ctx check)
 pub mod check;
 pub mod rules;

--- a/src/lsp_registry.rs
+++ b/src/lsp_registry.rs
@@ -1,0 +1,453 @@
+//! Client for the community LSP server registry (`agentis-tools/ctx-lsp-registry`).
+//!
+//! The registry is a separate repository hosting curated language-server
+//! entries as TOML. ctx fetches raw files over HTTPS from a pinned `v1`
+//! branch:
+//!
+//! - `{base}/index.toml` — the language index ([`RegistryIndex`])
+//! - `{base}/registry/{lang}.toml` — one entry per language ([`LanguageEntry`])
+//!
+//! The base URL can be overridden with the `CTX_LSP_REGISTRY_BASE_URL`
+//! environment variable (a test hook, also usable for mirrors). It is
+//! deliberately *not* a config key: the registry location is a distribution
+//! concern, not a per-project setting.
+//!
+//! This module is internal groundwork for the future `ctx lsp` commands; it
+//! has no CLI surface yet.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::error::{CtxError, Result};
+
+/// Raw-file base URL of the pinned `v1` branch of the registry repository.
+pub const DEFAULT_REGISTRY_BASE_URL: &str =
+    "https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1";
+
+/// The registry manifest schema version this ctx build understands.
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 1;
+
+/// Network timeout for registry fetches (small TOML files).
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Registry base URL, overridable via `CTX_LSP_REGISTRY_BASE_URL` (test
+/// hook / mirrors; deliberately not a config key).
+pub fn registry_base_url() -> String {
+    resolve_base_url(std::env::var("CTX_LSP_REGISTRY_BASE_URL").ok())
+}
+
+/// Pure resolution helper behind [`registry_base_url`], unit-testable without
+/// mutating process environment.
+fn resolve_base_url(env_override: Option<String>) -> String {
+    match env_override {
+        Some(url) if !url.trim().is_empty() => url,
+        _ => DEFAULT_REGISTRY_BASE_URL.to_string(),
+    }
+}
+
+fn http_client(timeout: Duration) -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .user_agent(concat!("ctx/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(CtxError::Network)
+}
+
+// ============================================================================
+// Manifest model
+// ============================================================================
+
+/// `index.toml`: the set of languages the registry covers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistryIndex {
+    /// Manifest schema version (must equal [`SUPPORTED_SCHEMA_VERSION`]).
+    pub schema_version: u32,
+    /// Language name -> summary. `BTreeMap` keeps listings deterministic.
+    #[serde(default)]
+    pub languages: BTreeMap<String, IndexLanguage>,
+}
+
+/// One `[languages.<name>]` row in `index.toml`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IndexLanguage {
+    /// Name of the recommended server for this language.
+    pub recommended: String,
+    /// All server names available in the language entry.
+    #[serde(default)]
+    pub servers: Vec<String>,
+}
+
+/// `registry/<lang>.toml`: full entry for one language.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LanguageEntry {
+    /// Manifest schema version (must equal [`SUPPORTED_SCHEMA_VERSION`]).
+    pub schema_version: u32,
+    /// Language name (matches the file name and the index key).
+    pub language: String,
+    /// File extensions (without dots) the language servers apply to.
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    /// Project-root marker files used to locate the workspace root.
+    #[serde(default)]
+    pub root_markers: Vec<String>,
+    /// Available servers; exactly one must be `recommended = true`.
+    #[serde(default)]
+    pub servers: Vec<ServerSpec>,
+}
+
+/// One `[[servers]]` block in a language entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerSpec {
+    /// Unique server name within the language entry (e.g. `pyright`).
+    pub name: String,
+    /// Whether this is the curated default for the language.
+    #[serde(default)]
+    pub recommended: bool,
+    /// Executable to spawn (must be non-empty).
+    pub command: String,
+    /// Arguments passed to the command.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// LSP capabilities ctx relies on (e.g. `documentSymbol`, `references`).
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Project homepage, if any.
+    #[serde(default)]
+    pub homepage: Option<String>,
+    /// Free-form curator notes.
+    #[serde(default)]
+    pub notes: Option<String>,
+    /// Install hints keyed by OS, with a required default.
+    #[serde(default)]
+    pub install: Option<InstallHints>,
+}
+
+/// `[servers.install]`: per-OS install commands falling back to `default`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InstallHints {
+    /// Fallback install command for any OS without a specific key.
+    pub default: String,
+    /// macOS-specific install command.
+    #[serde(default)]
+    pub macos: Option<String>,
+    /// Linux-specific install command.
+    #[serde(default)]
+    pub linux: Option<String>,
+    /// Windows-specific install command.
+    #[serde(default)]
+    pub windows: Option<String>,
+}
+
+impl LanguageEntry {
+    /// Select a server by name, or the recommended one when `name` is `None`.
+    pub fn server(&self, name: Option<&str>) -> Result<&ServerSpec> {
+        match name {
+            Some(name) => self.servers.iter().find(|s| s.name == name).ok_or_else(|| {
+                CtxError::Other(format!(
+                    "language '{}' has no server named '{name}' in the LSP registry \
+                     (available: {})",
+                    self.language,
+                    self.server_names().join(", ")
+                ))
+            }),
+            None => self.servers.iter().find(|s| s.recommended).ok_or_else(|| {
+                CtxError::Other(format!(
+                    "registry entry for '{}' has no recommended server",
+                    self.language
+                ))
+            }),
+        }
+    }
+
+    fn server_names(&self) -> Vec<&str> {
+        self.servers.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    /// Validate invariants beyond what serde enforces.
+    fn validate(&self, what: &str) -> Result<()> {
+        validate_schema_version(self.schema_version, what)?;
+        let recommended = self.servers.iter().filter(|s| s.recommended).count();
+        if recommended != 1 {
+            return Err(CtxError::Other(format!(
+                "{what} must mark exactly one server as recommended, found {recommended}"
+            )));
+        }
+        for server in &self.servers {
+            if server.name.trim().is_empty() {
+                return Err(CtxError::Other(format!(
+                    "{what} contains a server with an empty name"
+                )));
+            }
+            if server.command.trim().is_empty() {
+                return Err(CtxError::Other(format!(
+                    "{what}: server '{}' has an empty command",
+                    server.name
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The install hint matching the current OS, falling back to `default`.
+/// `None` when the server ships no install section at all.
+pub fn install_hint_for_current_os(server: &ServerSpec) -> Option<&str> {
+    install_hint_for_os(server, std::env::consts::OS)
+}
+
+fn install_hint_for_os<'a>(server: &'a ServerSpec, os: &str) -> Option<&'a str> {
+    let install = server.install.as_ref()?;
+    let os_specific = match os {
+        "macos" => install.macos.as_deref(),
+        "linux" => install.linux.as_deref(),
+        "windows" => install.windows.as_deref(),
+        _ => None,
+    };
+    Some(os_specific.unwrap_or(&install.default))
+}
+
+fn validate_schema_version(found: u32, what: &str) -> Result<()> {
+    if found != SUPPORTED_SCHEMA_VERSION {
+        return Err(CtxError::Other(format!(
+            "{what} uses registry schema_version {found}, but this ctx build supports \
+             version {SUPPORTED_SCHEMA_VERSION}; the registry entry requires a newer ctx — \
+             upgrade ctx or pin the registry to a compatible branch"
+        )));
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Parsing (pure; also used by the fetch functions below)
+// ============================================================================
+
+/// Parse and validate `index.toml` contents.
+pub fn parse_index(text: &str) -> Result<RegistryIndex> {
+    let index: RegistryIndex = toml::from_str(text)
+        .map_err(|e| CtxError::Other(format!("malformed registry index.toml: {e}")))?;
+    validate_schema_version(index.schema_version, "registry index.toml")?;
+    Ok(index)
+}
+
+/// Parse and validate a `registry/<lang>.toml` entry.
+pub fn parse_language(text: &str, lang: &str) -> Result<LanguageEntry> {
+    let what = format!("registry entry for '{lang}'");
+    let entry: LanguageEntry =
+        toml::from_str(text).map_err(|e| CtxError::Other(format!("malformed {what}: {e}")))?;
+    entry.validate(&what)?;
+    Ok(entry)
+}
+
+// ============================================================================
+// Fetching
+// ============================================================================
+
+/// Fetch and validate `{base}/index.toml`.
+pub fn fetch_index(base: &str) -> Result<RegistryIndex> {
+    let url = format!("{}/index.toml", base.trim_end_matches('/'));
+    parse_index(&fetch_text(&url, "registry index")?)
+}
+
+/// Fetch and validate `{base}/registry/{lang}.toml`.
+///
+/// A 404 means the language is not in the registry; the error says so
+/// explicitly (callers can print available languages from [`fetch_index`]).
+pub fn fetch_language(base: &str, lang: &str) -> Result<LanguageEntry> {
+    let url = format!("{}/registry/{lang}.toml", base.trim_end_matches('/'));
+    let client = http_client(FETCH_TIMEOUT)?;
+    let response = client.get(&url).send()?;
+    let status = response.status();
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Err(CtxError::Other(format!(
+            "language '{lang}' is unknown to the LSP registry ({url} returned HTTP 404); \
+             run against the registry index to list available languages"
+        )));
+    }
+    if !status.is_success() {
+        return Err(CtxError::Other(format!(
+            "LSP registry fetch failed: {url} returned HTTP {status}"
+        )));
+    }
+    parse_language(&response.text()?, lang)
+}
+
+fn fetch_text(url: &str, what: &str) -> Result<String> {
+    let client = http_client(FETCH_TIMEOUT)?;
+    let response = client.get(url).send()?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(CtxError::Other(format!(
+            "{what} fetch failed: {url} returned HTTP {status}"
+        )));
+    }
+    Ok(response.text()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOOD_INDEX: &str = r#"
+schema_version = 1
+
+[languages.python]
+recommended = "pyright"
+servers = ["pyright"]
+
+[languages.go]
+recommended = "gopls"
+servers = ["gopls"]
+"#;
+
+    const GOOD_PYTHON: &str = r#"
+schema_version = 1
+language = "python"
+extensions = ["py", "pyi"]
+root_markers = ["pyproject.toml", "setup.py", "setup.cfg", ".git"]
+
+[[servers]]
+name = "pyright"
+recommended = true
+command = "pyright-langserver"
+args = ["--stdio"]
+capabilities = ["documentSymbol", "references", "callHierarchy"]
+homepage = "https://github.com/microsoft/pyright"
+notes = "Fast, actively maintained."
+
+[servers.install]
+default = "npm install -g pyright"
+macos = "brew install pyright"
+
+[[servers]]
+name = "pylsp"
+recommended = false
+command = "pylsp"
+
+[servers.install]
+default = "pip install python-lsp-server"
+"#;
+
+    #[test]
+    fn parses_good_index() {
+        let index = parse_index(GOOD_INDEX).unwrap();
+        assert_eq!(index.schema_version, 1);
+        assert_eq!(index.languages.len(), 2);
+        let python = &index.languages["python"];
+        assert_eq!(python.recommended, "pyright");
+        assert_eq!(python.servers, vec!["pyright"]);
+    }
+
+    #[test]
+    fn parses_good_language_entry() {
+        let entry = parse_language(GOOD_PYTHON, "python").unwrap();
+        assert_eq!(entry.language, "python");
+        assert_eq!(entry.extensions, vec!["py", "pyi"]);
+        assert_eq!(entry.root_markers.len(), 4);
+        assert_eq!(entry.servers.len(), 2);
+
+        let recommended = entry.server(None).unwrap();
+        assert_eq!(recommended.name, "pyright");
+        assert_eq!(recommended.command, "pyright-langserver");
+        assert_eq!(recommended.args, vec!["--stdio"]);
+        assert_eq!(
+            recommended.capabilities,
+            vec!["documentSymbol", "references", "callHierarchy"]
+        );
+
+        let named = entry.server(Some("pylsp")).unwrap();
+        assert_eq!(named.command, "pylsp");
+
+        let err = entry.server(Some("nope")).unwrap_err().to_string();
+        assert!(err.contains("no server named 'nope'"), "{err}");
+        assert!(err.contains("pyright, pylsp"), "{err}");
+    }
+
+    #[test]
+    fn rejects_wrong_schema_version() {
+        let text = GOOD_PYTHON.replace("schema_version = 1", "schema_version = 2");
+        let err = parse_language(&text, "python").unwrap_err().to_string();
+        assert!(err.contains("upgrade ctx"), "{err}");
+
+        let text = GOOD_INDEX.replace("schema_version = 1", "schema_version = 99");
+        let err = parse_index(&text).unwrap_err().to_string();
+        assert!(err.contains("upgrade ctx"), "{err}");
+    }
+
+    #[test]
+    fn rejects_zero_recommended_servers() {
+        let text = GOOD_PYTHON.replace("recommended = true", "recommended = false");
+        let err = parse_language(&text, "python").unwrap_err().to_string();
+        assert!(err.contains("exactly one server"), "{err}");
+        assert!(err.contains("found 0"), "{err}");
+    }
+
+    #[test]
+    fn rejects_two_recommended_servers() {
+        let text = GOOD_PYTHON.replace("recommended = false", "recommended = true");
+        let err = parse_language(&text, "python").unwrap_err().to_string();
+        assert!(err.contains("exactly one server"), "{err}");
+        assert!(err.contains("found 2"), "{err}");
+    }
+
+    #[test]
+    fn rejects_empty_command() {
+        let text = GOOD_PYTHON.replace("command = \"pylsp\"", "command = \"\"");
+        let err = parse_language(&text, "python").unwrap_err().to_string();
+        assert!(err.contains("empty command"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_command() {
+        let text = GOOD_PYTHON.replace("command = \"pylsp\"\n", "");
+        let err = parse_language(&text, "python").unwrap_err().to_string();
+        assert!(err.contains("malformed"), "{err}");
+        assert!(err.contains("command"), "{err}");
+    }
+
+    #[test]
+    fn install_hint_prefers_current_os_and_falls_back_to_default() {
+        let entry = parse_language(GOOD_PYTHON, "python").unwrap();
+        let pyright = entry.server(Some("pyright")).unwrap();
+        assert_eq!(
+            install_hint_for_os(pyright, "macos"),
+            Some("brew install pyright")
+        );
+        assert_eq!(
+            install_hint_for_os(pyright, "linux"),
+            Some("npm install -g pyright")
+        );
+        assert_eq!(
+            install_hint_for_os(pyright, "windows"),
+            Some("npm install -g pyright")
+        );
+        // The current-OS wrapper resolves to one of the above.
+        assert!(install_hint_for_current_os(pyright).is_some());
+
+        let no_install = ServerSpec {
+            name: "x".into(),
+            recommended: true,
+            command: "x".into(),
+            args: vec![],
+            capabilities: vec![],
+            homepage: None,
+            notes: None,
+            install: None,
+        };
+        assert_eq!(install_hint_for_current_os(&no_install), None);
+    }
+
+    #[test]
+    fn base_url_resolution() {
+        assert_eq!(resolve_base_url(None), DEFAULT_REGISTRY_BASE_URL);
+        assert_eq!(
+            resolve_base_url(Some(String::new())),
+            DEFAULT_REGISTRY_BASE_URL
+        );
+        assert_eq!(
+            resolve_base_url(Some("http://127.0.0.1:9/mirror".to_string())),
+            "http://127.0.0.1:9/mirror"
+        );
+    }
+}

--- a/tests/lsp_registry_client.rs
+++ b/tests/lsp_registry_client.rs
@@ -1,0 +1,149 @@
+//! Integration tests for the LSP registry client + config writer pipeline:
+//! fetch manifests from a local mock HTTP server, map the chosen server to a
+//! config entry, and upsert it into a temp `.ctx/config.toml`.
+//!
+//! No CLI surface exists yet (it lands in a later PR), so these tests
+//! exercise the library functions directly, passing the mock server's URL as
+//! the explicit base. The `CTX_LSP_REGISTRY_BASE_URL` env override itself is
+//! covered by a unit test on the pure resolution helper in `lsp_registry`.
+
+use std::fs;
+
+use ctx::config_edit::{from_registry, registry_owned_languages, upsert_lsp_entry};
+use ctx::lsp_registry::{fetch_index, fetch_language, install_hint_for_current_os};
+use ctx::testutil::MockServer;
+
+const INDEX_TOML: &str = r#"
+schema_version = 1
+
+[languages.python]
+recommended = "pyright"
+servers = ["pyright"]
+"#;
+
+const PYTHON_TOML: &str = r#"
+schema_version = 1
+language = "python"
+extensions = ["py", "pyi"]
+root_markers = ["pyproject.toml", "setup.py", "setup.cfg", ".git"]
+
+[[servers]]
+name = "pyright"
+recommended = true
+command = "pyright-langserver"
+args = ["--stdio"]
+capabilities = ["documentSymbol", "references", "callHierarchy"]
+homepage = "https://github.com/microsoft/pyright"
+notes = "Fast, actively maintained."
+
+[servers.install]
+default = "npm install -g pyright"
+macos = "brew install pyright"
+"#;
+
+fn registry_server() -> MockServer {
+    let server = MockServer::start();
+    server.add_route("/index.toml", "text/plain; charset=utf-8", INDEX_TOML);
+    server.add_route(
+        "/registry/python.toml",
+        "text/plain; charset=utf-8",
+        PYTHON_TOML,
+    );
+    server
+}
+
+#[test]
+fn fetch_from_registry_and_write_config() {
+    let server = registry_server();
+    let base = server.url();
+
+    // Index lists python and its recommended server.
+    let index = fetch_index(&base).unwrap();
+    assert_eq!(index.languages.len(), 1);
+    assert_eq!(index.languages["python"].recommended, "pyright");
+
+    // Language entry resolves the recommended server.
+    let entry = fetch_language(&base, "python").unwrap();
+    let spec = entry.server(None).unwrap();
+    assert_eq!(spec.name, "pyright");
+    assert!(install_hint_for_current_os(spec).is_some());
+
+    // Map to a config entry and write it into a fresh .ctx/config.toml.
+    let dir = tempfile::tempdir().unwrap();
+    let config = from_registry(&entry, spec);
+    upsert_lsp_entry(dir.path(), &entry.language, &config).unwrap();
+
+    let text = fs::read_to_string(dir.path().join(".ctx/config.toml")).unwrap();
+    assert_eq!(
+        text,
+        r#"[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+extensions = ["py", "pyi"]
+root_markers = ["pyproject.toml", "setup.py", "setup.cfg", ".git"]
+capabilities = ["documentSymbol", "references", "callHierarchy"]
+backend = "hybrid"
+source = "registry"
+source_server = "pyright"
+"#
+    );
+
+    // The written table is recognized as registry-owned.
+    assert_eq!(registry_owned_languages(dir.path()).unwrap(), ["python"]);
+    assert_eq!(server.hits(), 2);
+}
+
+#[test]
+fn unknown_language_404_names_the_language() {
+    let server = registry_server();
+    let err = fetch_language(&server.url(), "cobol")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("'cobol'"), "{err}");
+    assert!(err.contains("unknown"), "{err}");
+}
+
+#[test]
+fn missing_index_is_an_error() {
+    let server = MockServer::start(); // no routes at all
+    let err = fetch_index(&server.url()).unwrap_err().to_string();
+    assert!(err.contains("404"), "{err}");
+}
+
+#[test]
+fn malformed_manifest_is_an_error() {
+    let server = MockServer::start();
+    server.add_route("/index.toml", "text/plain", "not valid = = toml");
+    server.add_route("/registry/python.toml", "text/plain", "also not : toml");
+
+    let err = fetch_index(&server.url()).unwrap_err().to_string();
+    assert!(err.contains("malformed"), "{err}");
+
+    let err = fetch_language(&server.url(), "python")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("malformed"), "{err}");
+}
+
+#[test]
+fn wrong_schema_version_says_upgrade() {
+    let server = MockServer::start();
+    server.add_route(
+        "/index.toml",
+        "text/plain",
+        INDEX_TOML.replace("schema_version = 1", "schema_version = 2"),
+    );
+    server.add_route(
+        "/registry/python.toml",
+        "text/plain",
+        PYTHON_TOML.replace("schema_version = 1", "schema_version = 2"),
+    );
+
+    let err = fetch_index(&server.url()).unwrap_err().to_string();
+    assert!(err.contains("upgrade"), "{err}");
+
+    let err = fetch_language(&server.url(), "python")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("upgrade"), "{err}");
+}


### PR DESCRIPTION
## Summary

Internal groundwork for AGE-10 (pluggable LSP support): the client layer for the new community LSP registry ([agentis-tools/ctx-lsp-registry](https://github.com/agentis-tools/ctx-lsp-registry)) and a format-preserving `.ctx/config.toml` writer. **No CLI surface, config contract, or documented behavior changes yet** — the `ctx lsp add/list/update` commands land in a follow-up PR that consumes these modules.

- `src/lsp_registry.rs`: fetches `index.toml` / `registry/<lang>.toml` from the registry's pinned `v1` branch (raw.githubusercontent.com), env-overridable via `CTX_LSP_REGISTRY_BASE_URL` (test hook, deliberately not a config key); serde manifest model; validates `schema_version == 1` with an "upgrade ctx" error otherwise; exactly-one-recommended-server and non-empty-command validation; per-OS install-hint helper.
- `src/config_edit.rs`: `toml_edit`-based upsert of `[lsp.<lang>]` tables that preserves user comments/formatting/unknown keys byte-for-byte outside the touched table; atomic write (staged temp file + rename); provenance keys `source = "registry"` / `source_server` so the future `ctx lsp update` only refreshes registry-owned entries.
- `toml_edit = "0.25"` added — already in Cargo.lock transitively, zero new compiled crates.

Part of [AGE-10](https://linear.app/itkonsult/issue/AGE-10). Registry repo (schema v1, 7 seeded languages, CI validation) is already live.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — pass
- `cargo test --locked --all-features` and `--no-default-features` — pass (19 new unit tests + 5 integration tests against `testutil::MockServer`)
- `python3 scripts/check-governance.py check` — pass
- `governance/contracts/cli.json` untouched (no CLI change); no version bump; changelog Unreleased/Internal entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)