### PR TITLE
feat: pluggable LSP extraction backend (AGE-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in meaning: entries that previously appeared through bare name matching now surface under
   `unresolved_callers` or not at all, so consumers reading `callers` see fewer, higher-confidence
   entries than before.
->>>>>>> origin/main
 
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Pluggable LSP extraction backend: any stdio language server can be registered
+  declaratively under `[lsp.<language>]` in `.ctx/config.toml`, with per-language
+  backend selection (`tree-sitter` (default) / `lsp` / `hybrid`), lazy server
+  startup, cross-file reference resolution via `textDocument/definition`, a
+  `.ctx/lsp_status.json` run sidecar, and graceful fallback to tree-sitter —
+  server failures never fail an indexing run.
+
 ### Documentation
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,
   harness regeneration after binary upgrades, and unresolved map focus behavior (#64).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "flate2",
  "globset",
  "ignore",
+ "lsp-types",
  "notify",
  "notify-debouncer-mini",
  "predicates",
@@ -333,7 +334,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -551,6 +552,12 @@ name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -991,7 +998,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -1469,6 +1476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2165,7 +2181,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -2321,7 +2337,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -2538,6 +2554,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,7 +2733,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2756,7 +2785,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2786,7 +2815,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2874,7 +2903,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2896,7 +2925,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3089,7 +3118,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3507,7 +3536,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3559,7 +3588,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3822,7 +3851,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
@@ -3868,7 +3897,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3881,7 +3910,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3977,7 +4006,7 @@ version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "clipboard-win",
  "home",
@@ -4073,7 +4102,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4149,6 +4178,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4405,7 +4445,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4786,7 +4826,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ notify = "8.2"
 notify-debouncer-mini = "0.7"
 dirs = "6.0.0"
 
+# Language Server Protocol types for the pluggable LSP extraction backend
+# (types only; the JSON-RPC stdio transport is hand-rolled in src/lsp/)
+lsp-types = "0.97"
+
 # Windows release artifacts are .zip (see .github/workflows/release.yml);
 # zip is already in the dependency graph transitively via libduckdb-sys
 [target.'cfg(windows)'.dependencies]

--- a/perf/Cargo.lock
+++ b/perf/Cargo.lock
@@ -18,10 +18,11 @@ dependencies = [
  "flate2",
  "globset",
  "ignore",
+ "lsp-types",
  "notify",
  "notify-debouncer-mini",
  "rayon",
- "reqwest",
+ "reqwest 0.13.4",
  "rusqlite",
  "rustyline",
  "semver",
@@ -31,7 +32,7 @@ dependencies = [
  "solang-parser",
  "sqlite-vec",
  "tar",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tiktoken-rs",
  "time",
  "tokio",
@@ -42,7 +43,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "zerocopy 0.7.35",
+ "zerocopy",
  "zip",
 ]
 
@@ -57,7 +58,7 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
- "zerocopy 0.8.54",
+ "zerocopy",
 ]
 
 [[package]]
@@ -95,6 +96,12 @@ checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -163,9 +170,6 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -258,6 +262,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,7 +308,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -289,6 +325,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -319,11 +361,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -390,13 +432,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -410,6 +453,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ciborium"
@@ -488,6 +542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +561,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -516,15 +589,49 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -555,9 +662,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -607,15 +714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,12 +746,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -728,17 +825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,11 +857,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -833,6 +920,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "endian-type"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "equator"
@@ -929,7 +1031,7 @@ dependencies = [
  "num-complex",
  "pulp",
  "rayon-core",
- "smallvec 1.15.2",
+ "smallvec",
  "zune-inflate",
 ]
 
@@ -947,26 +1049,28 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
 
 [[package]]
 name = "fastembed"
-version = "5.4.0"
+version = "5.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d719825156b62586040fd0e5653a4f7bc0ad9caf6c7ec38cb18f1a08ee0384"
+checksum = "545e4fb17fc48768ff36c2a3854aa5b0b809d0ed595ab5530fa8ac94f31bd0ea"
 dependencies = [
  "anyhow",
  "hf-hub",
  "image",
  "ndarray",
  "ort",
+ "safetensors",
+ "serde",
  "serde_json",
  "tokenizers",
 ]
@@ -982,17 +1086,6 @@ name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fdeflate"
@@ -1014,6 +1107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,10 +1130,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1059,6 +1173,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1131,24 +1251,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1170,8 +1282,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1224,7 +1339,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.54",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1234,6 +1349,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1259,9 +1387,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
  "http",
@@ -1270,13 +1398,19 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq 2.12.1",
- "windows-sys 0.60.2",
+ "ureq",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "home"
@@ -1327,6 +1461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,7 +1485,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec 1.15.2",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -1440,7 +1583,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.2",
+ "smallvec",
  "zerovec",
 ]
 
@@ -1498,7 +1641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.2",
+ "smallvec",
  "utf8_iter",
 ]
 
@@ -1580,24 +1723,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -1677,6 +1820,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,7 +1916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
@@ -1814,6 +2006,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +2034,31 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1903,23 +2126,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1975,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -2000,14 +2212,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "smallvec 1.15.2",
+ "smallvec",
 ]
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -2051,32 +2263,41 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.13.0",
- "crossbeam-channel",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "notify-debouncer-mini"
-version = "0.4.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
 dependencies = [
- "crossbeam-channel",
  "log",
  "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2144,12 +2365,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -2242,27 +2457,26 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "ndarray",
  "ort-sys",
- "smallvec 2.0.0-alpha.10",
+ "smallvec",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
- "flate2",
- "pkg-config",
- "sha2",
- "tar",
- "ureq 3.3.0",
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
 ]
 
 [[package]]
@@ -2294,7 +2508,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.2",
+ "smallvec",
  "windows-link",
 ]
 
@@ -2466,7 +2680,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.54",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2548,6 +2762,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,9 +2841,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radix_trie"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
  "endian-type",
  "nibble_vec",
@@ -2598,6 +2869,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2902,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2793,7 +3090,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -2829,6 +3125,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,14 +3197,23 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec 1.15.2",
+ "smallvec",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2887,6 +3234,7 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2897,13 +3245,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2911,6 +3299,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2924,14 +3313,13 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustyline"
-version = "17.0.2"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
  "clipboard-win",
- "fd-lock",
  "home",
  "libc",
  "log",
@@ -2941,7 +3329,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2949,6 +3337,19 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "same-file"
@@ -3039,6 +3440,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3047,12 +3449,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
+name = "serde_repr"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
- "serde",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3069,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3079,10 +3492,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -3092,6 +3521,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3110,12 +3545,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "smallvec"
-version = "2.0.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
 
 [[package]]
 name = "socket2"
@@ -3184,6 +3613,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -3279,7 +3714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3352,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "tiktoken-rs"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3425,6 +3860,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,7 +3915,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.1",
+ "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -3518,44 +3968,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3623,62 +4071,72 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.20.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.20.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d015c02ea98b62c806f7329ff71c383286dfc3a7a7da0cc484f6e42922f73c2c"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-python"
-version = "0.20.4"
+name = "tree-sitter-language"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c93b1b1fbd0d399db3445f51fd3058e43d0b4dcff62ddbdb46e66550978aa5"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.20.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -3686,6 +4144,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -3705,7 +4169,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
- "smallvec 1.15.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -3733,30 +4197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "native-tls",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.11",
-]
 
 [[package]]
 name = "ureq"
@@ -3765,15 +4215,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "der",
+ "flate2",
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "socks",
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3974,15 +4430,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
@@ -4064,27 +4511,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4105,21 +4534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4157,12 +4571,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4175,12 +4583,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4190,12 +4592,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4223,12 +4619,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4238,12 +4628,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4259,12 +4643,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4274,12 +4652,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4295,12 +4667,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -4355,32 +4724,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
- "zerocopy-derive 0.8.54",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4456,15 +4804,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "6.0.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
  "flate2",
  "indexmap",
  "memchr",
+ "typed-path",
  "zopfli",
 ]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,33 +2,27 @@
 //!
 //! An optional, committed TOML file that sets per-project defaults so teams
 //! don't have to pass the same flags/env vars on every invocation. Currently it
-//! configures the embedding backend and optional LSP extraction backends; more
-//! sections can be added over time.
+//! configures the embedding backend; more sections can be added over time.
+//! (The `[lsp.*]` sections of the same file are loaded separately by
+//! [`crate::lsp::LspConfig`].)
 //!
 //! ```toml
 //! [embedding]
 //! provider = "ollama"            # local | openai | ollama
 //! model = "qwen3-embedding:8b"   # provider-specific (Ollama/OpenAI model)
 //! # host = "http://localhost:11434"  # Ollama only
-//!
-//! [lsp.kotlin]                   # see crate::lsp::config::LspServerConfig
-//! command = "kotlin-language-server"
-//! extensions = ["kt", "kts"]
-//! backend = "lsp"                # tree-sitter | lsp | hybrid (default)
 //! ```
 //!
 //! Precedence for the resolved settings is always **CLI flag > environment
 //! variable > this file > built-in default**, so the config never overrides an
 //! explicit request.
 
-use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::Deserialize;
 
 use crate::embeddings::Provider;
 use crate::index::CTX_DIR;
-use crate::lsp::LspServerConfig;
 
 /// Config file name inside `.ctx/`.
 pub const CONFIG_FILE: &str = "config.toml";
@@ -40,10 +34,6 @@ pub const CONFIG_FILE: &str = "config.toml";
 pub struct CtxConfig {
     /// Embedding backend defaults.
     pub embedding: EmbeddingConfig,
-    /// Language servers registered as extraction backends, keyed by language
-    /// name (`[lsp.kotlin]`, `[lsp.python]`, ...). Empty map when no LSP is
-    /// configured — the LSP subsystem then never spawns anything.
-    pub lsp: BTreeMap<String, LspServerConfig>,
 }
 
 /// `[embedding]` section: default provider and provider-specific settings.
@@ -128,56 +118,6 @@ whatever = true
         );
         let cfg = CtxConfig::load_file(f.path());
         assert_eq!(cfg.embedding.provider, Some(Provider::Openai));
-        assert!(cfg.lsp.is_empty());
-    }
-
-    #[test]
-    fn parses_lsp_sections() {
-        let f = write_temp(
-            r#"
-[embedding]
-provider = "local"
-
-[lsp.kotlin]
-command = "kotlin-language-server"
-extensions = ["kt", "kts"]
-backend = "lsp"
-timeout_ms = 15000
-env = { JAVA_HOME = "/opt/java" }
-
-[lsp.python]
-command = "pyright-langserver"
-args = ["--stdio"]
-initialization_options = { python = { venvPath = ".venv" } }
-"#,
-        );
-        let cfg = CtxConfig::load_file(f.path());
-        assert_eq!(cfg.lsp.len(), 2);
-
-        let kotlin = &cfg.lsp["kotlin"];
-        assert_eq!(kotlin.command, "kotlin-language-server");
-        assert_eq!(kotlin.extensions, vec!["kt", "kts"]);
-        assert_eq!(kotlin.backend, crate::lsp::LspBackend::Lsp);
-        assert_eq!(kotlin.timeout_ms, Some(15000));
-        assert_eq!(kotlin.env["JAVA_HOME"], "/opt/java");
-
-        let python = &cfg.lsp["python"];
-        assert_eq!(python.args, vec!["--stdio"]);
-        assert_eq!(python.backend, crate::lsp::LspBackend::Hybrid, "default");
-        assert!(python.initialization_options.is_some());
-    }
-
-    #[test]
-    fn malformed_lsp_block_falls_back_to_defaults() {
-        // A type error anywhere in the file keeps load fault-tolerant.
-        let f = write_temp(
-            r#"
-[lsp.kotlin]
-command = 42
-"#,
-        );
-        let cfg = CtxConfig::load_file(f.path());
-        assert!(cfg.lsp.is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,25 +2,33 @@
 //!
 //! An optional, committed TOML file that sets per-project defaults so teams
 //! don't have to pass the same flags/env vars on every invocation. Currently it
-//! configures the embedding backend; more sections can be added over time.
+//! configures the embedding backend and optional LSP extraction backends; more
+//! sections can be added over time.
 //!
 //! ```toml
 //! [embedding]
 //! provider = "ollama"            # local | openai | ollama
 //! model = "qwen3-embedding:8b"   # provider-specific (Ollama/OpenAI model)
 //! # host = "http://localhost:11434"  # Ollama only
+//!
+//! [lsp.kotlin]                   # see crate::lsp::config::LspServerConfig
+//! command = "kotlin-language-server"
+//! extensions = ["kt", "kts"]
+//! backend = "lsp"                # tree-sitter | lsp | hybrid (default)
 //! ```
 //!
 //! Precedence for the resolved settings is always **CLI flag > environment
 //! variable > this file > built-in default**, so the config never overrides an
 //! explicit request.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::Deserialize;
 
 use crate::embeddings::Provider;
 use crate::index::CTX_DIR;
+use crate::lsp::LspServerConfig;
 
 /// Config file name inside `.ctx/`.
 pub const CONFIG_FILE: &str = "config.toml";
@@ -32,6 +40,10 @@ pub const CONFIG_FILE: &str = "config.toml";
 pub struct CtxConfig {
     /// Embedding backend defaults.
     pub embedding: EmbeddingConfig,
+    /// Language servers registered as extraction backends, keyed by language
+    /// name (`[lsp.kotlin]`, `[lsp.python]`, ...). Empty map when no LSP is
+    /// configured — the LSP subsystem then never spawns anything.
+    pub lsp: BTreeMap<String, LspServerConfig>,
 }
 
 /// `[embedding]` section: default provider and provider-specific settings.
@@ -116,6 +128,56 @@ whatever = true
         );
         let cfg = CtxConfig::load_file(f.path());
         assert_eq!(cfg.embedding.provider, Some(Provider::Openai));
+        assert!(cfg.lsp.is_empty());
+    }
+
+    #[test]
+    fn parses_lsp_sections() {
+        let f = write_temp(
+            r#"
+[embedding]
+provider = "local"
+
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]
+backend = "lsp"
+timeout_ms = 15000
+env = { JAVA_HOME = "/opt/java" }
+
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+initialization_options = { python = { venvPath = ".venv" } }
+"#,
+        );
+        let cfg = CtxConfig::load_file(f.path());
+        assert_eq!(cfg.lsp.len(), 2);
+
+        let kotlin = &cfg.lsp["kotlin"];
+        assert_eq!(kotlin.command, "kotlin-language-server");
+        assert_eq!(kotlin.extensions, vec!["kt", "kts"]);
+        assert_eq!(kotlin.backend, crate::lsp::LspBackend::Lsp);
+        assert_eq!(kotlin.timeout_ms, Some(15000));
+        assert_eq!(kotlin.env["JAVA_HOME"], "/opt/java");
+
+        let python = &cfg.lsp["python"];
+        assert_eq!(python.args, vec!["--stdio"]);
+        assert_eq!(python.backend, crate::lsp::LspBackend::Hybrid, "default");
+        assert!(python.initialization_options.is_some());
+    }
+
+    #[test]
+    fn malformed_lsp_block_falls_back_to_defaults() {
+        // A type error anywhere in the file keeps load fault-tolerant.
+        let f = write_temp(
+            r#"
+[lsp.kotlin]
+command = 42
+"#,
+        );
+        let cfg = CtxConfig::load_file(f.path());
+        assert!(cfg.lsp.is_empty());
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -12,5 +12,5 @@ pub mod schema;
 pub use models::*;
 pub use schema::{
     CrossFileEdge, Database, EdgeSymbol, FileComplexity, MapSymbolRow, SymbolMetrics,
-    SCHEMA_VERSION,
+    UnresolvedEdgeLocation, SCHEMA_VERSION,
 };

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1766,7 +1766,7 @@ impl Database {
     pub fn unresolved_edges_with_location(&self) -> Result<Vec<UnresolvedEdgeLocation>> {
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT e.id, s.file_path, e.line, COALESCE(e.col, 0)
+            SELECT e.id, s.file_path, e.line, COALESCE(e.col, 0), e.target_name
             FROM edges e
             JOIN symbols s ON s.id = e.source_id
             WHERE e.target_id IS NULL AND e.line IS NOT NULL
@@ -1779,6 +1779,7 @@ impl Database {
                 source_file: row.get(1)?,
                 line: row.get(2)?,
                 col: row.get(3)?,
+                target_name: row.get(4)?,
             })
         })?;
         rows.collect()
@@ -2058,6 +2059,9 @@ pub struct UnresolvedEdgeLocation {
     pub line: u32,
     /// 0-based column of the reference (0 when unknown).
     pub col: u32,
+    /// Recorded callee name (`edges.target_name`); the Stage B resolver only
+    /// accepts definition targets whose symbol name matches it.
+    pub target_name: String,
 }
 
 /// A resolved relationship edge whose endpoints live in different files

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1747,6 +1747,75 @@ impl Database {
         Ok(qualified_resolved + context_resolved + unique_resolved + same_file_unique)
     }
 
+    /// Unresolved edges that carry a call-site location, joined to the file
+    /// containing their source symbol.
+    ///
+    /// Used by the LSP Stage B resolver ([`crate::lsp::resolve`]) to ask a
+    /// language server `textDocument/definition` at each call site after
+    /// [`Database::resolve_edge_targets`] has done the cheap SQL passes.
+    pub fn unresolved_edges_with_location(&self) -> Result<Vec<UnresolvedEdgeLocation>> {
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT e.id, s.file_path, e.line, COALESCE(e.col, 0)
+            FROM edges e
+            JOIN symbols s ON s.id = e.source_id
+            WHERE e.target_id IS NULL AND e.line IS NOT NULL
+            ORDER BY s.file_path, e.line
+            "#,
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(UnresolvedEdgeLocation {
+                edge_id: row.get(0)?,
+                source_file: row.get(1)?,
+                line: row.get(2)?,
+                col: row.get(3)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Set the resolved target of one edge by rowid.
+    ///
+    /// This is a direct `UPDATE` used by LSP Stage B for cross-file targets:
+    /// unlike the `store_edges` insert path it never rewrites ids against the
+    /// source file's path, which would corrupt a cross-file target id into
+    /// `current_file::name`. Only still-unresolved edges are updated.
+    pub fn set_edge_target(&self, edge_id: i64, target_id: &str) -> Result<bool> {
+        let changed = self.conn.execute(
+            "UPDATE edges SET target_id = ? WHERE id = ? AND target_id IS NULL",
+            params![target_id, edge_id],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Find the symbol at a (1-based) line of a file: an exact `line_start`
+    /// match first, then the innermost symbol whose span contains the line.
+    pub fn symbol_id_at_line(&self, file_path: &str, line: u32) -> Result<Option<String>> {
+        if let Some(id) = self
+            .conn
+            .query_row(
+                "SELECT id FROM symbols WHERE file_path = ? AND line_start = ? LIMIT 1",
+                params![file_path, line],
+                |row| row.get(0),
+            )
+            .optional()?
+        {
+            return Ok(Some(id));
+        }
+        self.conn
+            .query_row(
+                r#"
+                SELECT id FROM symbols
+                WHERE file_path = ? AND line_start <= ? AND line_end >= ?
+                ORDER BY (line_end - line_start) ASC, line_start DESC
+                LIMIT 1
+                "#,
+                params![file_path, line, line],
+                |row| row.get(0),
+            )
+            .optional()
+    }
+
     /// Insert (or replace) a batch of MinHash fingerprints in one transaction.
     pub fn insert_fingerprints_batch(&self, fingerprints: &[Fingerprint]) -> Result<usize> {
         if fingerprints.is_empty() {
@@ -1964,6 +2033,21 @@ pub struct SymbolMetrics {
     pub fan_in: i64,
     pub fan_out: i64,
     pub complexity: i64,
+}
+
+/// An unresolved edge with a call-site location, joined to the file that
+/// contains its source symbol (see
+/// [`Database::unresolved_edges_with_location`]).
+#[derive(Debug, Clone)]
+pub struct UnresolvedEdgeLocation {
+    /// Rowid of the edge (`edges.id`).
+    pub edge_id: i64,
+    /// File containing the edge's source symbol.
+    pub source_file: String,
+    /// 1-based line of the reference.
+    pub line: u32,
+    /// 0-based column of the reference (0 when unknown).
+    pub col: u32,
 }
 
 /// A resolved relationship edge whose endpoints live in different files

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -117,7 +117,7 @@ impl Indexer {
         let db = Database::open(&db_path).map_err(|e| io::Error::other(e.to_string()))?;
 
         // Optional LSP extraction backend (inert without [lsp.*] config).
-        let config = crate::config::CtxConfig::load(&root);
+        let config = crate::lsp::LspConfig::load(&root);
         let lsp = LspManager::from_config(&root, &config, verbose);
 
         Ok(Self {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -59,6 +59,13 @@ fn rewrite_id(
 /// Default directory name for storing the database.
 pub const CTX_DIR: &str = ".ctx";
 
+/// Prefix marking a file record stored from a *degraded* extraction (LSP
+/// server unusable and no tree-sitter fallback, i.e. an empty symbol set that
+/// does not reflect the file's content). Because the stored hash never equals
+/// a real content hash, `needs_update` re-extracts the file on the next run —
+/// once the server is healthy again the real symbols replace the empty record.
+const LSP_DEGRADED_HASH_PREFIX: &str = "lsp-degraded:";
+
 /// Default database filename.
 pub const DB_FILE: &str = "codebase.sqlite";
 
@@ -165,34 +172,48 @@ impl Indexer {
     /// fallback: builtin languages re-parse with tree-sitter, dynamic
     /// languages store a file record with zero symbols (so incremental
     /// skipping and deletion cleanup keep working). Never fails the run.
+    ///
+    /// The `bool` is the *degraded* flag: `true` only for the empty-result
+    /// path (server unusable AND no tree-sitter fallback). Callers must then
+    /// store the file with [`degraded_hash`] so the next run retries instead
+    /// of skipping the empty record forever. A healthy server's answer (even
+    /// zero symbols, e.g. a `null` documentSymbol for an empty file) and a
+    /// tree-sitter fallback parse are durable results and are not poisoned.
     fn lsp_extract_or_fallback(
         &mut self,
         language: &str,
         rel_path: &str,
         abs_path: &Path,
         content: &str,
-    ) -> ParseResult {
+    ) -> (ParseResult, bool) {
         if let Some(mgr) = self.lsp.as_mut() {
             if let Some(result) = mgr.extract(language, rel_path, content) {
-                return result;
+                return (result, false);
             }
         }
 
         // Server missing/crashed (the manager already warned once per
-        // language): builtin grammars still produce full symbols.
+        // language): builtin grammars still produce full symbols, which is
+        // an acceptable durable result — no retry needed.
         if CodeParser::is_supported_static(abs_path) {
             if let Some(result) = self.parser.parse(abs_path, content) {
-                return result;
+                return (result, false);
             }
         }
 
-        ParseResult {
-            file_path: rel_path.to_string(),
-            language: language.to_string(),
-            symbols: Vec::new(),
-            edges: Vec::new(),
-            module: None,
-        }
+        // Degraded: no server and no fallback. The empty record keeps
+        // incremental bookkeeping and deletion cleanup working, but must be
+        // stored with a poisoned hash so a later healthy run re-extracts.
+        (
+            ParseResult {
+                file_path: rel_path.to_string(),
+                language: language.to_string(),
+                symbols: Vec::new(),
+                edges: Vec::new(),
+                module: None,
+            },
+            true,
+        )
     }
 
     /// Stage B: resolve leftover cross-file references for the given files
@@ -288,7 +309,7 @@ impl Indexer {
             }
 
             // Parse the file (tree-sitter or LSP, per backend)
-            let parse_result = match &backend {
+            let (parse_result, degraded) = match &backend {
                 FileBackend::Lsp(language) => {
                     let language = language.clone();
                     self.lsp_extract_or_fallback(
@@ -299,7 +320,7 @@ impl Indexer {
                     )
                 }
                 _ => match self.parser.parse(&entry.absolute_path, &content) {
-                    Some(r) => r,
+                    Some(r) => (r, false),
                     None => {
                         if self.verbose {
                             eprintln!("Warning: failed to parse {}", rel_path);
@@ -310,8 +331,16 @@ impl Indexer {
                 },
             };
 
+            // A degraded (empty) extraction is stored with a poisoned hash so
+            // the next run retries it once the server is healthy again.
+            let store_hash = if degraded {
+                degraded_hash(&hash)
+            } else {
+                hash.clone()
+            };
+
             // Store in database
-            if let Err(e) = self.store_file(&rel_path, &content, &hash, &parse_result) {
+            if let Err(e) = self.store_file(&rel_path, &content, &store_hash, &parse_result) {
                 if self.verbose {
                     eprintln!("Warning: failed to store {}: {}", rel_path, e);
                 }
@@ -533,13 +562,21 @@ impl Indexer {
                     if verbose {
                         eprintln!("Indexing (lsp:{}): {}", language, rel_path);
                     }
-                    let parse_result = self.lsp_extract_or_fallback(
+                    let (parse_result, degraded) = self.lsp_extract_or_fallback(
                         &language,
                         &rel_path,
                         &entry.absolute_path,
                         &content,
                     );
-                    if let Err(e) = self.store_file(&rel_path, &content, &hash, &parse_result) {
+                    // Poisoned hash for degraded (empty) extractions: the
+                    // next run retries instead of skipping forever.
+                    let store_hash = if degraded {
+                        degraded_hash(&hash)
+                    } else {
+                        hash.clone()
+                    };
+                    if let Err(e) = self.store_file(&rel_path, &content, &store_hash, &parse_result)
+                    {
                         if self.verbose {
                             eprintln!("Warning: failed to store {}: {}", rel_path, e);
                         }
@@ -628,19 +665,28 @@ impl Indexer {
         }
 
         // Parse (tree-sitter or LSP, per backend)
-        let parse_result = match &backend {
+        let (parse_result, degraded) = match &backend {
             FileBackend::Lsp(language) => {
                 let language = language.clone();
                 self.lsp_extract_or_fallback(&language, &rel_path, &abs_path, &content)
             }
-            _ => self
-                .parser
-                .parse(&abs_path, &content)
-                .ok_or_else(|| io::Error::other("Parse failed"))?,
+            _ => (
+                self.parser
+                    .parse(&abs_path, &content)
+                    .ok_or_else(|| io::Error::other("Parse failed"))?,
+                false,
+            ),
+        };
+
+        // Poisoned hash for degraded (empty) extractions: retried next run.
+        let store_hash = if degraded {
+            degraded_hash(&hash)
+        } else {
+            hash.clone()
         };
 
         // Store
-        self.store_file(&rel_path, &content, &hash, &parse_result)?;
+        self.store_file(&rel_path, &content, &store_hash, &parse_result)?;
 
         // The graph changed: invalidate the cached PageRank scores
         // (`ctx map` recomputes them lazily).
@@ -824,6 +870,13 @@ impl Indexer {
     pub fn database(&self) -> &Database {
         &self.db
     }
+}
+
+/// Hash stored for a degraded (empty, server-unavailable) extraction: keeps
+/// the real content hash for debuggability but never compares equal to one,
+/// so `needs_update` always retries the file on the next run.
+fn degraded_hash(hash: &str) -> String {
+    format!("{LSP_DEGRADED_HASH_PREFIX}{hash}")
 }
 
 /// Compute SHA256 hash of content.

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -18,6 +18,7 @@ use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 
 use crate::db::{Database, FileRecord, ParseResult};
+use crate::lsp::{FileBackend, LspManager};
 use crate::parser::CodeParser;
 use crate::walker::{discover_files, WalkerConfig};
 
@@ -90,6 +91,10 @@ pub struct Indexer {
     verbose: bool,
     /// Walker configuration for file discovery.
     walker_config: WalkerConfig,
+    /// LSP extraction backend; `None` unless `.ctx/config.toml` registers at
+    /// least one `[lsp.*]` server. Lives on the indexer so servers stay warm
+    /// across watch-mode events.
+    lsp: Option<LspManager>,
 }
 
 impl Indexer {
@@ -111,12 +116,17 @@ impl Indexer {
         let db_path = ctx_dir.join(DB_FILE);
         let db = Database::open(&db_path).map_err(|e| io::Error::other(e.to_string()))?;
 
+        // Optional LSP extraction backend (inert without [lsp.*] config).
+        let config = crate::config::CtxConfig::load(&root);
+        let lsp = LspManager::from_config(&root, &config, verbose);
+
         Ok(Self {
             db,
             parser: CodeParser::new(),
             root,
             verbose,
             walker_config,
+            lsp,
         })
     }
 
@@ -132,7 +142,86 @@ impl Indexer {
             root,
             verbose: false,
             walker_config: WalkerConfig::default(),
+            lsp: None,
         })
+    }
+
+    /// Decide how a file should be extracted: via the LSP manager when one is
+    /// configured, otherwise via the builtin tree-sitter language table.
+    pub fn backend_for(&self, path: &Path) -> FileBackend {
+        match &self.lsp {
+            Some(mgr) => mgr.backend_for(path),
+            None => {
+                if CodeParser::is_supported_static(path) {
+                    FileBackend::TreeSitter
+                } else {
+                    FileBackend::Unsupported
+                }
+            }
+        }
+    }
+
+    /// Stage A extraction for a file with an `lsp` backend, with graceful
+    /// fallback: builtin languages re-parse with tree-sitter, dynamic
+    /// languages store a file record with zero symbols (so incremental
+    /// skipping and deletion cleanup keep working). Never fails the run.
+    fn lsp_extract_or_fallback(
+        &mut self,
+        language: &str,
+        rel_path: &str,
+        abs_path: &Path,
+        content: &str,
+    ) -> ParseResult {
+        if let Some(mgr) = self.lsp.as_mut() {
+            if let Some(result) = mgr.extract(language, rel_path, content) {
+                return result;
+            }
+        }
+
+        // Server missing/crashed (the manager already warned once per
+        // language): builtin grammars still produce full symbols.
+        if CodeParser::is_supported_static(abs_path) {
+            if let Some(result) = self.parser.parse(abs_path, content) {
+                return result;
+            }
+        }
+
+        ParseResult {
+            file_path: rel_path.to_string(),
+            language: language.to_string(),
+            symbols: Vec::new(),
+            edges: Vec::new(),
+            module: None,
+        }
+    }
+
+    /// Stage B: resolve leftover cross-file references for the given files
+    /// via the language server, then refresh the LSP status sidecar.
+    /// Best-effort — never affects the exit code.
+    fn run_lsp_stage_b(&mut self, changed_files: &std::collections::HashSet<String>) {
+        let verbose = self.verbose;
+        if let Some(mgr) = self.lsp.as_mut() {
+            if !changed_files.is_empty() {
+                let resolved = crate::lsp::resolve::resolve_edges_with_lsp(
+                    &self.db,
+                    mgr,
+                    changed_files,
+                    verbose,
+                );
+                if verbose && resolved > 0 {
+                    eprintln!("Resolved {} edge targets via LSP", resolved);
+                }
+            }
+            mgr.write_status();
+        }
+    }
+
+    /// Shut down all LSP servers at the end of a full indexing run. Watch
+    /// mode never calls this so servers stay warm across events.
+    fn shutdown_lsp(&mut self) {
+        if let Some(mgr) = self.lsp.as_mut() {
+            mgr.shutdown_all();
+        }
     }
 
     /// Index the codebase.
@@ -153,12 +242,16 @@ impl Indexer {
 
         // Track files we've seen for cleanup
         let mut seen_files: Vec<String> = Vec::new();
+        // Files indexed this run with an lsp/hybrid backend (Stage B input).
+        let mut stage_b_files: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for entry in &entries {
             let rel_path = entry.relative_path.to_string_lossy().replace('\\', "/");
 
-            // Only process supported languages
-            if !self.parser.is_supported(&entry.relative_path) {
+            // Only process supported files (builtin grammars plus any
+            // language claimed by an [lsp.*] config block)
+            let backend = self.backend_for(&entry.relative_path);
+            if backend == FileBackend::Unsupported {
                 result.files_skipped += 1;
                 continue;
             }
@@ -194,16 +287,27 @@ impl Indexer {
                 eprintln!("Indexing: {}", rel_path);
             }
 
-            // Parse the file
-            let parse_result = match self.parser.parse(&entry.absolute_path, &content) {
-                Some(r) => r,
-                None => {
-                    if self.verbose {
-                        eprintln!("Warning: failed to parse {}", rel_path);
-                    }
-                    result.files_failed += 1;
-                    continue;
+            // Parse the file (tree-sitter or LSP, per backend)
+            let parse_result = match &backend {
+                FileBackend::Lsp(language) => {
+                    let language = language.clone();
+                    self.lsp_extract_or_fallback(
+                        &language,
+                        &rel_path,
+                        &entry.absolute_path,
+                        &content,
+                    )
                 }
+                _ => match self.parser.parse(&entry.absolute_path, &content) {
+                    Some(r) => r,
+                    None => {
+                        if self.verbose {
+                            eprintln!("Warning: failed to parse {}", rel_path);
+                        }
+                        result.files_failed += 1;
+                        continue;
+                    }
+                },
             };
 
             // Store in database
@@ -215,6 +319,9 @@ impl Indexer {
                 continue;
             }
 
+            if matches!(backend, FileBackend::Lsp(_) | FileBackend::Hybrid(_)) {
+                stage_b_files.insert(rel_path.clone());
+            }
             seen_files.push(rel_path);
             result.files_indexed += 1;
             result.symbols_extracted += parse_result.symbols.len();
@@ -241,6 +348,11 @@ impl Indexer {
                 }
             }
         }
+
+        // Stage B: LSP-assisted resolution for what the SQL passes left
+        // unresolved, then shut the servers down for this run.
+        self.run_lsp_stage_b(&stage_b_files);
+        self.shutdown_lsp();
 
         // The graph changed: invalidate the cached PageRank scores
         // (`ctx map` recomputes them lazily).
@@ -277,8 +389,10 @@ impl Indexer {
             .filter_map(|entry| {
                 let rel_path = entry.relative_path.to_string_lossy().replace('\\', "/");
 
-                // Only process supported languages
-                if !CodeParser::is_supported_static(&entry.relative_path) {
+                // Only process supported files (builtin grammars plus any
+                // language claimed by an [lsp.*] config block)
+                let backend = self.backend_for(&entry.relative_path);
+                if backend == FileBackend::Unsupported {
                     files_skipped.fetch_add(1, Ordering::Relaxed);
                     return None;
                 }
@@ -296,7 +410,7 @@ impl Indexer {
 
                 // Check if file needs updating
                 match self.db.needs_update(&rel_path, &hash) {
-                    Ok(true) => Some((entry.clone(), rel_path, content, hash)),
+                    Ok(true) => Some((entry.clone(), rel_path, content, hash, backend)),
                     Ok(false) => {
                         files_skipped.fetch_add(1, Ordering::Relaxed);
                         None
@@ -311,10 +425,26 @@ impl Indexer {
 
         let verbose = self.verbose;
 
+        // Files indexed this run with an lsp/hybrid backend (Stage B input).
+        let stage_b_files: std::collections::HashSet<String> = files_to_index
+            .iter()
+            .filter(|(_, _, _, _, backend)| {
+                matches!(backend, FileBackend::Lsp(_) | FileBackend::Hybrid(_))
+            })
+            .map(|(_, rel_path, _, _, _)| rel_path.clone())
+            .collect();
+
+        // Partition: `lsp`-backend files are extracted serially (Stage A)
+        // after the rayon parse phase; everything else (tree-sitter and
+        // hybrid) goes through the unchanged parallel parse path.
+        let (lsp_files, ts_files): (Vec<_>, Vec<_>) = files_to_index
+            .into_iter()
+            .partition(|(_, _, _, _, backend)| matches!(backend, FileBackend::Lsp(_)));
+
         // Parallel parse phase: parse all files that need updating
-        let parsed_files: Vec<ParsedFile> = files_to_index
+        let parsed_files: Vec<ParsedFile> = ts_files
             .par_iter()
-            .filter_map(|(entry, rel_path, content, hash)| {
+            .filter_map(|(entry, rel_path, content, hash, _)| {
                 // Create thread-local parser
                 let mut parser = CodeParser::new();
 
@@ -348,12 +478,14 @@ impl Indexer {
             elapsed_ms: 0,
         };
 
-        // Track files we've seen for cleanup (both indexed and skipped)
+        // Track files we've seen for cleanup (both indexed and skipped);
+        // includes LSP-claimed dynamic languages so their deletions are
+        // cleaned up like any other file.
         let seen_files: Vec<String> = entries
             .iter()
             .filter_map(|e| {
                 let rel = e.relative_path.to_string_lossy().replace('\\', "/");
-                if CodeParser::is_supported_static(&e.relative_path) {
+                if self.backend_for(&e.relative_path) != FileBackend::Unsupported {
                     Some(rel)
                 } else {
                     None
@@ -382,6 +514,45 @@ impl Indexer {
             result.edges_extracted += parsed.parse_result.edges.len();
         }
 
+        // Stage A: serial LSP extraction, grouped per language so each
+        // server handles its files consecutively while warm.
+        if !lsp_files.is_empty() {
+            let mut by_language: std::collections::BTreeMap<String, Vec<_>> =
+                std::collections::BTreeMap::new();
+            for (entry, rel_path, content, hash, backend) in lsp_files {
+                if let FileBackend::Lsp(language) = backend {
+                    by_language
+                        .entry(language)
+                        .or_default()
+                        .push((entry, rel_path, content, hash));
+                }
+            }
+
+            for (language, files) in by_language {
+                for (entry, rel_path, content, hash) in files {
+                    if verbose {
+                        eprintln!("Indexing (lsp:{}): {}", language, rel_path);
+                    }
+                    let parse_result = self.lsp_extract_or_fallback(
+                        &language,
+                        &rel_path,
+                        &entry.absolute_path,
+                        &content,
+                    );
+                    if let Err(e) = self.store_file(&rel_path, &content, &hash, &parse_result) {
+                        if self.verbose {
+                            eprintln!("Warning: failed to store {}: {}", rel_path, e);
+                        }
+                        result.files_failed += 1;
+                        continue;
+                    }
+                    result.files_indexed += 1;
+                    result.symbols_extracted += parse_result.symbols.len();
+                    result.edges_extracted += parse_result.edges.len();
+                }
+            }
+        }
+
         // Clean up deleted files
         if let Err(e) = self.cleanup_deleted_files(&seen_files) {
             if self.verbose {
@@ -402,6 +573,11 @@ impl Indexer {
                 }
             }
         }
+
+        // Stage B: LSP-assisted resolution for what the SQL passes left
+        // unresolved, then shut the servers down for this run.
+        self.run_lsp_stage_b(&stage_b_files);
+        self.shutdown_lsp();
 
         // The graph changed: invalidate the cached PageRank scores
         // (`ctx map` recomputes them lazily).
@@ -431,8 +607,9 @@ impl Indexer {
             .to_string_lossy()
             .replace('\\', "/");
 
-        // Check if supported
-        if !self.parser.is_supported(path) {
+        // Check if supported (builtin grammars plus LSP-claimed extensions)
+        let backend = self.backend_for(&abs_path);
+        if backend == FileBackend::Unsupported {
             return Ok(false);
         }
 
@@ -450,11 +627,17 @@ impl Indexer {
             return Ok(false);
         }
 
-        // Parse
-        let parse_result = self
-            .parser
-            .parse(&abs_path, &content)
-            .ok_or_else(|| io::Error::other("Parse failed"))?;
+        // Parse (tree-sitter or LSP, per backend)
+        let parse_result = match &backend {
+            FileBackend::Lsp(language) => {
+                let language = language.clone();
+                self.lsp_extract_or_fallback(&language, &rel_path, &abs_path, &content)
+            }
+            _ => self
+                .parser
+                .parse(&abs_path, &content)
+                .ok_or_else(|| io::Error::other("Parse failed"))?,
+        };
 
         // Store
         self.store_file(&rel_path, &content, &hash, &parse_result)?;
@@ -462,6 +645,19 @@ impl Indexer {
         // The graph changed: invalidate the cached PageRank scores
         // (`ctx map` recomputes them lazily).
         self.db.clear_symbol_rank().map_err(db_error)?;
+
+        // Stage B for this file (lsp/hybrid backends): run the cheap SQL
+        // resolution first so the language server only sees the leftovers.
+        // Servers stay warm on the indexer for subsequent watch events.
+        if matches!(backend, FileBackend::Lsp(_) | FileBackend::Hybrid(_)) {
+            if let Err(e) = self.db.resolve_edge_targets() {
+                if self.verbose {
+                    eprintln!("Warning: edge resolution failed: {}", e);
+                }
+            }
+            let changed: std::collections::HashSet<String> = std::iter::once(rel_path).collect();
+            self.run_lsp_stage_b(&changed);
+        }
 
         Ok(true)
     }
@@ -672,7 +868,6 @@ pub mod watch {
     use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 
     use super::Indexer;
-    use crate::parser::Language;
     use crate::walker::{FileFilter, WalkerConfig};
 
     /// Start watching the codebase for changes and reindex automatically.
@@ -730,9 +925,10 @@ pub mod watch {
                                 continue;
                             }
 
-                            // Check if it's a supported source file
-                            let lang = Language::from_path(path);
-                            if lang == Language::Unknown {
+                            // Check if it's a supported source file (LSP-aware:
+                            // dynamic languages registered in [lsp.*] must
+                            // reindex too, not just builtin grammars)
+                            if indexer.backend_for(path) == crate::lsp::FileBackend::Unsupported {
                                 continue;
                             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@
 //! | [`index`] | Build and update the code intelligence index |
 //! | [`db`] | SQLite storage: symbols, edges, files, FTS and vector search |
 //! | [`parser`] | Tree-sitter based symbol/relationship extraction |
+//! | [`lsp`] | Language-server extraction backend (configured via `.ctx/config.toml`) |
 //! | [`embeddings`] | Embedding providers (local fastembed or OpenAI) |
 //! | [`analytics`] | Call graph queries: callers, dependencies, impact (DuckDB) |
 //! | [`smart`] | Task-driven file selection for LLM context |
@@ -137,6 +138,7 @@ pub mod exit;
 pub mod fingerprint;
 pub mod index;
 pub mod json;
+pub mod lsp;
 pub mod parser;
 pub mod rank;
 pub mod tokens;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -49,10 +49,15 @@ pub struct LspClient {
     child: Child,
     stderr_lines: Arc<Mutex<VecDeque<String>>>,
     request_timeout: Duration,
+    /// Whether `timeout_ms` was configured explicitly. An explicit timeout is
+    /// honored as-is (no warmup extension), so tests and impatient users get
+    /// deterministic deadlines.
+    explicit_timeout: bool,
     /// `Some(reason)` once the server has been declared unusable.
     failed: Option<String>,
     consecutive_timeouts: u32,
-    /// The first request after `initialize` gets a longer warmup deadline.
+    /// The first request after `initialize` gets a longer warmup deadline
+    /// (unless the timeout was configured explicitly).
     warmup_pending: bool,
     shut_down: bool,
     /// Server-reported name from `initialize` (if any).
@@ -112,6 +117,7 @@ impl LspClient {
                 .timeout_ms
                 .map(Duration::from_millis)
                 .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
+            explicit_timeout: config.timeout_ms.is_some(),
             failed: None,
             consecutive_timeouts: 0,
             warmup_pending: true,
@@ -230,7 +236,7 @@ impl LspClient {
             return Err(reason.clone());
         }
 
-        let timeout = if self.warmup_pending {
+        let timeout = if self.warmup_pending && !self.explicit_timeout {
             self.request_timeout.max(WARMUP_TIMEOUT)
         } else {
             self.request_timeout

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1,0 +1,510 @@
+//! Language-server child process management and typed request wrappers.
+//!
+//! One [`LspClient`] per configured language. The client owns the child
+//! process, its framed [`Transport`], and a drained-stderr ring buffer, and
+//! tracks failure state (consecutive timeouts, broken pipes) so callers can
+//! fall back to tree-sitter without ever failing the indexing run.
+
+use std::collections::VecDeque;
+use std::io::BufRead;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use lsp_types::{
+    CallHierarchyItem, CallHierarchyOutgoingCall, DocumentSymbolResponse, GotoDefinitionResponse,
+    Location,
+};
+use serde_json::{json, Value};
+
+use super::config::LspServerConfig;
+use super::path_to_uri;
+use super::transport::{Transport, TransportError};
+
+/// Why a server could not be started, plus any stderr it left behind.
+#[derive(Debug)]
+pub struct SpawnError {
+    pub reason: String,
+    pub stderr: Vec<String>,
+}
+
+/// Default per-request timeout (overridable via `timeout_ms`).
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+/// Timeout for the `initialize` handshake.
+const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(30);
+/// One-time grace period for the first request after `initialize` (server
+/// warmup: many servers index the workspace before answering).
+const WARMUP_TIMEOUT: Duration = Duration::from_secs(60);
+/// Timeout for the `shutdown` request and for waiting on process exit.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+/// Consecutive request timeouts before the server is declared failed.
+const MAX_CONSECUTIVE_TIMEOUTS: u32 = 3;
+/// Lines of server stderr retained for diagnostics.
+const STDERR_RING_CAPACITY: usize = 40;
+
+/// A running (or failed) language server connection.
+pub struct LspClient {
+    transport: Transport,
+    child: Child,
+    stderr_lines: Arc<Mutex<VecDeque<String>>>,
+    request_timeout: Duration,
+    /// `Some(reason)` once the server has been declared unusable.
+    failed: Option<String>,
+    consecutive_timeouts: u32,
+    /// The first request after `initialize` gets a longer warmup deadline.
+    warmup_pending: bool,
+    shut_down: bool,
+    /// Server-reported name from `initialize` (if any).
+    pub server_name: Option<String>,
+    /// Server-reported version from `initialize` (if any).
+    pub server_version: Option<String>,
+    /// Raw negotiated `capabilities` object from `initialize`.
+    capabilities: Value,
+}
+
+impl LspClient {
+    /// Spawn the configured server and run the `initialize`/`initialized`
+    /// handshake. Returns a human-readable reason (plus captured stderr) on
+    /// failure.
+    pub fn spawn(config: &LspServerConfig, root: &Path, verbose: bool) -> Result<Self, SpawnError> {
+        let mut command = Command::new(&config.command);
+        command
+            .args(&config.args)
+            .envs(&config.env)
+            .current_dir(root)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = command.spawn().map_err(|e| SpawnError {
+            reason: format!("failed to spawn `{}`: {e}", config.command),
+            stderr: Vec::new(),
+        })?;
+
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stdin = child.stdin.take().expect("piped stdin");
+        let stderr = child.stderr.take().expect("piped stderr");
+
+        // Drain stderr into a bounded ring buffer for diagnostics.
+        let stderr_lines = Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_RING_CAPACITY)));
+        {
+            let stderr_lines = Arc::clone(&stderr_lines);
+            std::thread::spawn(move || {
+                let reader = std::io::BufReader::new(stderr);
+                for line in reader.lines().map_while(|l| l.ok()) {
+                    let mut ring = stderr_lines.lock().unwrap();
+                    if ring.len() >= STDERR_RING_CAPACITY {
+                        ring.pop_front();
+                    }
+                    ring.push_back(line);
+                }
+            });
+        }
+
+        let transport = Transport::new(stdout, stdin, verbose);
+
+        let mut client = Self {
+            transport,
+            child,
+            stderr_lines,
+            request_timeout: config
+                .timeout_ms
+                .map(Duration::from_millis)
+                .unwrap_or(DEFAULT_REQUEST_TIMEOUT),
+            failed: None,
+            consecutive_timeouts: 0,
+            warmup_pending: true,
+            shut_down: false,
+            server_name: None,
+            server_version: None,
+            capabilities: Value::Null,
+        };
+
+        client.initialize(config, root).map_err(|reason| {
+            let stderr = client.recent_stderr();
+            client.kill();
+            SpawnError { reason, stderr }
+        })?;
+
+        Ok(client)
+    }
+
+    /// Run the `initialize` request and `initialized` notification.
+    fn initialize(&mut self, config: &LspServerConfig, root: &Path) -> Result<(), String> {
+        let root_uri = path_to_uri(root);
+        let mut params = json!({
+            "processId": std::process::id(),
+            "rootUri": root_uri,
+            "workspaceFolders": [{
+                "uri": root_uri,
+                "name": root.file_name().and_then(|n| n.to_str()).unwrap_or("workspace"),
+            }],
+            "capabilities": {
+                "textDocument": {
+                    "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true,
+                    },
+                    "definition": { "linkSupport": true },
+                    "implementation": { "linkSupport": true },
+                    "references": {},
+                    "callHierarchy": {},
+                    "synchronization": {
+                        "didSave": false,
+                        "willSave": false,
+                        "willSaveWaitUntil": false,
+                    },
+                },
+                "workspace": {
+                    "configuration": true,
+                    "workspaceFolders": true,
+                },
+            },
+        });
+        if let Some(options) = &config.initialization_options {
+            params["initializationOptions"] = options.clone();
+        }
+
+        let result = self
+            .transport
+            .request("initialize", params, INITIALIZE_TIMEOUT)
+            .map_err(|e| format!("initialize failed: {e}"))?;
+
+        self.server_name = result
+            .pointer("/serverInfo/name")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        self.server_version = result
+            .pointer("/serverInfo/version")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        self.capabilities = result.get("capabilities").cloned().unwrap_or(Value::Null);
+
+        self.transport
+            .notify("initialized", json!({}))
+            .map_err(|e| format!("initialized notification failed: {e}"))?;
+
+        Ok(())
+    }
+
+    /// Whether the server has been declared unusable, and why.
+    pub fn failure(&self) -> Option<&str> {
+        self.failed.as_deref()
+    }
+
+    /// Server name/version reported during `initialize`.
+    pub fn server_info(&self) -> (Option<&str>, Option<&str>) {
+        (self.server_name.as_deref(), self.server_version.as_deref())
+    }
+
+    /// Names of negotiated server capabilities (keys of the `capabilities`
+    /// object whose value is not `false`/`null`).
+    pub fn capability_names(&self) -> Vec<String> {
+        match &self.capabilities {
+            Value::Object(map) => map
+                .iter()
+                .filter(|(_, v)| !matches!(v, Value::Null | Value::Bool(false)))
+                .map(|(k, _)| k.clone())
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Whether the server negotiated a truthy capability under `key`
+    /// (e.g. `"documentSymbolProvider"`).
+    pub fn supports(&self, key: &str) -> bool {
+        !matches!(
+            self.capabilities.get(key),
+            None | Some(Value::Null) | Some(Value::Bool(false))
+        )
+    }
+
+    /// The most recent stderr lines from the server process.
+    pub fn recent_stderr(&self) -> Vec<String> {
+        self.stderr_lines.lock().unwrap().iter().cloned().collect()
+    }
+
+    /// Send a request with failure accounting (timeouts, broken pipes).
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+        if let Some(reason) = &self.failed {
+            return Err(reason.clone());
+        }
+
+        let timeout = if self.warmup_pending {
+            self.request_timeout.max(WARMUP_TIMEOUT)
+        } else {
+            self.request_timeout
+        };
+
+        match self.transport.request(method, params, timeout) {
+            Ok(value) => {
+                self.warmup_pending = false;
+                self.consecutive_timeouts = 0;
+                Ok(value)
+            }
+            Err(TransportError::Timeout) => {
+                self.warmup_pending = false;
+                self.consecutive_timeouts += 1;
+                if self.consecutive_timeouts >= MAX_CONSECUTIVE_TIMEOUTS {
+                    self.fail(format!(
+                        "{MAX_CONSECUTIVE_TIMEOUTS} consecutive request timeouts (last: {method})"
+                    ));
+                }
+                Err(format!("{method} timed out"))
+            }
+            Err(TransportError::Closed) => {
+                let reason = format!("connection lost during {method} (server exited?)");
+                self.fail(reason.clone());
+                Err(reason)
+            }
+            Err(TransportError::Io(e)) => {
+                let reason = format!("write failed during {method}: {e}");
+                self.fail(reason.clone());
+                Err(reason)
+            }
+            // A JSON-RPC error is a *response*: the server is alive, the
+            // request just isn't supported/valid. Don't fail the client.
+            Err(TransportError::Rpc(e)) => {
+                self.warmup_pending = false;
+                self.consecutive_timeouts = 0;
+                Err(format!("{method}: {e}"))
+            }
+        }
+    }
+
+    /// Declare the server unusable and kill the process.
+    fn fail(&mut self, reason: String) {
+        if self.failed.is_none() {
+            self.failed = Some(reason);
+        }
+        self.kill();
+    }
+
+    fn kill(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        self.shut_down = true;
+    }
+
+    // ---- Notifications -----------------------------------------------------
+
+    /// `textDocument/didOpen` with full text sync.
+    ///
+    /// A failed write means the server is gone (e.g. it crashed right after
+    /// `initialize`): the client is marked failed so the caller falls back
+    /// with the usual once-per-language warning.
+    pub fn did_open(&mut self, uri: &str, language_id: &str, text: &str) -> Result<(), String> {
+        if let Some(reason) = &self.failed {
+            return Err(reason.clone());
+        }
+        match self.transport.notify(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": language_id,
+                    "version": 1,
+                    "text": text,
+                }
+            }),
+        ) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let reason = format!("connection lost during textDocument/didOpen: {e}");
+                self.fail(reason.clone());
+                Err(reason)
+            }
+        }
+    }
+
+    /// `textDocument/didClose`.
+    pub fn did_close(&mut self, uri: &str) {
+        if self.failed.is_some() {
+            return;
+        }
+        let _ = self.transport.notify(
+            "textDocument/didClose",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+    }
+
+    // ---- Typed request wrappers --------------------------------------------
+
+    /// `textDocument/documentSymbol`. `Ok(None)` means the server returned
+    /// `null` (no symbols).
+    pub fn document_symbols(
+        &mut self,
+        uri: &str,
+    ) -> Result<Option<DocumentSymbolResponse>, String> {
+        let result = self.request(
+            "textDocument/documentSymbol",
+            json!({ "textDocument": { "uri": uri } }),
+        )?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        serde_json::from_value(result)
+            .map(Some)
+            .map_err(|e| format!("malformed documentSymbol response: {e}"))
+    }
+
+    /// `textDocument/definition` at a 0-based position. Returns the first
+    /// resulting location, if any.
+    pub fn definition(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<(String, u32)>, String> {
+        let result = self.request(
+            "textDocument/definition",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+            }),
+        )?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        let response: GotoDefinitionResponse = serde_json::from_value(result)
+            .map_err(|e| format!("malformed definition response: {e}"))?;
+        Ok(first_definition_target(response))
+    }
+
+    /// `textDocument/prepareCallHierarchy` at a 0-based position.
+    pub fn prepare_call_hierarchy(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<CallHierarchyItem>, String> {
+        let result = self.request(
+            "textDocument/prepareCallHierarchy",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+            }),
+        )?;
+        if result.is_null() {
+            return Ok(Vec::new());
+        }
+        serde_json::from_value(result)
+            .map_err(|e| format!("malformed prepareCallHierarchy response: {e}"))
+    }
+
+    /// `callHierarchy/outgoingCalls` for a prepared item.
+    pub fn outgoing_calls(
+        &mut self,
+        item: &CallHierarchyItem,
+    ) -> Result<Vec<CallHierarchyOutgoingCall>, String> {
+        let item_value = serde_json::to_value(item).map_err(|e| format!("serialize item: {e}"))?;
+        let result = self.request("callHierarchy/outgoingCalls", json!({ "item": item_value }))?;
+        if result.is_null() {
+            return Ok(Vec::new());
+        }
+        serde_json::from_value(result).map_err(|e| format!("malformed outgoingCalls response: {e}"))
+    }
+
+    /// `textDocument/implementation` at a 0-based position.
+    pub fn implementation(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<(String, u32)>, String> {
+        let result = self.request(
+            "textDocument/implementation",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+            }),
+        )?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        let response: GotoDefinitionResponse = serde_json::from_value(result)
+            .map_err(|e| format!("malformed implementation response: {e}"))?;
+        Ok(first_definition_target(response))
+    }
+
+    /// `textDocument/references` at a 0-based position.
+    pub fn references(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<(String, u32)>, String> {
+        let result = self.request(
+            "textDocument/references",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+                "context": { "includeDeclaration": false },
+            }),
+        )?;
+        if result.is_null() {
+            return Ok(Vec::new());
+        }
+        let locations: Vec<Location> = serde_json::from_value(result)
+            .map_err(|e| format!("malformed references response: {e}"))?;
+        Ok(locations.iter().map(location_target).collect())
+    }
+
+    /// Graceful shutdown: `shutdown` request (2s) -> `exit` notification ->
+    /// bounded wait -> kill. Safe to call more than once.
+    pub fn shutdown(&mut self) {
+        if self.shut_down {
+            return;
+        }
+        self.shut_down = true;
+
+        if self.failed.is_none() {
+            let _ = self
+                .transport
+                .request("shutdown", Value::Null, SHUTDOWN_TIMEOUT);
+            let _ = self.transport.notify("exit", Value::Null);
+        }
+
+        // Bounded wait for the process to exit, then kill.
+        let deadline = std::time::Instant::now() + SHUTDOWN_TIMEOUT;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for LspClient {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Reduce a definition-style response to `(uri, 0-based start line)` of its
+/// first target.
+fn first_definition_target(response: GotoDefinitionResponse) -> Option<(String, u32)> {
+    match response {
+        GotoDefinitionResponse::Scalar(location) => Some(location_target(&location)),
+        GotoDefinitionResponse::Array(locations) => locations.first().map(location_target),
+        GotoDefinitionResponse::Link(links) => links.first().map(|link| {
+            (
+                link.target_uri.as_str().to_string(),
+                link.target_selection_range.start.line,
+            )
+        }),
+    }
+}
+
+fn location_target(location: &Location) -> (String, u32) {
+    (location.uri.as_str().to_string(), location.range.start.line)
+}

--- a/src/lsp/config.rs
+++ b/src/lsp/config.rs
@@ -18,8 +18,50 @@
 //! `ctx index` keeps working with the remaining (or builtin) backends.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use serde::Deserialize;
+
+/// The `[lsp.*]` sections of `.ctx/config.toml`, loaded independently of
+/// [`crate::config::CtxConfig`] so the optional LSP subsystem never changes
+/// that struct's public shape. Unknown keys are ignored so older binaries
+/// tolerate newer config files.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct LspConfig {
+    /// Language servers keyed by language name (`[lsp.kotlin]`,
+    /// `[lsp.python]`, ...). Empty map when no LSP is configured — the LSP
+    /// subsystem then never spawns anything.
+    pub lsp: BTreeMap<String, LspServerConfig>,
+}
+
+impl LspConfig {
+    /// Load `<root>/.ctx/config.toml`. A missing file yields defaults; a
+    /// malformed file yields defaults with a warning (never fatal — config
+    /// is optional, matching [`crate::config::CtxConfig::load`]).
+    pub fn load(root: &Path) -> Self {
+        Self::load_file(
+            &root
+                .join(crate::index::CTX_DIR)
+                .join(crate::config::CONFIG_FILE),
+        )
+    }
+
+    /// Load from an explicit path (used by tests and [`LspConfig::load`]).
+    pub fn load_file(path: &Path) -> Self {
+        let text = match std::fs::read_to_string(path) {
+            Ok(text) => text,
+            Err(_) => return Self::default(), // absent/unreadable → defaults
+        };
+        match toml::from_str(&text) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("Warning: ignoring malformed {} ({e})", path.display());
+                Self::default()
+            }
+        }
+    }
+}
 
 /// Per-language extraction backend selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
@@ -293,5 +335,72 @@ extensions = [".KT", " kts "]
         assert_eq!(servers["kotlin"].extensions, vec!["kt", "kts"]);
         assert_eq!(claims["kt"], "kotlin");
         assert_eq!(claims["kts"], "kotlin");
+    }
+
+    fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn load_parses_lsp_sections_and_ignores_other_tables() {
+        let f = write_temp(
+            r#"
+[embedding]
+provider = "local"
+
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]
+backend = "lsp"
+timeout_ms = 15000
+env = { JAVA_HOME = "/opt/java" }
+
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+initialization_options = { python = { venvPath = ".venv" } }
+"#,
+        );
+        let cfg = LspConfig::load_file(f.path());
+        assert_eq!(cfg.lsp.len(), 2);
+
+        let kotlin = &cfg.lsp["kotlin"];
+        assert_eq!(kotlin.command, "kotlin-language-server");
+        assert_eq!(kotlin.extensions, vec!["kt", "kts"]);
+        assert_eq!(kotlin.backend, LspBackend::Lsp);
+        assert_eq!(kotlin.timeout_ms, Some(15000));
+        assert_eq!(kotlin.env["JAVA_HOME"], "/opt/java");
+
+        let python = &cfg.lsp["python"];
+        assert_eq!(python.args, vec!["--stdio"]);
+        assert_eq!(python.backend, LspBackend::Hybrid, "default");
+        assert!(python.initialization_options.is_some());
+    }
+
+    #[test]
+    fn load_malformed_file_falls_back_to_defaults() {
+        // A type error anywhere in the file keeps load fault-tolerant.
+        let f = write_temp(
+            r#"
+[lsp.kotlin]
+command = 42
+"#,
+        );
+        assert!(LspConfig::load_file(f.path()).lsp.is_empty());
+
+        let f = write_temp("this is not valid toml : : :");
+        assert!(LspConfig::load_file(f.path()).lsp.is_empty());
+    }
+
+    #[test]
+    fn load_missing_file_is_default() {
+        assert!(
+            LspConfig::load_file(std::path::Path::new("/nonexistent/config.toml"))
+                .lsp
+                .is_empty()
+        );
     }
 }

--- a/src/lsp/config.rs
+++ b/src/lsp/config.rs
@@ -1,0 +1,297 @@
+//! Declarative LSP server registration (`[lsp.<language>]` in `.ctx/config.toml`).
+//!
+//! Users register any stdio language server per language:
+//!
+//! ```toml
+//! [lsp.kotlin]
+//! command = "kotlin-language-server"
+//! extensions = ["kt", "kts"]
+//! backend = "lsp"            # tree-sitter | lsp | hybrid (default hybrid)
+//!
+//! [lsp.python]
+//! command = "pyright-langserver"
+//! args = ["--stdio"]
+//! # extensions default to the builtin set for builtin language names
+//! ```
+//!
+//! Configuration is never fatal: invalid blocks are skipped with a warning so
+//! `ctx index` keeps working with the remaining (or builtin) backends.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// Per-language extraction backend selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LspBackend {
+    /// Extract with tree-sitter only (LSP block is effectively disabled for
+    /// extraction; useful to keep a registration around without using it).
+    TreeSitter,
+    /// Extract symbols and call edges with the language server.
+    Lsp,
+    /// Extract with tree-sitter, then use the language server to resolve
+    /// cross-file references tree-sitter left unresolved.
+    #[default]
+    Hybrid,
+}
+
+impl LspBackend {
+    /// Stable string form (matches the kebab-case config spelling).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LspBackend::TreeSitter => "tree-sitter",
+            LspBackend::Lsp => "lsp",
+            LspBackend::Hybrid => "hybrid",
+        }
+    }
+}
+
+/// One `[lsp.<language>]` block. All fields are optional except `command`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct LspServerConfig {
+    /// Executable to spawn (resolved via `PATH` unless absolute).
+    pub command: String,
+    /// Arguments passed to the server (e.g. `["--stdio"]`).
+    pub args: Vec<String>,
+    /// File extensions (without the dot) this server claims. Defaults to the
+    /// builtin extension set when the block key is a builtin language name.
+    pub extensions: Vec<String>,
+    /// Marker files/dirs identifying a workspace root (informational; used by
+    /// health checks).
+    pub root_markers: Vec<String>,
+    /// Capabilities the user expects the server to provide (e.g.
+    /// `["documentSymbol", "definition"]`); compared against the negotiated
+    /// server capabilities by the doctor probe.
+    pub capabilities: Vec<String>,
+    /// Extraction backend for files claimed by this block.
+    pub backend: LspBackend,
+    /// Passed through verbatim as LSP `initializationOptions`.
+    pub initialization_options: Option<serde_json::Value>,
+    /// Extra environment variables for the server process.
+    pub env: BTreeMap<String, String>,
+    /// Per-request timeout in milliseconds (default 10 000).
+    pub timeout_ms: Option<u64>,
+    /// Provenance metadata written by tooling (`ctx lsp add`); accepted and
+    /// ignored so configs from newer binaries keep loading.
+    pub source: Option<String>,
+    /// Provenance metadata written by tooling; accepted and ignored.
+    pub source_server: Option<String>,
+}
+
+/// Builtin extension sets, keyed by the builtin language name used as an
+/// `[lsp.<name>]` table key (mirrors [`crate::parser::Language::from_path`]).
+pub(crate) fn builtin_extensions(language: &str) -> Option<&'static [&'static str]> {
+    match language {
+        "rust" => Some(&["rs"]),
+        "typescript" => Some(&["ts"]),
+        "tsx" => Some(&["tsx"]),
+        "javascript" => Some(&["js", "mjs", "cjs"]),
+        "jsx" => Some(&["jsx"]),
+        "python" => Some(&["py", "pyi"]),
+        "go" => Some(&["go"]),
+        "solidity" => Some(&["sol"]),
+        "yaml" => Some(&["yaml", "yml"]),
+        _ => None,
+    }
+}
+
+/// Validate and normalize the raw `[lsp.*]` blocks from `.ctx/config.toml`.
+///
+/// Never fatal: invalid blocks are dropped with an `eprintln!` warning.
+/// Returns the surviving blocks plus the extension → language claim map
+/// (first block wins on duplicate extension claims, in table-key order).
+pub(crate) fn validate(
+    lsp: &BTreeMap<String, LspServerConfig>,
+) -> (BTreeMap<String, LspServerConfig>, BTreeMap<String, String>) {
+    let mut servers: BTreeMap<String, LspServerConfig> = BTreeMap::new();
+    let mut extension_claims: BTreeMap<String, String> = BTreeMap::new();
+
+    for (language, raw) in lsp {
+        let mut cfg = raw.clone();
+
+        if cfg.command.trim().is_empty() {
+            eprintln!("Warning: ignoring [lsp.{language}] in .ctx/config.toml: `command` is empty");
+            continue;
+        }
+
+        // Normalize extensions: lowercase, no leading dot, no empties.
+        cfg.extensions = cfg
+            .extensions
+            .iter()
+            .map(|e| e.trim().trim_start_matches('.').to_ascii_lowercase())
+            .filter(|e| !e.is_empty())
+            .collect();
+
+        if cfg.extensions.is_empty() {
+            match builtin_extensions(language) {
+                Some(defaults) => {
+                    cfg.extensions = defaults.iter().map(|e| e.to_string()).collect();
+                }
+                None => {
+                    eprintln!(
+                        "Warning: ignoring [lsp.{language}] in .ctx/config.toml: \
+                         `extensions` is required for non-builtin languages"
+                    );
+                    continue;
+                }
+            }
+        }
+
+        for ext in &cfg.extensions {
+            match extension_claims.get(ext) {
+                Some(owner) => {
+                    eprintln!(
+                        "Warning: [lsp.{language}] also claims extension `.{ext}`, \
+                         already claimed by [lsp.{owner}]; first claim wins"
+                    );
+                }
+                None => {
+                    extension_claims.insert(ext.clone(), language.clone());
+                }
+            }
+        }
+
+        servers.insert(language.clone(), cfg);
+    }
+
+    (servers, extension_claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml_text: &str) -> BTreeMap<String, LspServerConfig> {
+        #[derive(Deserialize, Default)]
+        #[serde(default)]
+        struct Wrapper {
+            lsp: BTreeMap<String, LspServerConfig>,
+        }
+        toml::from_str::<Wrapper>(toml_text)
+            .expect("valid toml")
+            .lsp
+    }
+
+    #[test]
+    fn defaults_and_backend_enum() {
+        let lsp = parse(
+            r#"
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]
+backend = "lsp"
+
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+
+[lsp.rust]
+command = "rust-analyzer"
+backend = "tree-sitter"
+timeout_ms = 5000
+"#,
+        );
+        assert_eq!(lsp["kotlin"].backend, LspBackend::Lsp);
+        assert_eq!(
+            lsp["python"].backend,
+            LspBackend::Hybrid,
+            "default is hybrid"
+        );
+        assert_eq!(lsp["rust"].backend, LspBackend::TreeSitter);
+        assert_eq!(lsp["python"].args, vec!["--stdio"]);
+        assert_eq!(lsp["rust"].timeout_ms, Some(5000));
+        assert!(lsp["kotlin"].initialization_options.is_none());
+        assert!(lsp["kotlin"].env.is_empty());
+
+        let (servers, claims) = validate(&lsp);
+        assert_eq!(servers.len(), 3);
+        // Builtin names get builtin extension defaults.
+        assert_eq!(servers["python"].extensions, vec!["py", "pyi"]);
+        assert_eq!(servers["rust"].extensions, vec!["rs"]);
+        assert_eq!(claims["kt"], "kotlin");
+        assert_eq!(claims["py"], "python");
+    }
+
+    #[test]
+    fn tolerates_provenance_keys_and_unknown_keys() {
+        let lsp = parse(
+            r#"
+[lsp.kotlin]
+command = "kls"
+extensions = ["kt"]
+source = "ctx lsp add"
+source_server = "kotlin-language-server@1.3"
+some_future_key = true
+"#,
+        );
+        assert_eq!(lsp["kotlin"].command, "kls");
+        assert_eq!(lsp["kotlin"].source.as_deref(), Some("ctx lsp add"));
+        assert_eq!(
+            lsp["kotlin"].source_server.as_deref(),
+            Some("kotlin-language-server@1.3")
+        );
+    }
+
+    #[test]
+    fn empty_command_is_dropped_not_fatal() {
+        let lsp = parse(
+            r#"
+[lsp.kotlin]
+command = ""
+extensions = ["kt"]
+"#,
+        );
+        let (servers, claims) = validate(&lsp);
+        assert!(servers.is_empty());
+        assert!(claims.is_empty());
+    }
+
+    #[test]
+    fn dynamic_language_without_extensions_is_dropped() {
+        let lsp = parse(
+            r#"
+[lsp.kotlin]
+command = "kls"
+"#,
+        );
+        let (servers, _) = validate(&lsp);
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn duplicate_extension_claims_first_wins() {
+        let lsp = parse(
+            r#"
+[lsp.alpha]
+command = "a-ls"
+extensions = ["zz"]
+
+[lsp.beta]
+command = "b-ls"
+extensions = ["zz", "yy"]
+"#,
+        );
+        let (servers, claims) = validate(&lsp);
+        assert_eq!(servers.len(), 2);
+        // BTreeMap order: alpha validates first and claims `.zz`.
+        assert_eq!(claims["zz"], "alpha");
+        assert_eq!(claims["yy"], "beta");
+    }
+
+    #[test]
+    fn extensions_are_normalized() {
+        let lsp = parse(
+            r#"
+[lsp.kotlin]
+command = "kls"
+extensions = [".KT", " kts "]
+"#,
+        );
+        let (servers, claims) = validate(&lsp);
+        assert_eq!(servers["kotlin"].extensions, vec!["kt", "kts"]);
+        assert_eq!(claims["kt"], "kotlin");
+        assert_eq!(claims["kts"], "kotlin");
+    }
+}

--- a/src/lsp/config.rs
+++ b/src/lsp/config.rs
@@ -158,6 +158,15 @@ pub(crate) fn validate(
             continue;
         }
 
+        // Validation floor: a zero timeout would make every request fail
+        // instantly; treat it as "not set" (the built-in default applies).
+        if cfg.timeout_ms == Some(0) {
+            eprintln!(
+                "Warning: [lsp.{language}] timeout_ms = 0 is invalid; using the default timeout"
+            );
+            cfg.timeout_ms = None;
+        }
+
         // Normalize extensions: lowercase, no leading dot, no empties.
         cfg.extensions = cfg
             .extensions
@@ -300,6 +309,33 @@ command = "kls"
         );
         let (servers, _) = validate(&lsp);
         assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn zero_timeout_is_floored_to_default() {
+        let lsp = parse(
+            r#"
+[lsp.python]
+command = "pyls"
+timeout_ms = 0
+"#,
+        );
+        let (servers, _) = validate(&lsp);
+        assert_eq!(
+            servers["python"].timeout_ms, None,
+            "0 falls back to default"
+        );
+
+        // Non-zero values pass through.
+        let lsp = parse(
+            r#"
+[lsp.python]
+command = "pyls"
+timeout_ms = 200
+"#,
+        );
+        let (servers, _) = validate(&lsp);
+        assert_eq!(servers["python"].timeout_ms, Some(200));
     }
 
     #[test]

--- a/src/lsp/extract.rs
+++ b/src/lsp/extract.rs
@@ -1,0 +1,582 @@
+//! Convert LSP responses into ctx's extraction contract
+//! ([`crate::db::Symbol`] / [`crate::db::Edge`]).
+//!
+//! Provisional symbol ids use [`Symbol::make_id`] (no line suffix) exactly
+//! like the tree-sitter parsers, so `store_symbols` rewrites them into the
+//! canonical `path::[parent::]name@line` form through the same id map.
+
+use lsp_types::{
+    CallHierarchyOutgoingCall, DocumentSymbol, DocumentSymbolResponse, SymbolInformation,
+    SymbolKind as LspSymbolKind,
+};
+
+use crate::db::{Edge, EdgeKind, Symbol, SymbolKind, Visibility};
+
+/// A converted symbol plus the LSP selection position (0-based) needed for
+/// follow-up requests such as `prepareCallHierarchy`.
+#[derive(Debug, Clone)]
+pub struct ExtractedSymbol {
+    pub symbol: Symbol,
+    /// 0-based line of the symbol's selection range (its name).
+    pub sel_line: u32,
+    /// 0-based character of the symbol's selection range.
+    pub sel_col: u32,
+}
+
+/// Map an LSP symbol kind to a ctx [`SymbolKind`].
+///
+/// Variable-like kinds map to [`SymbolKind::Variable`]; the callers skip
+/// those when they are nested inside a function/method body (locals).
+/// Unknown kinds return `None` and are dropped.
+fn map_kind(kind: LspSymbolKind) -> Option<SymbolKind> {
+    Some(match kind {
+        LspSymbolKind::FILE
+        | LspSymbolKind::MODULE
+        | LspSymbolKind::NAMESPACE
+        | LspSymbolKind::PACKAGE => SymbolKind::Module,
+        LspSymbolKind::CLASS => SymbolKind::Class,
+        LspSymbolKind::METHOD | LspSymbolKind::CONSTRUCTOR | LspSymbolKind::OPERATOR => {
+            SymbolKind::Method
+        }
+        LspSymbolKind::PROPERTY | LspSymbolKind::FIELD | LspSymbolKind::EVENT => SymbolKind::Field,
+        LspSymbolKind::ENUM => SymbolKind::Enum,
+        LspSymbolKind::ENUM_MEMBER => SymbolKind::Variant,
+        LspSymbolKind::INTERFACE => SymbolKind::Interface,
+        LspSymbolKind::FUNCTION => SymbolKind::Function,
+        LspSymbolKind::CONSTANT => SymbolKind::Const,
+        LspSymbolKind::STRUCT => SymbolKind::Struct,
+        LspSymbolKind::TYPE_PARAMETER => SymbolKind::Type,
+        LspSymbolKind::VARIABLE
+        | LspSymbolKind::STRING
+        | LspSymbolKind::NUMBER
+        | LspSymbolKind::BOOLEAN
+        | LspSymbolKind::ARRAY
+        | LspSymbolKind::OBJECT
+        | LspSymbolKind::KEY
+        | LspSymbolKind::NULL => SymbolKind::Variable,
+        _ => return None,
+    })
+}
+
+/// Variable-like kinds are locals when nested inside a function/method and
+/// must be skipped.
+fn is_variable_like(kind: SymbolKind) -> bool {
+    matches!(kind, SymbolKind::Variable)
+}
+
+fn is_function_like(kind: SymbolKind) -> bool {
+    matches!(kind, SymbolKind::Function | SymbolKind::Method)
+}
+
+/// Convert a `textDocument/documentSymbol` response into symbols.
+pub fn symbols_from_response(
+    rel_path: &str,
+    text: &str,
+    response: DocumentSymbolResponse,
+) -> Vec<ExtractedSymbol> {
+    match response {
+        DocumentSymbolResponse::Nested(roots) => {
+            let lines: Vec<&str> = text.lines().collect();
+            let mut out = Vec::new();
+            for root in &roots {
+                convert_nested(rel_path, &lines, root, &[], &mut out);
+            }
+            out
+        }
+        DocumentSymbolResponse::Flat(infos) => convert_flat(rel_path, text, &infos),
+    }
+}
+
+/// Recursively convert a hierarchical [`DocumentSymbol`] subtree.
+///
+/// `ancestors` is the chain of (name, ctx-kind) pairs above this node.
+fn convert_nested(
+    rel_path: &str,
+    lines: &[&str],
+    node: &DocumentSymbol,
+    ancestors: &[(String, SymbolKind)],
+    out: &mut Vec<ExtractedSymbol>,
+) {
+    let Some(kind) = map_kind(node.kind) else {
+        return;
+    };
+
+    // Skip locals: variable-like symbols nested inside a function/method
+    // body (and their subtrees) are not indexed.
+    let inside_function = ancestors
+        .last()
+        .map(|(_, k)| is_function_like(*k))
+        .unwrap_or(false);
+    if is_variable_like(kind) && inside_function {
+        return;
+    }
+
+    let name = node.name.trim().to_string();
+    if name.is_empty() {
+        return;
+    }
+
+    let parent_name = ancestors.last().map(|(n, _)| n.as_str());
+    let id = Symbol::make_id(rel_path, &name, parent_name);
+    let parent_id = parent_name.map(|p| Symbol::make_id(rel_path, p, None));
+
+    // Qualified name: parent chain + own name joined with "." (None at the
+    // top level, mirroring the tree-sitter extractors).
+    let qualified_name = if ancestors.is_empty() {
+        None
+    } else {
+        let mut parts: Vec<&str> = ancestors.iter().map(|(n, _)| n.as_str()).collect();
+        parts.push(&name);
+        Some(parts.join("."))
+    };
+
+    // LSP positions are 0-based; ctx lines are 1-based (columns stay 0-based).
+    let line_start = node.range.start.line + 1;
+    let line_end = node.range.end.line + 1;
+
+    let signature = node
+        .detail
+        .as_deref()
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+        .map(str::to_string);
+
+    let source = slice_lines(lines, node.range.start.line, node.range.end.line);
+
+    let visibility = if name.starts_with('_') {
+        Visibility::Private
+    } else {
+        Visibility::Public
+    };
+
+    out.push(ExtractedSymbol {
+        symbol: Symbol {
+            id,
+            file_path: rel_path.to_string(),
+            name: name.clone(),
+            qualified_name,
+            kind,
+            visibility,
+            signature,
+            brief: None,
+            docstring: None,
+            line_start,
+            line_end,
+            col_start: node.range.start.character,
+            col_end: node.range.end.character,
+            parent_id,
+            source,
+        },
+        sel_line: node.selection_range.start.line,
+        sel_col: node.selection_range.start.character,
+    });
+
+    if let Some(children) = &node.children {
+        let mut chain = ancestors.to_vec();
+        chain.push((name, kind));
+        for child in children {
+            convert_nested(rel_path, lines, child, &chain, out);
+        }
+    }
+}
+
+/// Convert a flat [`SymbolInformation`] list (servers without hierarchical
+/// document symbols). Containers are only known by name (`container_name`),
+/// so nesting is approximated through the parent name alone.
+fn convert_flat(rel_path: &str, text: &str, infos: &[SymbolInformation]) -> Vec<ExtractedSymbol> {
+    let lines: Vec<&str> = text.lines().collect();
+
+    // Names of function-like symbols, to apply the local-variable skip rule.
+    let function_names: Vec<&str> = infos
+        .iter()
+        .filter(|i| map_kind(i.kind).map(is_function_like).unwrap_or(false))
+        .map(|i| i.name.as_str())
+        .collect();
+
+    let mut out = Vec::new();
+    for info in infos {
+        let Some(kind) = map_kind(info.kind) else {
+            continue;
+        };
+
+        let container = info
+            .container_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|c| !c.is_empty());
+
+        if is_variable_like(kind) {
+            if let Some(container) = container {
+                if function_names.contains(&container) {
+                    continue; // local inside a function/method
+                }
+            }
+        }
+
+        let name = info.name.trim().to_string();
+        if name.is_empty() {
+            continue;
+        }
+
+        let id = Symbol::make_id(rel_path, &name, container);
+        let parent_id = container.map(|p| Symbol::make_id(rel_path, p, None));
+        let qualified_name = container.map(|c| format!("{c}.{name}"));
+
+        let range = info.location.range;
+        let visibility = if name.starts_with('_') {
+            Visibility::Private
+        } else {
+            Visibility::Public
+        };
+
+        out.push(ExtractedSymbol {
+            symbol: Symbol {
+                id,
+                file_path: rel_path.to_string(),
+                name,
+                qualified_name,
+                kind,
+                visibility,
+                signature: None,
+                brief: None,
+                docstring: None,
+                line_start: range.start.line + 1,
+                line_end: range.end.line + 1,
+                col_start: range.start.character,
+                col_end: range.end.character,
+                parent_id,
+                source: slice_lines(&lines, range.start.line, range.end.line),
+            },
+            sel_line: range.start.line,
+            sel_col: range.start.character,
+        });
+    }
+    out
+}
+
+/// Inclusive 0-based line slice of the file text.
+fn slice_lines(lines: &[&str], start: u32, end: u32) -> Option<String> {
+    let start = start as usize;
+    let end = (end as usize).min(lines.len().saturating_sub(1));
+    if start >= lines.len() || start > end {
+        return None;
+    }
+    Some(lines[start..=end].join("\n"))
+}
+
+/// Convert `callHierarchy/outgoingCalls` results for one source symbol into
+/// `Calls` edges.
+///
+/// Same-file targets are wired to the target's provisional id (rewritten by
+/// `store_symbols` through the shared id map). Cross-file targets stay
+/// unresolved (`target_id: None`) and carry the call-site line/col so Stage B
+/// can resolve them with `textDocument/definition`. They must never be routed
+/// through `store_edges`' path rewriting.
+pub fn edges_from_outgoing_calls(
+    source: &ExtractedSymbol,
+    file_uri: &str,
+    file_symbols: &[ExtractedSymbol],
+    calls: &[CallHierarchyOutgoingCall],
+) -> Vec<Edge> {
+    let mut edges = Vec::new();
+
+    for call in calls {
+        let target_name = call.to.name.trim().to_string();
+        if target_name.is_empty() {
+            continue;
+        }
+
+        // Same-file target: match the extracted symbol whose selection range
+        // starts where the call-hierarchy item's does.
+        let same_file = call.to.uri.as_str() == file_uri;
+        let target_id = if same_file {
+            file_symbols
+                .iter()
+                .find(|s| {
+                    s.sel_line == call.to.selection_range.start.line
+                        && s.sel_col == call.to.selection_range.start.character
+                })
+                .or_else(|| {
+                    file_symbols.iter().find(|s| {
+                        s.symbol.name == target_name
+                            && s.symbol.line_start == call.to.range.start.line + 1
+                    })
+                })
+                .map(|s| s.symbol.id.clone())
+        } else {
+            None
+        };
+
+        for range in &call.from_ranges {
+            edges.push(Edge {
+                source_id: source.symbol.id.clone(),
+                target_id: target_id.clone(),
+                target_name: target_name.clone(),
+                kind: EdgeKind::Calls,
+                line: Some(range.start.line + 1),
+                col: Some(range.start.character),
+                context: Some(target_name.clone()),
+            });
+        }
+
+        // Some servers return no from_ranges; still record one edge so the
+        // relationship isn't lost (without a call-site location it cannot be
+        // Stage-B resolved, but same-file targets are already resolved).
+        if call.from_ranges.is_empty() {
+            edges.push(Edge {
+                source_id: source.symbol.id.clone(),
+                target_id: target_id.clone(),
+                target_name: target_name.clone(),
+                kind: EdgeKind::Calls,
+                line: None,
+                col: None,
+                context: Some(target_name.clone()),
+            });
+        }
+    }
+
+    edges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const KOTLIN_FIXTURE: &str = "class Greeter {\n    val name = \"x\"\n    fun greet(who: String): String {\n        val message = \"hi\"\n        return message + who\n    }\n}\nfun _hidden() {}\nfun top() {}\n";
+
+    /// A hierarchical documentSymbol response for `KOTLIN_FIXTURE`.
+    fn nested_response() -> DocumentSymbolResponse {
+        serde_json::from_value(json!([
+            {
+                "name": "Greeter",
+                "kind": 5, // Class
+                "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 6, "character": 1 } },
+                "selectionRange": { "start": { "line": 0, "character": 6 }, "end": { "line": 0, "character": 13 } },
+                "children": [
+                    {
+                        "name": "name",
+                        "kind": 8, // Field
+                        "range": { "start": { "line": 1, "character": 4 }, "end": { "line": 1, "character": 18 } },
+                        "selectionRange": { "start": { "line": 1, "character": 8 }, "end": { "line": 1, "character": 12 } }
+                    },
+                    {
+                        "name": "greet",
+                        "detail": "fun greet(who: String): String",
+                        "kind": 6, // Method
+                        "range": { "start": { "line": 2, "character": 4 }, "end": { "line": 5, "character": 5 } },
+                        "selectionRange": { "start": { "line": 2, "character": 8 }, "end": { "line": 2, "character": 13 } },
+                        "children": [
+                            {
+                                "name": "message",
+                                "kind": 13, // Variable -> local, skipped
+                                "range": { "start": { "line": 3, "character": 8 }, "end": { "line": 3, "character": 28 } },
+                                "selectionRange": { "start": { "line": 3, "character": 12 }, "end": { "line": 3, "character": 19 } }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "_hidden",
+                "kind": 12, // Function
+                "range": { "start": { "line": 7, "character": 0 }, "end": { "line": 7, "character": 16 } },
+                "selectionRange": { "start": { "line": 7, "character": 4 }, "end": { "line": 7, "character": 11 } }
+            },
+            {
+                "name": "top",
+                "kind": 12, // Function
+                "range": { "start": { "line": 8, "character": 0 }, "end": { "line": 8, "character": 12 } },
+                "selectionRange": { "start": { "line": 8, "character": 4 }, "end": { "line": 8, "character": 7 } }
+            }
+        ]))
+        .map(DocumentSymbolResponse::Nested)
+        .unwrap()
+    }
+
+    #[test]
+    fn nested_symbols_convert_with_hierarchy_and_line_conversion() {
+        let extracted = symbols_from_response("src/main.kt", KOTLIN_FIXTURE, nested_response());
+        let names: Vec<&str> = extracted.iter().map(|e| e.symbol.name.as_str()).collect();
+        assert_eq!(names, vec!["Greeter", "name", "greet", "_hidden", "top"]);
+
+        let class = &extracted[0].symbol;
+        assert_eq!(class.kind, SymbolKind::Class);
+        assert_eq!(class.line_start, 1, "0-based LSP line 0 -> ctx line 1");
+        assert_eq!(class.line_end, 7);
+        assert_eq!(class.id, "src/main.kt::Greeter");
+        assert!(class.parent_id.is_none());
+        assert!(class.qualified_name.is_none(), "top level has no chain");
+        assert_eq!(class.visibility, Visibility::Public);
+        assert!(class
+            .source
+            .as_deref()
+            .unwrap()
+            .starts_with("class Greeter"));
+
+        let field = &extracted[1].symbol;
+        assert_eq!(field.kind, SymbolKind::Field);
+        assert_eq!(field.parent_id.as_deref(), Some("src/main.kt::Greeter"));
+        assert_eq!(field.qualified_name.as_deref(), Some("Greeter.name"));
+
+        let method = &extracted[2].symbol;
+        assert_eq!(method.kind, SymbolKind::Method);
+        assert_eq!(method.id, "src/main.kt::Greeter::greet");
+        assert_eq!(method.qualified_name.as_deref(), Some("Greeter.greet"));
+        assert_eq!(
+            method.signature.as_deref(),
+            Some("fun greet(who: String): String")
+        );
+        assert_eq!(method.line_start, 3);
+        assert_eq!(method.line_end, 6);
+        assert_eq!(extracted[2].sel_line, 2);
+        assert_eq!(extracted[2].sel_col, 8);
+
+        // The local `message` variable inside the method was skipped.
+        assert!(!names.contains(&"message"));
+
+        // Leading underscore -> private.
+        assert_eq!(extracted[3].symbol.visibility, Visibility::Private);
+    }
+
+    #[test]
+    fn kind_mapping_table() {
+        let cases: Vec<(i32, Option<SymbolKind>)> = vec![
+            (1, Some(SymbolKind::Module)), // File
+            (2, Some(SymbolKind::Module)), // Module
+            (3, Some(SymbolKind::Module)), // Namespace
+            (4, Some(SymbolKind::Module)), // Package
+            (5, Some(SymbolKind::Class)),  // Class
+            (6, Some(SymbolKind::Method)), // Method
+            (7, Some(SymbolKind::Field)),  // Property
+            (8, Some(SymbolKind::Field)),  // Field
+            (9, Some(SymbolKind::Method)), // Constructor
+            (10, Some(SymbolKind::Enum)),  // Enum
+            (11, Some(SymbolKind::Interface)),
+            (12, Some(SymbolKind::Function)),
+            (13, Some(SymbolKind::Variable)),
+            (14, Some(SymbolKind::Const)),    // Constant
+            (15, Some(SymbolKind::Variable)), // String
+            (19, Some(SymbolKind::Variable)), // Object
+            (22, Some(SymbolKind::Variant)),  // EnumMember
+            (23, Some(SymbolKind::Struct)),   // Struct
+            (24, Some(SymbolKind::Field)),    // Event
+            (25, Some(SymbolKind::Method)),   // Operator
+            (26, Some(SymbolKind::Type)),     // TypeParameter
+        ];
+        for (raw, expected) in cases {
+            let kind: LspSymbolKind = serde_json::from_value(json!(raw)).unwrap();
+            assert_eq!(map_kind(kind), expected, "LSP kind {raw}");
+        }
+    }
+
+    #[test]
+    fn flat_symbol_information_fallback() {
+        let infos: Vec<SymbolInformation> = serde_json::from_value(json!([
+            {
+                "name": "Greeter",
+                "kind": 5,
+                "location": {
+                    "uri": "file:///w/src/main.kt",
+                    "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 6, "character": 1 } }
+                }
+            },
+            {
+                "name": "greet",
+                "kind": 6,
+                "containerName": "Greeter",
+                "location": {
+                    "uri": "file:///w/src/main.kt",
+                    "range": { "start": { "line": 2, "character": 4 }, "end": { "line": 5, "character": 5 } }
+                }
+            },
+            {
+                "name": "message",
+                "kind": 13,
+                "containerName": "greet",
+                "location": {
+                    "uri": "file:///w/src/main.kt",
+                    "range": { "start": { "line": 3, "character": 8 }, "end": { "line": 3, "character": 28 } }
+                }
+            }
+        ]))
+        .unwrap();
+
+        let extracted = symbols_from_response(
+            "src/main.kt",
+            KOTLIN_FIXTURE,
+            DocumentSymbolResponse::Flat(infos),
+        );
+        let names: Vec<&str> = extracted.iter().map(|e| e.symbol.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["Greeter", "greet"],
+            "local skipped in flat mode"
+        );
+        assert_eq!(extracted[1].symbol.id, "src/main.kt::Greeter::greet");
+        assert_eq!(
+            extracted[1].symbol.qualified_name.as_deref(),
+            Some("Greeter.greet")
+        );
+        assert_eq!(extracted[1].symbol.line_start, 3);
+    }
+
+    #[test]
+    fn outgoing_calls_become_edges() {
+        let extracted = symbols_from_response("src/main.kt", KOTLIN_FIXTURE, nested_response());
+        let greet = extracted
+            .iter()
+            .find(|e| e.symbol.name == "greet")
+            .unwrap()
+            .clone();
+
+        let calls: Vec<CallHierarchyOutgoingCall> = serde_json::from_value(json!([
+            {
+                // Same-file target: `top`, matched by selection position.
+                "to": {
+                    "name": "top",
+                    "kind": 12,
+                    "uri": "file:///w/src/main.kt",
+                    "range": { "start": { "line": 8, "character": 0 }, "end": { "line": 8, "character": 12 } },
+                    "selectionRange": { "start": { "line": 8, "character": 4 }, "end": { "line": 8, "character": 7 } }
+                },
+                "fromRanges": [
+                    { "start": { "line": 4, "character": 15 }, "end": { "line": 4, "character": 18 } }
+                ]
+            },
+            {
+                // Cross-file target: stays unresolved for Stage B.
+                "to": {
+                    "name": "helper",
+                    "kind": 12,
+                    "uri": "file:///w/src/util.kt",
+                    "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 2, "character": 1 } },
+                    "selectionRange": { "start": { "line": 0, "character": 4 }, "end": { "line": 0, "character": 10 } }
+                },
+                "fromRanges": [
+                    { "start": { "line": 3, "character": 22 }, "end": { "line": 3, "character": 28 } }
+                ]
+            }
+        ]))
+        .unwrap();
+
+        let edges = edges_from_outgoing_calls(&greet, "file:///w/src/main.kt", &extracted, &calls);
+        assert_eq!(edges.len(), 2);
+
+        let same_file = &edges[0];
+        assert_eq!(same_file.source_id, "src/main.kt::Greeter::greet");
+        assert_eq!(same_file.target_id.as_deref(), Some("src/main.kt::top"));
+        assert_eq!(same_file.target_name, "top");
+        assert_eq!(same_file.kind, EdgeKind::Calls);
+        assert_eq!(same_file.line, Some(5), "0-based from_range line 4 -> 5");
+        assert_eq!(same_file.col, Some(15));
+
+        let cross_file = &edges[1];
+        assert!(
+            cross_file.target_id.is_none(),
+            "cross-file stays unresolved"
+        );
+        assert_eq!(cross_file.target_name, "helper");
+        assert_eq!(cross_file.line, Some(4));
+    }
+}

--- a/src/lsp/mock.rs
+++ b/src/lsp/mock.rs
@@ -50,7 +50,9 @@ struct Scenario {
     server_version: Option<String>,
     /// Respond to `initialize`, then exit immediately (simulated crash).
     exit_after_initialize: bool,
-    /// Read requests but never answer anything (simulated hang).
+    /// Complete the `initialize` handshake, then read but never answer any
+    /// further message (simulated hang; exercises the client's
+    /// consecutive-timeout failure logic).
     never_respond: bool,
     /// Append one line per received message (`method<TAB>uri`) to this file.
     hits_file: Option<PathBuf>,
@@ -99,7 +101,10 @@ pub fn run_stdio_mock(scenario_path: &Path) {
 
         record_hit(&scenario, &method, &message);
 
-        if scenario.never_respond {
+        // Simulated hang: the handshake succeeds so the server looks healthy,
+        // then every later request times out (the process exits when the
+        // client kills it / closes stdin).
+        if scenario.never_respond && method != "initialize" {
             continue;
         }
 

--- a/src/lsp/mock.rs
+++ b/src/lsp/mock.rs
@@ -1,0 +1,274 @@
+//! Scripted mock language server for tests.
+//!
+//! The ctx binary itself doubles as the mock: when the environment variable
+//! `CTX_INTERNAL_MOCK_LSP` points at a scenario JSON file, `main()` enters
+//! this stdio loop *before* clap parsing and never runs a real command. Tests
+//! register the ctx test binary as the `command` of an `[lsp.*]` block with
+//! that variable in its `env` map.
+//!
+//! The mock speaks real `Content-Length` framing, answers
+//! `initialize`/`shutdown` properly, and serves scripted
+//! `textDocument/documentSymbol` and `textDocument/definition` responses.
+//!
+//! Scenario format (all fields optional):
+//!
+//! ```json
+//! {
+//!   "server_name": "ctx-mock-lsp",
+//!   "exit_after_initialize": false,
+//!   "never_respond": false,
+//!   "hits_file": "/tmp/hits.log",
+//!   "capabilities": { "documentSymbolProvider": true },
+//!   "document_symbols": {
+//!     "src/main.kt": [ { "name": "...", "kind": 12, ... } ]
+//!   },
+//!   "definitions": {
+//!     "app.py": { "path": "util.py", "line": 0 },
+//!     "app.py:3:8": { "path": "util.py", "line": 0, "character": 4 }
+//!   }
+//! }
+//! ```
+//!
+//! `document_symbols` keys match by URI suffix. `definitions` keys are either
+//! a bare suffix (matches any position in that file) or `suffix:line:col`
+//! with the 0-based request position. Definition target `path`s are resolved
+//! against the `rootUri` received in `initialize`.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::transport::read_message;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct Scenario {
+    server_name: Option<String>,
+    server_version: Option<String>,
+    /// Respond to `initialize`, then exit immediately (simulated crash).
+    exit_after_initialize: bool,
+    /// Read requests but never answer anything (simulated hang).
+    never_respond: bool,
+    /// Append one line per received message (`method<TAB>uri`) to this file.
+    hits_file: Option<PathBuf>,
+    /// Override the advertised server capabilities.
+    capabilities: Option<Value>,
+    /// URI-suffix -> `textDocument/documentSymbol` result.
+    document_symbols: BTreeMap<String, Value>,
+    /// `suffix[:line:col]` -> definition target.
+    definitions: BTreeMap<String, MockDefinition>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MockDefinition {
+    /// Target file, relative to the workspace root from `initialize`.
+    path: String,
+    /// 0-based target line.
+    line: u32,
+    /// 0-based target character.
+    #[serde(default)]
+    character: u32,
+}
+
+/// Run the mock server loop over stdin/stdout. Returns when the client sends
+/// `exit` or closes stdin.
+pub fn run_stdio_mock(scenario_path: &Path) {
+    let scenario: Scenario = std::fs::read_to_string(scenario_path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default();
+
+    let stdin = std::io::stdin();
+    let mut reader = stdin.lock();
+    let stdout = std::io::stdout();
+    let mut writer = stdout.lock();
+
+    // rootUri from initialize; definition targets resolve against it.
+    let mut root_uri = String::new();
+
+    while let Some(message) = read_message(&mut reader) {
+        let method = message
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let id = message.get("id").cloned();
+
+        record_hit(&scenario, &method, &message);
+
+        if scenario.never_respond {
+            continue;
+        }
+
+        match method.as_str() {
+            "initialize" => {
+                if let Some(uri) = message.pointer("/params/rootUri").and_then(Value::as_str) {
+                    root_uri = uri.trim_end_matches('/').to_string();
+                }
+                let capabilities = scenario.capabilities.clone().unwrap_or_else(|| {
+                    json!({
+                        "textDocumentSync": 1,
+                        "documentSymbolProvider": true,
+                        "definitionProvider": true,
+                    })
+                });
+                respond(
+                    &mut writer,
+                    id,
+                    json!({
+                        "capabilities": capabilities,
+                        "serverInfo": {
+                            "name": scenario.server_name.as_deref().unwrap_or("ctx-mock-lsp"),
+                            "version": scenario.server_version.as_deref().unwrap_or("1.0.0"),
+                        },
+                    }),
+                );
+                if scenario.exit_after_initialize {
+                    return; // simulated crash right after the handshake
+                }
+            }
+            "shutdown" => respond(&mut writer, id, Value::Null),
+            "exit" => return,
+            "textDocument/documentSymbol" => {
+                let uri = request_uri(&message);
+                let result = scenario
+                    .document_symbols
+                    .iter()
+                    .find(|(suffix, _)| uri.ends_with(suffix.as_str()))
+                    .map(|(_, symbols)| symbols.clone())
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            "textDocument/definition" => {
+                let uri = request_uri(&message);
+                let line = message
+                    .pointer("/params/position/line")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                let col = message
+                    .pointer("/params/position/character")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+
+                let target = lookup_definition(&scenario, &uri, line, col);
+                let result = match target {
+                    Some(def) => json!({
+                        "uri": format!("{root_uri}/{}", def.path),
+                        "range": {
+                            "start": { "line": def.line, "character": def.character },
+                            "end": { "line": def.line, "character": def.character },
+                        },
+                    }),
+                    None => Value::Null,
+                };
+                respond(&mut writer, id, result);
+            }
+            _ => {
+                // Unknown request: answer null so the client never stalls.
+                // Notifications (didOpen/didClose/initialized/...) have no id
+                // and get no reply.
+                if id.is_some() {
+                    respond(&mut writer, id, Value::Null);
+                }
+            }
+        }
+    }
+}
+
+/// Match a definition request against the scenario table: exact
+/// `suffix:line:col` entries first, then bare-suffix wildcard entries.
+fn lookup_definition<'s>(
+    scenario: &'s Scenario,
+    uri: &str,
+    line: u64,
+    col: u64,
+) -> Option<&'s MockDefinition> {
+    let mut wildcard: Option<&MockDefinition> = None;
+    for (key, def) in &scenario.definitions {
+        match key.rsplitn(3, ':').collect::<Vec<_>>()[..] {
+            // rsplitn yields reversed order: [col, line, suffix]
+            [col_s, line_s, suffix] => {
+                if let (Ok(l), Ok(c)) = (line_s.parse::<u64>(), col_s.parse::<u64>()) {
+                    if uri.ends_with(suffix) && l == line && c == col {
+                        return Some(def);
+                    }
+                    continue;
+                }
+                // Not numeric: treat the whole key as a suffix.
+                if uri.ends_with(key.as_str()) {
+                    wildcard = Some(def);
+                }
+            }
+            _ => {
+                if uri.ends_with(key.as_str()) {
+                    wildcard = Some(def);
+                }
+            }
+        }
+    }
+    wildcard
+}
+
+fn request_uri(message: &Value) -> String {
+    message
+        .pointer("/params/textDocument/uri")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn respond<W: Write>(writer: &mut W, id: Option<Value>, result: Value) {
+    let reply = json!({
+        "jsonrpc": "2.0",
+        "id": id.unwrap_or(Value::Null),
+        "result": result,
+    });
+    let body = serde_json::to_vec(&reply).unwrap_or_default();
+    let _ = writer.write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes());
+    let _ = writer.write_all(&body);
+    let _ = writer.flush();
+}
+
+fn record_hit(scenario: &Scenario, method: &str, message: &Value) {
+    let Some(hits_file) = &scenario.hits_file else {
+        return;
+    };
+    let uri = message
+        .pointer("/params/textDocument/uri")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(hits_file)
+    {
+        let _ = writeln!(file, "{method}\t{uri}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_lookup_prefers_exact_position() {
+        let scenario: Scenario = serde_json::from_value(json!({
+            "definitions": {
+                "app.py": { "path": "wild.py", "line": 1 },
+                "app.py:3:8": { "path": "exact.py", "line": 2 },
+            }
+        }))
+        .unwrap();
+
+        let exact = lookup_definition(&scenario, "file:///w/app.py", 3, 8).unwrap();
+        assert_eq!(exact.path, "exact.py");
+
+        let wild = lookup_definition(&scenario, "file:///w/app.py", 9, 9).unwrap();
+        assert_eq!(wild.path, "wild.py");
+
+        assert!(lookup_definition(&scenario, "file:///w/other.py", 3, 8).is_none());
+    }
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -409,9 +409,41 @@ fn is_uri_path_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~' | b'/' | b':')
 }
 
+/// Strip a Windows verbatim (extended-length) prefix from a path string:
+/// `\\?\C:\...` becomes `C:\...` and `\\?\UNC\server\share\...` becomes
+/// `\\server\share\...`. Anything else is returned unchanged.
+///
+/// `Path::canonicalize` on Windows returns verbatim paths; feeding those into
+/// a URI verbatim yields `file:////%3F/C:/...`, which real language servers
+/// reject. Pure string logic so it is unit-testable on any platform.
+fn strip_verbatim(raw: &str) -> String {
+    if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = raw.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        raw.to_string()
+    }
+}
+
+/// Strip the leading slash of a URI path like `/C:/Users/x` (the decoded path
+/// component of `file:///C:/...`) so it becomes a Windows drive path. Pure
+/// string logic, applied only on Windows but testable everywhere.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn strip_uri_drive_slash(text: String) -> String {
+    let bytes = text.as_bytes();
+    if bytes.len() >= 3 && bytes[0] == b'/' && bytes[1].is_ascii_alphabetic() && bytes[2] == b':' {
+        let mut text = text;
+        text.remove(0);
+        text
+    } else {
+        text
+    }
+}
+
 /// Build a `file://` URI for an absolute path.
 pub(crate) fn path_to_uri(path: &Path) -> String {
-    let raw = path.to_string_lossy().replace('\\', "/");
+    let raw = strip_verbatim(&path.to_string_lossy()).replace('\\', "/");
     let mut encoded = String::with_capacity(raw.len() + 8);
     encoded.push_str("file://");
     if !raw.starts_with('/') {
@@ -464,13 +496,7 @@ pub(crate) fn uri_to_path(uri: &str) -> Option<PathBuf> {
 
     // file:///C:/x -> C:/x
     #[cfg(windows)]
-    let text = {
-        let mut text = text;
-        if text.len() >= 3 && text.as_bytes()[0] == b'/' && text.as_bytes()[2] == b':' {
-            text.remove(0);
-        }
-        text
-    };
+    let text = strip_uri_drive_slash(text);
 
     Some(PathBuf::from(text))
 }
@@ -493,6 +519,40 @@ mod tests {
         let uri = path_to_uri(path);
         assert!(uri.starts_with("file:///tmp/my%20project/"), "{uri}");
         assert_eq!(uri_to_path(&uri).unwrap(), path);
+    }
+
+    #[test]
+    fn strip_verbatim_handles_drive_and_unc_prefixes() {
+        assert_eq!(strip_verbatim(r"\\?\C:\Users\x"), r"C:\Users\x");
+        assert_eq!(strip_verbatim(r"\\?\UNC\srv\share\x"), r"\\srv\share\x");
+        // Non-verbatim inputs pass through untouched.
+        assert_eq!(strip_verbatim(r"C:\Users\x"), r"C:\Users\x");
+        assert_eq!(strip_verbatim("/tmp/project"), "/tmp/project");
+    }
+
+    #[test]
+    fn uri_from_verbatim_drive_path_has_three_slashes() {
+        // Windows canonicalize() yields \\?\C:\...; the URI must not leak
+        // the verbatim prefix and must use the file:///C:/... form.
+        let uri = path_to_uri(Path::new(r"\\?\C:\Users\x"));
+        assert_eq!(uri, "file:///C:/Users/x");
+        // Round trip (string logic; the leading-slash strip is applied under
+        // cfg(windows) in uri_to_path).
+        assert_eq!(
+            strip_uri_drive_slash("/C:/Users/x".to_string()),
+            "C:/Users/x"
+        );
+        // Unix absolute paths are never mistaken for drive paths.
+        assert_eq!(strip_uri_drive_slash("/tmp/x".to_string()), "/tmp/x");
+    }
+
+    #[test]
+    fn uri_from_verbatim_unc_path_drops_the_verbatim_prefix() {
+        let uri = path_to_uri(Path::new(r"\\?\UNC\srv\share\x"));
+        // `\\srv\share\x` -> `//srv/share/x` -> empty-authority file URI.
+        assert_eq!(uri, "file:////srv/share/x");
+        assert_eq!(uri_to_path(&uri).unwrap(), PathBuf::from("//srv/share/x"));
+        assert!(!uri.contains("%3F"), "verbatim `?` must not leak: {uri}");
     }
 
     #[test]

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 
 use crate::db::{Edge, ParseResult};
 
-pub use config::{LspBackend, LspServerConfig};
+pub use config::{LspBackend, LspConfig, LspServerConfig};
 
 use client::LspClient;
 use extract::ExtractedSymbol;
@@ -71,15 +71,11 @@ pub struct LspManager {
 impl LspManager {
     /// Build a manager from the project config. Returns `None` when no valid
     /// `[lsp.*]` block exists — the subsystem then stays completely inert.
-    pub fn from_config(
-        root: &Path,
-        ctx_config: &crate::config::CtxConfig,
-        verbose: bool,
-    ) -> Option<Self> {
-        if ctx_config.lsp.is_empty() {
+    pub fn from_config(root: &Path, lsp_config: &LspConfig, verbose: bool) -> Option<Self> {
+        if lsp_config.lsp.is_empty() {
             return None;
         }
-        let (servers, extension_claims) = config::validate(&ctx_config.lsp);
+        let (servers, extension_claims) = config::validate(&lsp_config.lsp);
         if servers.is_empty() {
             return None;
         }
@@ -510,17 +506,17 @@ mod tests {
     }
 
     fn manager_with(toml_text: &str) -> LspManager {
-        let cfg: crate::config::CtxConfig = toml::from_str(toml_text).unwrap();
+        let cfg: LspConfig = toml::from_str(toml_text).unwrap();
         LspManager::from_config(Path::new("/tmp/w"), &cfg, false).unwrap()
     }
 
     #[test]
     fn from_config_is_none_without_lsp_blocks() {
-        let cfg = crate::config::CtxConfig::default();
+        let cfg = LspConfig::default();
         assert!(LspManager::from_config(Path::new("/tmp/w"), &cfg, false).is_none());
 
         // Blocks that all fail validation also yield None.
-        let cfg: crate::config::CtxConfig = toml::from_str(
+        let cfg: LspConfig = toml::from_str(
             r#"
 [lsp.kotlin]
 command = ""

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,0 +1,593 @@
+//! Language Server Protocol extraction backend.
+//!
+//! Alongside the builtin tree-sitter parsers, any stdio language server can
+//! be registered declaratively in `.ctx/config.toml` (see
+//! [`config::LspServerConfig`]). Per language the backend is selectable:
+//!
+//! - `tree-sitter` (default when nothing is configured): builtin grammars.
+//! - `lsp`: symbols and call edges come from the language server.
+//! - `hybrid` (default for configured blocks): tree-sitter extracts, the
+//!   language server resolves cross-file references afterwards (Stage B).
+//!
+//! The subsystem is runtime-gated: without any `[lsp.*]` config block nothing
+//! is spawned and indexing behaves exactly as before. Failures never abort an
+//! indexing run — a broken or missing server degrades to tree-sitter (builtin
+//! languages) or to file records without symbols (dynamic languages), with a
+//! warning on stderr.
+
+pub mod client;
+pub mod config;
+pub mod extract;
+pub mod mock;
+pub mod resolve;
+pub mod status;
+pub mod transport;
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use crate::db::{Edge, ParseResult};
+
+pub use config::{LspBackend, LspServerConfig};
+
+use client::LspClient;
+use extract::ExtractedSymbol;
+
+/// How a file should be extracted, as decided by extension claims in the
+/// `[lsp.*]` config plus the builtin language table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileBackend {
+    /// Builtin tree-sitter extraction (also the fallback when no LSP block
+    /// claims the file's extension).
+    TreeSitter,
+    /// Extract with the language server registered for this language.
+    Lsp(String),
+    /// Extract with tree-sitter, resolve leftover cross-file references with
+    /// the language server for this language (Stage B).
+    Hybrid(String),
+    /// Neither a builtin grammar nor an LSP registration covers this file.
+    Unsupported,
+}
+
+/// Lifecycle state of one language's server within a run.
+enum ClientSlot {
+    Ready(Box<LspClient>),
+    Failed(String),
+}
+
+/// Per-run registry of language-server clients (one per configured language,
+/// spawned lazily on first use).
+pub struct LspManager {
+    root: PathBuf,
+    verbose: bool,
+    servers: BTreeMap<String, LspServerConfig>,
+    /// extension (lowercase, no dot) -> language key; first config block wins.
+    extension_claims: BTreeMap<String, String>,
+    clients: HashMap<String, ClientSlot>,
+    /// Languages already warned about on stderr (warn once per run).
+    warned: HashSet<String>,
+}
+
+impl LspManager {
+    /// Build a manager from the project config. Returns `None` when no valid
+    /// `[lsp.*]` block exists — the subsystem then stays completely inert.
+    pub fn from_config(
+        root: &Path,
+        ctx_config: &crate::config::CtxConfig,
+        verbose: bool,
+    ) -> Option<Self> {
+        if ctx_config.lsp.is_empty() {
+            return None;
+        }
+        let (servers, extension_claims) = config::validate(&ctx_config.lsp);
+        if servers.is_empty() {
+            return None;
+        }
+        Some(Self {
+            root: root.to_path_buf(),
+            verbose,
+            servers,
+            extension_claims,
+            clients: HashMap::new(),
+            warned: HashSet::new(),
+        })
+    }
+
+    /// Project root the servers run in.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Decide the extraction backend for a path.
+    pub fn backend_for(&self, path: &Path) -> FileBackend {
+        let builtin_supported = crate::parser::CodeParser::is_supported_static(path);
+
+        let claimed = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .and_then(|ext| self.extension_claims.get(&ext));
+
+        let Some(language) = claimed else {
+            return if builtin_supported {
+                FileBackend::TreeSitter
+            } else {
+                FileBackend::Unsupported
+            };
+        };
+
+        match self.servers[language].backend {
+            LspBackend::TreeSitter => {
+                if builtin_supported {
+                    FileBackend::TreeSitter
+                } else {
+                    FileBackend::Unsupported
+                }
+            }
+            LspBackend::Lsp => FileBackend::Lsp(language.clone()),
+            LspBackend::Hybrid => {
+                if builtin_supported {
+                    FileBackend::Hybrid(language.clone())
+                } else {
+                    // No builtin grammar to extract with: hybrid degrades to
+                    // full LSP extraction for dynamic languages.
+                    FileBackend::Lsp(language.clone())
+                }
+            }
+        }
+    }
+
+    /// The configured server command for a language (for messages).
+    fn command_for(&self, language: &str) -> String {
+        self.servers
+            .get(language)
+            .map(|c| c.command.clone())
+            .unwrap_or_default()
+    }
+
+    /// Warn once per language that its server is unusable.
+    fn warn_fallback(&mut self, language: &str, reason: &str) {
+        if self.warned.insert(language.to_string()) {
+            eprintln!(
+                "Warning: LSP server '{}' for {} {}; falling back to tree-sitter",
+                self.command_for(language),
+                language,
+                reason
+            );
+        }
+    }
+
+    /// Lazily spawn (or reuse) the client for a language. Returns `None` when
+    /// the server is (or just became) failed; the warning has been emitted.
+    fn client(&mut self, language: &str) -> Option<&mut LspClient> {
+        // Existing slot: check for a failure recorded by a previous request.
+        if let Some(slot) = self.clients.get(language) {
+            match slot {
+                ClientSlot::Failed(_) => return None,
+                ClientSlot::Ready(client) => {
+                    if let Some(reason) = client.failure() {
+                        let reason = reason.to_string();
+                        self.clients
+                            .insert(language.to_string(), ClientSlot::Failed(reason.clone()));
+                        self.warn_fallback(language, &reason);
+                        return None;
+                    }
+                }
+            }
+        } else {
+            let cfg = self.servers.get(language).cloned()?;
+            match LspClient::spawn(&cfg, &self.root, self.verbose) {
+                Ok(client) => {
+                    if self.verbose {
+                        let (name, version) = client.server_info();
+                        eprintln!(
+                            "Started LSP server '{}' for {} ({} {})",
+                            cfg.command,
+                            language,
+                            name.unwrap_or("unknown"),
+                            version.unwrap_or("")
+                        );
+                    }
+                    self.clients
+                        .insert(language.to_string(), ClientSlot::Ready(Box::new(client)));
+                }
+                Err(e) => {
+                    self.clients
+                        .insert(language.to_string(), ClientSlot::Failed(e.reason.clone()));
+                    self.warn_fallback(language, &e.reason);
+                    return None;
+                }
+            }
+        }
+
+        match self.clients.get_mut(language) {
+            Some(ClientSlot::Ready(client)) => Some(client.as_mut()),
+            _ => None,
+        }
+    }
+
+    /// Client accessor for the Stage B resolver (crate-internal).
+    pub(crate) fn client_for_stage_b(&mut self, language: &str) -> Option<&mut LspClient> {
+        self.client(language)
+    }
+
+    /// Record a failure detected while a client borrow was held.
+    fn note_failure_if_any(&mut self, language: &str) {
+        if let Some(ClientSlot::Ready(client)) = self.clients.get(language) {
+            if let Some(reason) = client.failure() {
+                let reason = reason.to_string();
+                self.clients
+                    .insert(language.to_string(), ClientSlot::Failed(reason.clone()));
+                self.warn_fallback(language, &reason);
+            }
+        }
+    }
+
+    /// Stage A: extract one file with the language's server.
+    ///
+    /// Returns `None` when the server is unusable (spawn failure, crash,
+    /// repeated timeouts) or the extraction request failed — the caller then
+    /// falls back to tree-sitter / an empty symbol set. LSP failures never
+    /// become indexing errors.
+    pub fn extract(&mut self, language: &str, rel_path: &str, text: &str) -> Option<ParseResult> {
+        let abs_path = self.root.join(rel_path);
+        let uri = path_to_uri(&abs_path);
+        let verbose = self.verbose;
+
+        let outcome = {
+            let client = self.client(language)?;
+
+            if client.did_open(&uri, language, text).is_err() {
+                None
+            } else {
+                let response = client.document_symbols(&uri);
+                match response {
+                    Ok(response) => {
+                        let symbols: Vec<ExtractedSymbol> = response
+                            .map(|r| extract::symbols_from_response(rel_path, text, r))
+                            .unwrap_or_default();
+                        let edges = collect_call_edges(client, &uri, &symbols, verbose, rel_path);
+                        client.did_close(&uri);
+                        Some((symbols, edges))
+                    }
+                    Err(e) => {
+                        if verbose {
+                            eprintln!("Warning: LSP documentSymbol failed for {rel_path}: {e}");
+                        }
+                        client.did_close(&uri);
+                        None
+                    }
+                }
+            }
+        };
+
+        // The borrow on the client is released: sync failure state (warns
+        // once per language when the server died mid-run).
+        self.note_failure_if_any(language);
+
+        let (symbols, edges) = outcome?;
+        Some(ParseResult {
+            file_path: rel_path.to_string(),
+            language: language.to_string(),
+            symbols: symbols.into_iter().map(|e| e.symbol).collect(),
+            edges,
+            module: None,
+        })
+    }
+
+    /// Whether Stage B resolution applies to files of this backend.
+    pub fn wants_stage_b(&self, backend: &FileBackend) -> bool {
+        matches!(backend, FileBackend::Lsp(_) | FileBackend::Hybrid(_))
+    }
+
+    /// Write the `.ctx/lsp_status.json` sidecar for this run.
+    pub fn write_status(&self) {
+        let entries: Vec<status::LspStatusEntry> = self
+            .servers
+            .iter()
+            .map(|(language, cfg)| {
+                let (state, reason, server_name, server_version, capabilities) =
+                    match self.clients.get(language) {
+                        Some(ClientSlot::Ready(client)) => match client.failure() {
+                            Some(reason) => (
+                                "failed",
+                                Some(reason.to_string()),
+                                client.server_name.clone(),
+                                client.server_version.clone(),
+                                client.capability_names(),
+                            ),
+                            None => (
+                                "healthy",
+                                None,
+                                client.server_name.clone(),
+                                client.server_version.clone(),
+                                client.capability_names(),
+                            ),
+                        },
+                        Some(ClientSlot::Failed(reason)) => {
+                            ("failed", Some(reason.clone()), None, None, Vec::new())
+                        }
+                        None => ("idle", None, None, None, Vec::new()),
+                    };
+                status::LspStatusEntry {
+                    language: language.clone(),
+                    command: cfg.command.clone(),
+                    backend: cfg.backend.as_str().to_string(),
+                    state: state.to_string(),
+                    reason,
+                    server_name,
+                    server_version,
+                    capabilities,
+                }
+            })
+            .collect();
+
+        if let Err(e) = status::write_status_file(&self.root, &entries) {
+            if self.verbose {
+                eprintln!("Warning: failed to write lsp_status.json: {e}");
+            }
+        }
+    }
+
+    /// Shut down every running server (graceful `shutdown`/`exit`, then kill).
+    pub fn shutdown_all(&mut self) {
+        for slot in self.clients.values_mut() {
+            if let ClientSlot::Ready(client) = slot {
+                client.shutdown();
+            }
+        }
+        self.clients.clear();
+    }
+}
+
+impl Drop for LspManager {
+    fn drop(&mut self) {
+        self.shutdown_all();
+    }
+}
+
+/// Collect `Calls` edges via the call-hierarchy requests (best effort; any
+/// failure keeps the symbols and simply stops collecting edges).
+fn collect_call_edges(
+    client: &mut LspClient,
+    uri: &str,
+    symbols: &[ExtractedSymbol],
+    verbose: bool,
+    rel_path: &str,
+) -> Vec<Edge> {
+    let mut edges = Vec::new();
+    if !client.supports("callHierarchyProvider") {
+        return edges;
+    }
+
+    for extracted in symbols {
+        if !matches!(
+            extracted.symbol.kind,
+            crate::db::SymbolKind::Function | crate::db::SymbolKind::Method
+        ) {
+            continue;
+        }
+
+        let items = match client.prepare_call_hierarchy(uri, extracted.sel_line, extracted.sel_col)
+        {
+            Ok(items) => items,
+            Err(e) => {
+                if verbose {
+                    eprintln!("Warning: prepareCallHierarchy failed for {rel_path}: {e}");
+                }
+                if client.failure().is_some() {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        let Some(item) = items.first() else {
+            continue;
+        };
+
+        match client.outgoing_calls(item) {
+            Ok(calls) => {
+                edges.extend(extract::edges_from_outgoing_calls(
+                    extracted, uri, symbols, &calls,
+                ));
+            }
+            Err(e) => {
+                if verbose {
+                    eprintln!("Warning: outgoingCalls failed for {rel_path}: {e}");
+                }
+                if client.failure().is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
+    edges
+}
+
+// ---- file:// URI helpers ----------------------------------------------------
+
+/// Bytes left unencoded in the path portion of a `file://` URI.
+fn is_uri_path_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~' | b'/' | b':')
+}
+
+/// Build a `file://` URI for an absolute path.
+pub(crate) fn path_to_uri(path: &Path) -> String {
+    let raw = path.to_string_lossy().replace('\\', "/");
+    let mut encoded = String::with_capacity(raw.len() + 8);
+    encoded.push_str("file://");
+    if !raw.starts_with('/') {
+        encoded.push('/'); // Windows drive paths: file:///C:/...
+    }
+    for &b in raw.as_bytes() {
+        if is_uri_path_byte(b) {
+            encoded.push(b as char);
+        } else {
+            encoded.push_str(&format!("%{b:02X}"));
+        }
+    }
+    encoded
+}
+
+/// Parse a `file://` URI back into a filesystem path.
+pub(crate) fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    // Skip an optional authority (host) component; only empty or localhost
+    // authorities are meaningful for local files.
+    let path_part = if let Some(stripped) = rest.strip_prefix('/') {
+        // Empty authority: rest already was the path (put the slash back).
+        let mut s = String::with_capacity(stripped.len() + 1);
+        s.push('/');
+        s.push_str(stripped);
+        s
+    } else {
+        let (authority, path) = rest.split_once('/')?;
+        if !authority.is_empty() && authority != "localhost" {
+            return None;
+        }
+        format!("/{path}")
+    };
+
+    // Percent-decode.
+    let bytes = path_part.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).ok()?;
+            decoded.push(u8::from_str_radix(hex, 16).ok()?);
+            i += 3;
+        } else {
+            decoded.push(bytes[i]);
+            i += 1;
+        }
+    }
+    let text = String::from_utf8(decoded).ok()?;
+
+    // file:///C:/x -> C:/x
+    #[cfg(windows)]
+    let text = {
+        let mut text = text;
+        if text.len() >= 3 && text.as_bytes()[0] == b'/' && text.as_bytes()[2] == b':' {
+            text.remove(0);
+        }
+        text
+    };
+
+    Some(PathBuf::from(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uri_roundtrip_plain() {
+        let path = Path::new("/tmp/project/src/main.kt");
+        let uri = path_to_uri(path);
+        assert_eq!(uri, "file:///tmp/project/src/main.kt");
+        assert_eq!(uri_to_path(&uri).unwrap(), path);
+    }
+
+    #[test]
+    fn uri_roundtrip_with_spaces_and_unicode() {
+        let path = Path::new("/tmp/my project/söurce.kt");
+        let uri = path_to_uri(path);
+        assert!(uri.starts_with("file:///tmp/my%20project/"), "{uri}");
+        assert_eq!(uri_to_path(&uri).unwrap(), path);
+    }
+
+    #[test]
+    fn uri_to_path_rejects_remote_hosts() {
+        assert!(uri_to_path("file://example.com/x/y").is_none());
+        assert!(uri_to_path("https://example.com/x").is_none());
+        assert_eq!(
+            uri_to_path("file://localhost/x/y").unwrap(),
+            PathBuf::from("/x/y")
+        );
+    }
+
+    fn manager_with(toml_text: &str) -> LspManager {
+        let cfg: crate::config::CtxConfig = toml::from_str(toml_text).unwrap();
+        LspManager::from_config(Path::new("/tmp/w"), &cfg, false).unwrap()
+    }
+
+    #[test]
+    fn from_config_is_none_without_lsp_blocks() {
+        let cfg = crate::config::CtxConfig::default();
+        assert!(LspManager::from_config(Path::new("/tmp/w"), &cfg, false).is_none());
+
+        // Blocks that all fail validation also yield None.
+        let cfg: crate::config::CtxConfig = toml::from_str(
+            r#"
+[lsp.kotlin]
+command = ""
+"#,
+        )
+        .unwrap();
+        assert!(LspManager::from_config(Path::new("/tmp/w"), &cfg, false).is_none());
+    }
+
+    #[test]
+    fn backend_for_honors_claims_and_falls_back_to_builtin() {
+        let mgr = manager_with(
+            r#"
+[lsp.kotlin]
+command = "kls"
+extensions = ["kt"]
+backend = "lsp"
+
+[lsp.python]
+command = "pyls"
+backend = "hybrid"
+
+[lsp.go]
+command = "gopls"
+backend = "tree-sitter"
+
+[lsp.scala]
+command = "metals"
+extensions = ["scala"]
+backend = "hybrid"
+"#,
+        );
+
+        // Dynamic language, explicit lsp backend.
+        assert_eq!(
+            mgr.backend_for(Path::new("src/App.kt")),
+            FileBackend::Lsp("kotlin".to_string())
+        );
+        // Builtin language, hybrid.
+        assert_eq!(
+            mgr.backend_for(Path::new("app/main.py")),
+            FileBackend::Hybrid("python".to_string())
+        );
+        // Builtin language forced back to tree-sitter.
+        assert_eq!(
+            mgr.backend_for(Path::new("pkg/x.go")),
+            FileBackend::TreeSitter
+        );
+        // Dynamic language with hybrid degrades to lsp (no builtin grammar).
+        assert_eq!(
+            mgr.backend_for(Path::new("core/Main.scala")),
+            FileBackend::Lsp("scala".to_string())
+        );
+        // Unclaimed builtin extension keeps working.
+        assert_eq!(
+            mgr.backend_for(Path::new("src/lib.rs")),
+            FileBackend::TreeSitter
+        );
+        // Unclaimed unknown extension stays unsupported.
+        assert_eq!(
+            mgr.backend_for(Path::new("README.adoc")),
+            FileBackend::Unsupported
+        );
+        // Extension matching is case-insensitive.
+        assert_eq!(
+            mgr.backend_for(Path::new("src/App.KT")),
+            FileBackend::Lsp("kotlin".to_string())
+        );
+    }
+}

--- a/src/lsp/resolve.rs
+++ b/src/lsp/resolve.rs
@@ -10,6 +10,15 @@
 //! by edge rowid. They must never be routed through the `store_edges` insert
 //! path, whose id rewriting would corrupt a cross-file target id into
 //! `<current_file>::name`.
+//!
+//! Two safeguards keep Stage B from writing a *wrong* target (worse than an
+//! unresolved one, since it is never corrected):
+//!
+//! - The definition request is aimed at the callee identifier, not the start
+//!   of the call expression tree-sitter records (for `obj.helper()` that is
+//!   the receiver `obj`, whose definition is a different symbol entirely).
+//! - The resolved symbol's name must match the edge's `target_name`; on a
+//!   mismatch the edge is left unresolved.
 
 use std::collections::{BTreeMap, HashSet};
 
@@ -45,8 +54,8 @@ pub fn resolve_edges_with_lsp(
 
     // Group the candidate edges per (language, source file); only files
     // changed this run with an lsp/hybrid backend participate.
-    // (edge_id, 1-based line, 0-based col) per edge.
-    type EdgeSite = (i64, u32, u32);
+    // (edge_id, 1-based line, 0-based col, target_name) per edge.
+    type EdgeSite = (i64, u32, u32, String);
     let mut per_language: BTreeMap<String, BTreeMap<String, Vec<EdgeSite>>> = BTreeMap::new();
     for edge in &unresolved {
         if !changed_files.contains(&edge.source_file) {
@@ -61,7 +70,7 @@ pub fn resolve_edges_with_lsp(
             .or_default()
             .entry(edge.source_file.clone())
             .or_default()
-            .push((edge.edge_id, edge.line, edge.col));
+            .push((edge.edge_id, edge.line, edge.col, edge.target_name.clone()));
     }
 
     let root = mgr.root().to_path_buf();
@@ -74,6 +83,7 @@ pub fn resolve_edges_with_lsp(
                 continue;
             };
             let uri = path_to_uri(&abs_path);
+            let lines: Vec<&str> = text.lines().collect();
 
             // One didOpen per source file, then a definition request per edge.
             let Some(client) = mgr.client_for_stage_b(&language) else {
@@ -83,7 +93,15 @@ pub fn resolve_edges_with_lsp(
                 break;
             }
 
-            for (edge_id, line, col) in edges {
+            for (edge_id, line, col, target_name) in edges {
+                // Aim at the callee identifier: tree-sitter stores the start
+                // of the whole call expression, which for method calls is the
+                // receiver — asking definition there resolves the wrong symbol.
+                let col = lines
+                    .get(line.saturating_sub(1) as usize)
+                    .map(|line_text| callee_column(line_text, &target_name, col))
+                    .unwrap_or(col);
+
                 // ctx lines are 1-based; LSP positions are 0-based.
                 let target = match client.definition(&uri, line.saturating_sub(1), col) {
                     Ok(target) => target,
@@ -105,7 +123,9 @@ pub fn resolve_edges_with_lsp(
                     continue;
                 };
 
-                if let Some(target_id) = map_target(db, &root, &target_uri, target_line0, verbose) {
+                if let Some(target_id) =
+                    map_target(db, &root, &target_uri, target_line0, &target_name, verbose)
+                {
                     match db.set_edge_target(edge_id, &target_id) {
                         Ok(true) => resolved += 1,
                         Ok(false) => {}
@@ -125,16 +145,53 @@ pub fn resolve_edges_with_lsp(
     resolved
 }
 
+/// Column of the callee identifier for a definition request: the first
+/// occurrence of `target_name` at-or-after the stored column of the source
+/// line. Falls back to the stored column when the name does not appear
+/// (macro-generated code, stale text). Byte-index based, consistent with the
+/// columns tree-sitter records.
+fn callee_column(line_text: &str, target_name: &str, stored_col: u32) -> u32 {
+    if target_name.is_empty() {
+        return stored_col;
+    }
+    line_text
+        .match_indices(target_name)
+        .map(|(i, _)| i)
+        .find(|&i| i >= stored_col as usize)
+        .map(|i| i as u32)
+        .unwrap_or(stored_col)
+}
+
+/// Whether a resolved symbol plausibly is the callee named by the edge:
+/// exact name match, or a qualified tail match (`X.name` / `X::name`) for
+/// methods whose symbol name carries the container.
+fn name_matches(name: &str, qualified_name: Option<&str>, target_name: &str) -> bool {
+    if target_name.is_empty() {
+        return false;
+    }
+    let dot_tail = format!(".{target_name}");
+    let path_tail = format!("::{target_name}");
+    let candidate_matches = |candidate: &str| {
+        candidate == target_name
+            || candidate.ends_with(&dot_tail)
+            || candidate.ends_with(&path_tail)
+    };
+    candidate_matches(name) || qualified_name.is_some_and(candidate_matches)
+}
+
 /// Map a definition target (`uri` + 0-based line) to an indexed symbol id.
 ///
-/// The target must be a local file under the project root and already present
-/// in the index; anything else (stdlib, dependencies, generated files) is
-/// skipped.
+/// The target must be a local file under the project root, already present in
+/// the index, and the symbol found at the target line must be named like the
+/// edge's `target_name`; anything else (stdlib, dependencies, generated
+/// files, receiver/wrong-symbol answers) is skipped so the edge stays
+/// unresolved instead of pointing at the wrong symbol.
 fn map_target(
     db: &Database,
     root: &std::path::Path,
     target_uri: &str,
     target_line0: u32,
+    target_name: &str,
     verbose: bool,
 ) -> Option<String> {
     let target_path = uri_to_path(target_uri)?;
@@ -153,14 +210,68 @@ fn map_target(
     }
 
     let line = target_line0 + 1;
-    match db.symbol_id_at_line(&rel, line) {
-        Ok(Some(id)) => Some(id),
-        Ok(None) => None,
+    let id = match db.symbol_id_at_line(&rel, line) {
+        Ok(Some(id)) => id,
+        Ok(None) => return None,
         Err(e) => {
             if verbose {
                 eprintln!("Warning: symbol lookup failed for {rel}:{line}: {e}");
             }
-            None
+            return None;
         }
+    };
+
+    // Safety guard: never write a target whose name does not match the
+    // recorded callee name. A wrong target_id is worse than NULL — it is
+    // never corrected by later runs.
+    let symbol = db.get_symbol(&id).ok()??;
+    if name_matches(&symbol.name, symbol.qualified_name.as_deref(), target_name) {
+        Some(id)
+    } else {
+        if verbose {
+            eprintln!(
+                "Warning: definition for `{target_name}` resolved to `{}` at {rel}:{line}; \
+                 leaving edge unresolved",
+                symbol.name
+            );
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn callee_column_targets_identifier_after_receiver() {
+        // Stored col 11 = start of `obj`; `helper` begins at col 15.
+        let line = "    return obj.helper()";
+        assert_eq!(callee_column(line, "helper", 11), 15);
+        // Bare call: the name sits exactly at the stored column.
+        assert_eq!(callee_column("    return helper()", "helper", 11), 11);
+        // Earlier occurrences (before the stored col) are ignored.
+        assert_eq!(callee_column("helper = obj.helper()", "helper", 9), 13);
+        // Name not found at-or-after the column: keep the stored column.
+        assert_eq!(callee_column("    return mangled()", "helper", 11), 11);
+        // Column past the end of the line: keep the stored column.
+        assert_eq!(callee_column("x()", "helper", 40), 40);
+        assert_eq!(callee_column("", "helper", 0), 0);
+    }
+
+    #[test]
+    fn name_guard_accepts_exact_and_qualified_tail_matches() {
+        assert!(name_matches("helper", None, "helper"));
+        assert!(name_matches("Greeter.helper", None, "helper"));
+        assert!(name_matches("helper", Some("Greeter.helper"), "helper"));
+        assert!(name_matches("helper", Some("mod::helper"), "helper"));
+
+        // Wrong symbol (e.g. the receiver's enclosing method): rejected.
+        assert!(!name_matches("main", None, "helper"));
+        assert!(!name_matches("main", Some("app.main"), "helper"));
+        // Suffix-of-identifier is not a tail match.
+        assert!(!name_matches("do_helper", None, "helper"));
+        assert!(!name_matches("", None, "helper"));
+        assert!(!name_matches("helper", None, ""));
     }
 }

--- a/src/lsp/resolve.rs
+++ b/src/lsp/resolve.rs
@@ -1,0 +1,166 @@
+//! Stage B: resolve leftover cross-file references with the language server.
+//!
+//! After the cheap SQL passes in [`Database::resolve_edge_targets`], edges
+//! whose target could not be determined statically still have
+//! `target_id IS NULL`. For files handled by an `lsp` or `hybrid` backend we
+//! ask the language server `textDocument/definition` at each recorded call
+//! site and update the edge directly.
+//!
+//! Targets are written with [`Database::set_edge_target`] — a plain `UPDATE`
+//! by edge rowid. They must never be routed through the `store_edges` insert
+//! path, whose id rewriting would corrupt a cross-file target id into
+//! `<current_file>::name`.
+
+use std::collections::{BTreeMap, HashSet};
+
+use crate::db::Database;
+
+use super::{path_to_uri, uri_to_path, FileBackend, LspManager};
+
+/// Resolve unresolved edges for the given files (index-relative paths) via
+/// `textDocument/definition`. Returns the number of edges resolved. Never
+/// fails: any server or IO problem simply leaves edges unresolved.
+pub fn resolve_edges_with_lsp(
+    db: &Database,
+    mgr: &mut LspManager,
+    changed_files: &HashSet<String>,
+    verbose: bool,
+) -> usize {
+    if changed_files.is_empty() {
+        return 0;
+    }
+
+    let unresolved = match db.unresolved_edges_with_location() {
+        Ok(edges) => edges,
+        Err(e) => {
+            if verbose {
+                eprintln!("Warning: could not list unresolved edges: {e}");
+            }
+            return 0;
+        }
+    };
+    if unresolved.is_empty() {
+        return 0;
+    }
+
+    // Group the candidate edges per (language, source file); only files
+    // changed this run with an lsp/hybrid backend participate.
+    // (edge_id, 1-based line, 0-based col) per edge.
+    type EdgeSite = (i64, u32, u32);
+    let mut per_language: BTreeMap<String, BTreeMap<String, Vec<EdgeSite>>> = BTreeMap::new();
+    for edge in &unresolved {
+        if !changed_files.contains(&edge.source_file) {
+            continue;
+        }
+        let language = match mgr.backend_for(std::path::Path::new(&edge.source_file)) {
+            FileBackend::Lsp(lang) | FileBackend::Hybrid(lang) => lang,
+            _ => continue,
+        };
+        per_language
+            .entry(language)
+            .or_default()
+            .entry(edge.source_file.clone())
+            .or_default()
+            .push((edge.edge_id, edge.line, edge.col));
+    }
+
+    let root = mgr.root().to_path_buf();
+    let mut resolved = 0usize;
+
+    for (language, files) in per_language {
+        'files: for (rel_path, edges) in files {
+            let abs_path = root.join(&rel_path);
+            let Ok(text) = std::fs::read_to_string(&abs_path) else {
+                continue;
+            };
+            let uri = path_to_uri(&abs_path);
+
+            // One didOpen per source file, then a definition request per edge.
+            let Some(client) = mgr.client_for_stage_b(&language) else {
+                break; // server unusable: skip the rest of this language
+            };
+            if client.did_open(&uri, &language, &text).is_err() {
+                break;
+            }
+
+            for (edge_id, line, col) in edges {
+                // ctx lines are 1-based; LSP positions are 0-based.
+                let target = match client.definition(&uri, line.saturating_sub(1), col) {
+                    Ok(target) => target,
+                    Err(e) => {
+                        if verbose {
+                            eprintln!(
+                                "Warning: definition lookup failed in {rel_path}:{line}: {e}"
+                            );
+                        }
+                        if client.failure().is_some() {
+                            // Server died: stop Stage B for this language.
+                            break 'files;
+                        }
+                        continue;
+                    }
+                };
+
+                let Some((target_uri, target_line0)) = target else {
+                    continue;
+                };
+
+                if let Some(target_id) = map_target(db, &root, &target_uri, target_line0, verbose) {
+                    match db.set_edge_target(edge_id, &target_id) {
+                        Ok(true) => resolved += 1,
+                        Ok(false) => {}
+                        Err(e) => {
+                            if verbose {
+                                eprintln!("Warning: failed to update edge {edge_id}: {e}");
+                            }
+                        }
+                    }
+                }
+            }
+
+            client.did_close(&uri);
+        }
+    }
+
+    resolved
+}
+
+/// Map a definition target (`uri` + 0-based line) to an indexed symbol id.
+///
+/// The target must be a local file under the project root and already present
+/// in the index; anything else (stdlib, dependencies, generated files) is
+/// skipped.
+fn map_target(
+    db: &Database,
+    root: &std::path::Path,
+    target_uri: &str,
+    target_line0: u32,
+    verbose: bool,
+) -> Option<String> {
+    let target_path = uri_to_path(target_uri)?;
+    // Canonicalize to survive symlinked roots (e.g. /tmp on macOS).
+    let target_path = target_path.canonicalize().ok()?;
+    let rel = target_path
+        .strip_prefix(root)
+        .ok()?
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    // Only resolve against files that are actually indexed.
+    match db.get_file_hash(&rel) {
+        Ok(Some(_)) => {}
+        _ => return None,
+    }
+
+    let line = target_line0 + 1;
+    match db.symbol_id_at_line(&rel, line) {
+        Ok(Some(id)) => Some(id),
+        Ok(None) => None,
+        Err(e) => {
+            if verbose {
+                eprintln!("Warning: symbol lookup failed for {rel}:{line}: {e}");
+            }
+            None
+        }
+    }
+}

--- a/src/lsp/status.rs
+++ b/src/lsp/status.rs
@@ -13,7 +13,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
-use crate::config::CtxConfig;
 use crate::index::CTX_DIR;
 
 use super::client::LspClient;
@@ -102,8 +101,8 @@ pub struct LspHealthReport {
 
 /// Probe every configured server: PATH check, spawn + handshake, capability
 /// diff, recent stderr. Never fatal; one report per valid `[lsp.*]` block.
-pub fn doctor(root: &Path, ctx_config: &CtxConfig) -> Vec<LspHealthReport> {
-    let (servers, _) = config::validate(&ctx_config.lsp);
+pub fn doctor(root: &Path, lsp_config: &config::LspConfig) -> Vec<LspHealthReport> {
+    let (servers, _) = config::validate(&lsp_config.lsp);
     servers
         .iter()
         .map(|(language, cfg)| probe_server(root, language, cfg))
@@ -232,7 +231,7 @@ mod tests {
 
     #[test]
     fn doctor_reports_missing_binary_without_spawning() {
-        let cfg: CtxConfig = toml::from_str(
+        let cfg: config::LspConfig = toml::from_str(
             r#"
 [lsp.kotlin]
 command = "definitely-not-on-path-xyz"

--- a/src/lsp/status.rs
+++ b/src/lsp/status.rs
@@ -1,0 +1,278 @@
+//! LSP run status sidecar (`.ctx/lsp_status.json`) and health-check probes.
+//!
+//! The sidecar records, per configured language, which server ran, what it
+//! reported during `initialize`, and whether it stayed healthy — without
+//! touching the SQLite schema. `.ctx/` is never indexed, so the sidecar never
+//! shows up in query results.
+//!
+//! [`doctor`] powers a future `ctx lsp doctor` command; it has no CLI wiring
+//! in this crate yet.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use crate::config::CtxConfig;
+use crate::index::CTX_DIR;
+
+use super::client::LspClient;
+use super::config::{self, LspServerConfig};
+
+/// File name of the sidecar inside `.ctx/`.
+pub const STATUS_FILE: &str = "lsp_status.json";
+
+/// One language's entry in the status sidecar.
+#[derive(Debug, Clone, Serialize)]
+pub struct LspStatusEntry {
+    /// Language key from the `[lsp.<language>]` block.
+    pub language: String,
+    /// Configured server command.
+    pub command: String,
+    /// Configured backend (`tree-sitter` | `lsp` | `hybrid`).
+    pub backend: String,
+    /// `healthy`, `failed`, or `idle` (configured but never needed this run).
+    pub state: String,
+    /// Failure reason when `state == "failed"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Server-reported name from `initialize`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_name: Option<String>,
+    /// Server-reported version from `initialize`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_version: Option<String>,
+    /// Negotiated capability names (truthy keys of the server's
+    /// `capabilities` object).
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct StatusDocument<'a> {
+    generated_at: u64,
+    servers: &'a [LspStatusEntry],
+}
+
+/// Write the sidecar for this run (best effort; callers treat errors as
+/// warnings).
+pub(crate) fn write_status_file(root: &Path, entries: &[LspStatusEntry]) -> std::io::Result<()> {
+    let ctx_dir = root.join(CTX_DIR);
+    std::fs::create_dir_all(&ctx_dir)?;
+    let doc = StatusDocument {
+        generated_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        servers: entries,
+    };
+    let text = serde_json::to_string_pretty(&doc).map_err(std::io::Error::other)?;
+    std::fs::write(ctx_dir.join(STATUS_FILE), text)
+}
+
+/// Result of probing one configured server (consumed by a future
+/// `ctx lsp doctor`).
+#[derive(Debug, Clone, Serialize)]
+pub struct LspHealthReport {
+    pub language: String,
+    pub command: String,
+    pub backend: String,
+    /// The command resolves to an executable (PATH lookup or explicit path).
+    pub binary_found: bool,
+    /// Where the binary was found, when it was.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary_path: Option<String>,
+    /// Which configured `root_markers` exist under the project root.
+    pub root_markers_found: Vec<String>,
+    /// Spawn + `initialize` handshake succeeded.
+    pub handshake_ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_version: Option<String>,
+    /// Truthy capability keys negotiated during the probe.
+    pub negotiated_capabilities: Vec<String>,
+    /// Configured `capabilities` the server did NOT negotiate.
+    pub missing_capabilities: Vec<String>,
+    /// Last stderr lines captured from the probe process.
+    pub stderr: Vec<String>,
+    /// Spawn/handshake error, when any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Probe every configured server: PATH check, spawn + handshake, capability
+/// diff, recent stderr. Never fatal; one report per valid `[lsp.*]` block.
+pub fn doctor(root: &Path, ctx_config: &CtxConfig) -> Vec<LspHealthReport> {
+    let (servers, _) = config::validate(&ctx_config.lsp);
+    servers
+        .iter()
+        .map(|(language, cfg)| probe_server(root, language, cfg))
+        .collect()
+}
+
+fn probe_server(root: &Path, language: &str, cfg: &LspServerConfig) -> LspHealthReport {
+    let binary_path = find_executable(&cfg.command);
+    let root_markers_found = cfg
+        .root_markers
+        .iter()
+        .filter(|marker| root.join(marker).exists())
+        .cloned()
+        .collect();
+
+    let mut report = LspHealthReport {
+        language: language.to_string(),
+        command: cfg.command.clone(),
+        backend: cfg.backend.as_str().to_string(),
+        binary_found: binary_path.is_some(),
+        binary_path: binary_path.map(|p| p.to_string_lossy().to_string()),
+        root_markers_found,
+        handshake_ok: false,
+        server_name: None,
+        server_version: None,
+        negotiated_capabilities: Vec::new(),
+        missing_capabilities: Vec::new(),
+        stderr: Vec::new(),
+        error: None,
+    };
+
+    if !report.binary_found {
+        report.error = Some(format!("`{}` not found on PATH", cfg.command));
+        report.missing_capabilities = cfg.capabilities.clone();
+        return report;
+    }
+
+    match LspClient::spawn(cfg, root, false) {
+        Ok(mut client) => {
+            report.handshake_ok = true;
+            report.server_name = client.server_name.clone();
+            report.server_version = client.server_version.clone();
+            report.negotiated_capabilities = client.capability_names();
+            report.missing_capabilities = cfg
+                .capabilities
+                .iter()
+                .filter(|c| !client.supports(&capability_key(c)))
+                .cloned()
+                .collect();
+            report.stderr = client.recent_stderr();
+            client.shutdown();
+        }
+        Err(e) => {
+            report.error = Some(e.reason);
+            report.stderr = e.stderr;
+            report.missing_capabilities = cfg.capabilities.clone();
+        }
+    }
+
+    report
+}
+
+/// Map a user-facing capability name to the `ServerCapabilities` key
+/// (`"documentSymbol"` -> `"documentSymbolProvider"`). Full provider keys are
+/// accepted as-is.
+fn capability_key(name: &str) -> String {
+    if name.ends_with("Provider") || name == "textDocumentSync" {
+        name.to_string()
+    } else {
+        format!("{name}Provider")
+    }
+}
+
+/// Resolve a command to an executable path (explicit path or PATH search).
+fn find_executable(command: &str) -> Option<PathBuf> {
+    let candidate = Path::new(command);
+    if candidate.components().count() > 1 {
+        return if candidate.is_file() {
+            Some(candidate.to_path_buf())
+        } else {
+            None
+        };
+    }
+
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let full = dir.join(command);
+        if full.is_file() {
+            return Some(full);
+        }
+        #[cfg(windows)]
+        {
+            for ext in ["exe", "cmd", "bat"] {
+                let with_ext = dir.join(format!("{command}.{ext}"));
+                if with_ext.is_file() {
+                    return Some(with_ext);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_key_mapping() {
+        assert_eq!(capability_key("documentSymbol"), "documentSymbolProvider");
+        assert_eq!(capability_key("definition"), "definitionProvider");
+        assert_eq!(capability_key("callHierarchy"), "callHierarchyProvider");
+        assert_eq!(
+            capability_key("documentSymbolProvider"),
+            "documentSymbolProvider"
+        );
+        assert_eq!(capability_key("textDocumentSync"), "textDocumentSync");
+    }
+
+    #[test]
+    fn find_executable_resolves_common_binaries() {
+        // `git` is a hard requirement of this repo's test suite already.
+        assert!(find_executable("git").is_some());
+        assert!(find_executable("definitely-not-on-path-xyz").is_none());
+    }
+
+    #[test]
+    fn doctor_reports_missing_binary_without_spawning() {
+        let cfg: CtxConfig = toml::from_str(
+            r#"
+[lsp.kotlin]
+command = "definitely-not-on-path-xyz"
+extensions = ["kt"]
+capabilities = ["documentSymbol", "definition"]
+"#,
+        )
+        .unwrap();
+        let reports = doctor(Path::new("/tmp"), &cfg);
+        assert_eq!(reports.len(), 1);
+        let report = &reports[0];
+        assert!(!report.binary_found);
+        assert!(!report.handshake_ok);
+        assert_eq!(
+            report.missing_capabilities,
+            vec!["documentSymbol", "definition"]
+        );
+        assert!(report.error.as_deref().unwrap().contains("not found"));
+    }
+
+    #[test]
+    fn status_file_is_written_under_ctx_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let entries = vec![LspStatusEntry {
+            language: "kotlin".into(),
+            command: "kls".into(),
+            backend: "lsp".into(),
+            state: "healthy".into(),
+            reason: None,
+            server_name: Some("mock".into()),
+            server_version: Some("1.0".into()),
+            capabilities: vec!["documentSymbolProvider".into()],
+        }];
+        write_status_file(temp.path(), &entries).unwrap();
+
+        let text = std::fs::read_to_string(temp.path().join(CTX_DIR).join(STATUS_FILE)).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(doc["servers"][0]["language"], "kotlin");
+        assert_eq!(doc["servers"][0]["state"], "healthy");
+        assert_eq!(doc["servers"][0]["server_name"], "mock");
+        assert!(doc["generated_at"].as_u64().unwrap() > 0);
+    }
+}

--- a/src/lsp/transport.rs
+++ b/src/lsp/transport.rs
@@ -1,23 +1,33 @@
 //! Hand-rolled JSON-RPC 2.0 transport with LSP `Content-Length` framing.
 //!
 //! Deliberately synchronous: the indexing path is sync (rayon + rusqlite), so
-//! the transport uses a background reader thread plus `mpsc` channels instead
-//! of an async runtime. Generic over `Read`/`Write` so it is unit-testable
-//! with in-memory pipes.
+//! the transport uses a background reader thread, a background writer thread,
+//! and `mpsc` channels instead of an async runtime. Generic over
+//! `Read`/`Write` so it is unit-testable with in-memory pipes.
+//!
+//! All writes go through a bounded queue owned by the writer thread. This
+//! keeps every caller-facing operation time-bounded: if the server stops
+//! draining its stdin (wedged process, SIGSTOP) a plain `write_all` larger
+//! than the OS pipe buffer would block forever — and would do so while
+//! holding a writer lock, so even the failure accounting that kills the child
+//! could never run. With the queue, senders give up at their deadline with
+//! [`TransportError::Timeout`] and the client's consecutive-timeout logic can
+//! kill the child, which breaks the pipe and unblocks the writer thread.
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 
 /// Transport-level failures surfaced to the client layer.
 #[derive(Debug)]
 pub enum TransportError {
-    /// No response arrived within the deadline.
+    /// No response arrived within the deadline, or the outgoing message could
+    /// not even be queued for writing within it (server not draining stdin).
     Timeout,
     /// The peer closed the connection (EOF/broken pipe) or the transport was
     /// already shut down.
@@ -40,44 +50,66 @@ impl std::fmt::Display for TransportError {
 }
 
 type Pending = Arc<Mutex<HashMap<i64, mpsc::Sender<Result<Value, TransportError>>>>>;
-type SharedWriter = Arc<Mutex<Box<dyn Write + Send>>>;
+
+/// Maximum outgoing messages queued for the writer thread.
+const WRITE_QUEUE_CAPACITY: usize = 64;
+/// Enqueue deadline for notifications (which carry no caller timeout).
+const NOTIFY_ENQUEUE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Poll interval while waiting for space in the write queue.
+const ENQUEUE_POLL_INTERVAL: Duration = Duration::from_millis(5);
+/// Maximum accepted `Content-Length` (64 MB). Anything larger is treated as a
+/// framing error and kills the connection, instead of letting a corrupt or
+/// hostile header drive an unbounded allocation.
+pub(crate) const MAX_CONTENT_LENGTH: usize = 64 * 1024 * 1024;
 
 /// Framed JSON-RPC connection over arbitrary byte streams.
 pub struct Transport {
-    writer: SharedWriter,
+    /// Bounded queue of framed bytes; `None` once closed. The writer thread
+    /// owns the underlying stream and is the only place blocking writes run.
+    write_tx: Option<mpsc::SyncSender<Vec<u8>>>,
     pending: Pending,
     next_id: AtomicI64,
     alive: Arc<AtomicBool>,
     reader_handle: Option<JoinHandle<()>>,
+    writer_handle: Option<JoinHandle<()>>,
 }
 
 impl Transport {
     /// Start a transport over the given streams. Spawns the background reader
-    /// thread immediately.
+    /// and writer threads immediately.
     pub fn new<R, W>(reader: R, writer: W, verbose: bool) -> Self
     where
         R: Read + Send + 'static,
         W: Write + Send + 'static,
     {
-        let writer: SharedWriter = Arc::new(Mutex::new(Box::new(writer)));
         let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
         let alive = Arc::new(AtomicBool::new(true));
+        let (write_tx, write_rx) = mpsc::sync_channel::<Vec<u8>>(WRITE_QUEUE_CAPACITY);
+
+        let writer_handle = {
+            let alive = Arc::clone(&alive);
+            let pending = Arc::clone(&pending);
+            std::thread::spawn(move || {
+                writer_loop(write_rx, writer, &alive, &pending);
+            })
+        };
 
         let reader_handle = {
-            let writer = Arc::clone(&writer);
+            let write_tx = write_tx.clone();
             let pending = Arc::clone(&pending);
             let alive = Arc::clone(&alive);
             std::thread::spawn(move || {
-                reader_loop(reader, writer, pending, &alive, verbose);
+                reader_loop(reader, &write_tx, &pending, &alive, verbose);
             })
         };
 
         Self {
-            writer,
+            write_tx: Some(write_tx),
             pending,
             next_id: AtomicI64::new(1),
             alive,
             reader_handle: Some(reader_handle),
+            writer_handle: Some(writer_handle),
         }
     }
 
@@ -86,7 +118,10 @@ impl Transport {
         self.alive.load(Ordering::SeqCst)
     }
 
-    /// Send a request and wait up to `timeout` for its response.
+    /// Send a request and wait up to `timeout` for its response. The timeout
+    /// covers both queueing the outgoing bytes and waiting for the reply, so
+    /// a server that stops reading its stdin surfaces as `Timeout` (feeding
+    /// the client's consecutive-timeout kill logic) instead of blocking.
     pub fn request(
         &self,
         method: &str,
@@ -96,6 +131,10 @@ impl Transport {
         if !self.is_alive() {
             return Err(TransportError::Closed);
         }
+        let Some(write_tx) = &self.write_tx else {
+            return Err(TransportError::Closed);
+        };
+        let deadline = Instant::now() + timeout;
 
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let (tx, rx) = mpsc::channel();
@@ -108,12 +147,20 @@ impl Transport {
             "params": params,
         });
 
-        if let Err(e) = write_message(&self.writer, &message) {
+        let frame = match frame_message(&message) {
+            Ok(frame) => frame,
+            Err(e) => {
+                self.pending.lock().unwrap().remove(&id);
+                return Err(e);
+            }
+        };
+        if let Err(e) = enqueue_until(write_tx, frame, deadline) {
             self.pending.lock().unwrap().remove(&id);
             return Err(e);
         }
 
-        match rx.recv_timeout(timeout) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match rx.recv_timeout(remaining) {
             Ok(result) => result,
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 self.pending.lock().unwrap().remove(&id);
@@ -123,28 +170,40 @@ impl Transport {
         }
     }
 
-    /// Send a notification (no response expected).
+    /// Send a notification (no response expected). Bounded: gives up with
+    /// `Timeout` if the write queue stays full past a fixed deadline.
     pub fn notify(&self, method: &str, params: Value) -> Result<(), TransportError> {
         if !self.is_alive() {
             return Err(TransportError::Closed);
         }
+        let Some(write_tx) = &self.write_tx else {
+            return Err(TransportError::Closed);
+        };
         let message = json!({
             "jsonrpc": "2.0",
             "method": method,
             "params": params,
         });
-        write_message(&self.writer, &message)?;
-        Ok(())
+        let frame = frame_message(&message)?;
+        enqueue_until(write_tx, frame, Instant::now() + NOTIFY_ENQUEUE_TIMEOUT)
     }
 
-    /// Drop the connection: marks the transport closed and detaches the
-    /// reader thread (it exits on EOF once the peer goes away).
+    /// Drop the connection: marks the transport closed and detaches both
+    /// background threads.
     pub fn close(&mut self) {
         self.alive.store(false, Ordering::SeqCst);
         self.pending.lock().unwrap().clear();
-        // The reader thread blocks on `read` until the peer closes its end
-        // (the caller kills the child process); don't join, just detach.
+        // Dropping our sender lets the writer thread exit once the reader
+        // thread (which holds the other clone) is gone and the queue drains.
+        // If the writer is blocked mid-write it exits when the caller kills
+        // the child and the pipe breaks (EPIPE).
+        self.write_tx.take();
+        // Never join: either thread may be blocked on a wedged peer. They
+        // exit on EOF / broken pipe once the child process goes away.
         if let Some(handle) = self.reader_handle.take() {
+            drop(handle);
+        }
+        if let Some(handle) = self.writer_handle.take() {
             drop(handle);
         }
     }
@@ -156,21 +215,60 @@ impl Drop for Transport {
     }
 }
 
-/// Write one `Content-Length`-framed JSON-RPC message.
-fn write_message(writer: &SharedWriter, message: &Value) -> Result<(), TransportError> {
+/// Serialize one message into `Content-Length`-framed bytes.
+fn frame_message(message: &Value) -> Result<Vec<u8>, TransportError> {
     let body = serde_json::to_vec(message).map_err(|e| TransportError::Io(e.to_string()))?;
-    let mut w = writer.lock().unwrap();
-    let header = format!("Content-Length: {}\r\n\r\n", body.len());
-    w.write_all(header.as_bytes())
-        .and_then(|_| w.write_all(&body))
-        .and_then(|_| w.flush())
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                TransportError::Closed
-            } else {
-                TransportError::Io(e.to_string())
+    let mut frame = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+    frame.extend_from_slice(&body);
+    Ok(frame)
+}
+
+/// Queue framed bytes for the writer thread, retrying until `deadline`.
+///
+/// Uses `try_send` + a short poll instead of a blocking `send` so a wedged
+/// server (full queue that never drains) costs at most the caller's deadline.
+fn enqueue_until(
+    tx: &mpsc::SyncSender<Vec<u8>>,
+    mut frame: Vec<u8>,
+    deadline: Instant,
+) -> Result<(), TransportError> {
+    loop {
+        match tx.try_send(frame) {
+            Ok(()) => return Ok(()),
+            Err(mpsc::TrySendError::Full(f)) => {
+                if Instant::now() >= deadline {
+                    return Err(TransportError::Timeout);
+                }
+                frame = f;
+                std::thread::sleep(ENQUEUE_POLL_INTERVAL);
             }
-        })
+            Err(mpsc::TrySendError::Disconnected(_)) => return Err(TransportError::Closed),
+        }
+    }
+}
+
+/// Writer thread: the only place blocking writes happen. Owns the stream;
+/// exits when every sender is gone (transport closed and reader exited) or a
+/// write fails (child killed -> EPIPE). A write failure marks the transport
+/// dead and wakes in-flight requests so they fail fast.
+fn writer_loop<W: Write>(
+    rx: mpsc::Receiver<Vec<u8>>,
+    mut writer: W,
+    alive: &AtomicBool,
+    pending: &Pending,
+) {
+    while let Ok(frame) = rx.recv() {
+        if writer
+            .write_all(&frame)
+            .and_then(|_| writer.flush())
+            .is_err()
+        {
+            alive.store(false, Ordering::SeqCst);
+            pending.lock().unwrap().clear();
+            break;
+        }
+    }
+    // Dropping the writer closes the child's stdin.
 }
 
 /// Read one framed message; `None` on EOF or malformed framing.
@@ -195,20 +293,38 @@ pub(crate) fn read_message<R: BufRead>(reader: &mut R) -> Option<Value> {
     }
 
     let len = content_length?;
+    if len > MAX_CONTENT_LENGTH {
+        return None; // framing error: connection is treated as dead
+    }
     let mut body = vec![0u8; len];
     reader.read_exact(&mut body).ok()?;
     serde_json::from_slice(&body).ok()
 }
 
+/// Runs the reader-loop epilogue even if the loop body panics: mark the
+/// connection dead and wake in-flight requests so they fail fast.
+struct ReaderEpilogue<'a> {
+    alive: &'a AtomicBool,
+    pending: &'a Pending,
+}
+
+impl Drop for ReaderEpilogue<'_> {
+    fn drop(&mut self) {
+        self.alive.store(false, Ordering::SeqCst);
+        self.pending.lock().unwrap().clear();
+    }
+}
+
 /// Background loop: parse incoming messages and dispatch them.
 fn reader_loop<R: Read>(
     reader: R,
-    writer: SharedWriter,
-    pending: Pending,
+    write_tx: &mpsc::SyncSender<Vec<u8>>,
+    pending: &Pending,
     alive: &AtomicBool,
     verbose: bool,
 ) {
     let mut reader = BufReader::new(reader);
+    let _epilogue = ReaderEpilogue { alive, pending };
 
     while alive.load(Ordering::SeqCst) {
         let Some(message) = read_message(&mut reader) else {
@@ -224,8 +340,12 @@ fn reader_loop<R: Read>(
                 let method = message["method"].as_str().unwrap_or("");
                 let result = auto_reply(method, message.get("params"));
                 let reply = json!({ "jsonrpc": "2.0", "id": id, "result": result });
-                if write_message(&writer, &reply).is_err() {
-                    break;
+                // Never block the reader on a full write queue: drop the
+                // reply instead. Blocking here would deadlock the transport
+                // (the reader is what unblocks pending requests), and a full
+                // queue means the server is not draining stdin anyway.
+                if let Ok(frame) = frame_message(&reply) {
+                    let _ = write_tx.try_send(frame);
                 }
             }
             // Notification: dropped (logged under verbose for log messages).
@@ -262,10 +382,6 @@ fn reader_loop<R: Read>(
             (false, None) => {} // malformed; ignore
         }
     }
-
-    alive.store(false, Ordering::SeqCst);
-    // Wake up any in-flight requests so they fail fast instead of timing out.
-    pending.lock().unwrap().clear();
 }
 
 /// Canned replies for server -> client requests we don't implement.
@@ -361,6 +477,59 @@ mod tests {
         }
     }
 
+    /// A writer whose peer never drains: accepts up to `capacity` bytes, then
+    /// blocks until `release()` (after which it fails like a broken pipe).
+    /// Models a wedged language server that stopped reading its stdin.
+    #[derive(Clone)]
+    struct StuckWriter {
+        capacity: usize,
+        written: Arc<Mutex<usize>>,
+        gate: Arc<(Mutex<bool>, Condvar)>,
+        /// Signals each `write` call (used to sequence tests).
+        write_signal: Option<mpsc::Sender<()>>,
+    }
+
+    impl StuckWriter {
+        fn new(capacity: usize) -> Self {
+            StuckWriter {
+                capacity,
+                written: Arc::new(Mutex::new(0)),
+                gate: Arc::new((Mutex::new(false), Condvar::new())),
+                write_signal: None,
+            }
+        }
+
+        fn release(&self) {
+            let (lock, cvar) = &*self.gate;
+            *lock.lock().unwrap() = true;
+            cvar.notify_all();
+        }
+    }
+
+    impl Write for StuckWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            if let Some(signal) = &self.write_signal {
+                let _ = signal.send(());
+            }
+            let mut written = self.written.lock().unwrap();
+            if *written + data.len() > self.capacity {
+                drop(written);
+                let (lock, cvar) = &*self.gate;
+                let mut released = lock.lock().unwrap();
+                while !*released {
+                    released = cvar.wait(released).unwrap();
+                }
+                return Err(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
+            }
+            *written += data.len();
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     /// Spawn a scripted peer: reads framed messages from `incoming` and
     /// passes them to `handler`, writing any returned messages to `outgoing`.
     fn spawn_peer<F>(incoming: Pipe, outgoing: Pipe, mut handler: F) -> JoinHandle<Vec<Value>>
@@ -394,6 +563,16 @@ mod tests {
         let peer = spawn_peer(client_to_server.clone(), server_to_client.clone(), handler);
         let transport = Transport::new(server_to_client.clone(), client_to_server.clone(), false);
         (transport, client_to_server, server_to_client, peer)
+    }
+
+    /// Write one framed message directly onto a pipe (as the server would).
+    fn inject(pipe: &Pipe, message: &Value) {
+        let body = serde_json::to_vec(message).unwrap();
+        let mut writer = pipe.clone();
+        writer
+            .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+            .unwrap();
+        writer.write_all(&body).unwrap();
     }
 
     #[test]
@@ -470,50 +649,42 @@ mod tests {
 
     #[test]
     fn auto_replies_to_server_requests() {
-        // The peer sends a workspace/configuration request as soon as it sees
-        // our request, then answers our request afterwards.
+        // The peer answers any request of ours; the injected server->client
+        // request below is auto-replied by the reader thread.
         let (transport, c2s, s2c, peer) = transport_with_peer(|msg| {
             let id = msg.get("id")?.clone();
-            if msg["method"] == "first" {
-                // Two messages: a server->client request, then our response.
-                // spawn_peer writes only one message per handler call, so
-                // pack them by returning the server request first and the
-                // response on a later call is not possible; instead reply to
-                // "first" directly and let the dedicated test below cover the
-                // config request path.
-                Some(json!({"jsonrpc": "2.0", "id": id, "result": null}))
-            } else {
-                None
-            }
+            Some(json!({"jsonrpc": "2.0", "id": id, "result": null}))
         });
 
         // Inject a server->client request by writing it straight onto the
         // server->client pipe.
-        {
-            let server_request = json!({
+        inject(
+            &s2c,
+            &json!({
                 "jsonrpc": "2.0",
                 "id": 999,
                 "method": "workspace/configuration",
                 "params": { "items": [ {"section": "a"}, {"section": "b"} ] },
-            });
-            let body = serde_json::to_vec(&server_request).unwrap();
-            let mut s2c_writer = s2c.clone();
-            s2c_writer
-                .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
-                .unwrap();
-            s2c_writer.write_all(&body).unwrap();
-        }
+            }),
+        );
 
         // Our own request still completes (correlation by id skips the auto-
         // reply traffic).
         transport
             .request("first", json!({}), Duration::from_secs(2))
             .unwrap();
+        // Writes are asynchronous now: a second request fences the queue.
+        // The reader saw the 999 request before it dispatched the response
+        // to "first", so its auto-reply is queued before "second" — once the
+        // peer answered "second" the auto-reply has been written.
+        transport
+            .request("second", json!({}), Duration::from_secs(2))
+            .unwrap();
 
         c2s.close();
         s2c.close();
         let received = peer.join().unwrap();
-        // The peer saw our request plus the auto-reply to id 999 with one
+        // The peer saw our requests plus the auto-reply to id 999 with one
         // null per configuration item.
         let reply = received
             .iter()
@@ -553,19 +724,14 @@ mod tests {
         });
 
         // A notification from the server must not disturb correlation.
-        {
-            let notification = json!({
+        inject(
+            &s2c,
+            &json!({
                 "jsonrpc": "2.0",
                 "method": "window/logMessage",
                 "params": { "type": 3, "message": "hello" },
-            });
-            let body = serde_json::to_vec(&notification).unwrap();
-            let mut s2c_writer = s2c.clone();
-            s2c_writer
-                .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
-                .unwrap();
-            s2c_writer.write_all(&body).unwrap();
-        }
+            }),
+        );
 
         let value = transport
             .request("ping", json!({}), Duration::from_secs(2))
@@ -573,11 +739,142 @@ mod tests {
         assert_eq!(value, json!(42));
 
         transport.notify("initialized", json!({})).unwrap();
+        // Writes are asynchronous: fence the queued notification with a
+        // request the peer answers before closing the pipes.
+        transport
+            .request("after", json!({}), Duration::from_secs(2))
+            .unwrap();
 
         c2s.close();
         s2c.close();
         let received = peer.join().unwrap();
         assert!(received.iter().any(|m| m["method"] == "initialized"));
         drop(transport);
+    }
+
+    /// A wedged server (never drains stdin) must surface as `Timeout` on the
+    /// caller — never as an indefinitely blocked `request()`. Guarded by its
+    /// own watchdog so a regression fails instead of hanging the test run.
+    #[test]
+    fn request_times_out_when_server_stops_draining_stdin() {
+        let s2c = Pipe::new();
+        let writer = StuckWriter::new(8); // smaller than any framed message
+        let release_handle = writer.clone();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let reader = s2c.clone();
+        std::thread::spawn(move || {
+            let transport = Transport::new(reader, writer, false);
+            let result = transport.request("hang", json!({}), Duration::from_millis(300));
+            done_tx.send(result).unwrap();
+        });
+
+        let result = done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("request() must not block on a wedged server");
+        assert!(
+            matches!(result, Err(TransportError::Timeout)),
+            "got {result:?}"
+        );
+
+        release_handle.release();
+        s2c.close();
+    }
+
+    /// When the write queue itself is full (writer blocked, queue at
+    /// capacity), enqueueing must give up at the caller's deadline.
+    #[test]
+    fn full_write_queue_times_out_request_instead_of_blocking() {
+        let s2c = Pipe::new();
+        let writer = StuckWriter::new(0); // first write blocks immediately
+        let release_handle = writer.clone();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let reader = s2c.clone();
+        std::thread::spawn(move || {
+            let transport = Transport::new(reader, writer, false);
+            // Fill the queue: the writer thread is stuck on the first frame,
+            // the rest sit in the bounded channel.
+            for _ in 0..(WRITE_QUEUE_CAPACITY + 1) {
+                let _ = transport.notify("noise", json!({}));
+            }
+            let result = transport.request("hang", json!({}), Duration::from_millis(200));
+            done_tx.send(result).unwrap();
+        });
+
+        let result = done_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("request() must not block on a full write queue");
+        assert!(
+            matches!(result, Err(TransportError::Timeout)),
+            "got {result:?}"
+        );
+
+        release_handle.release();
+        s2c.close();
+    }
+
+    /// The reader thread must keep dispatching responses even when the write
+    /// queue is full and it cannot send auto-replies (they are dropped).
+    #[test]
+    fn reader_auto_replies_never_deadlock_against_full_write_queue() {
+        let s2c = Pipe::new();
+        let (write_signal_tx, write_signal_rx) = mpsc::channel();
+        let mut writer = StuckWriter::new(0); // wedged from the first byte
+        writer.write_signal = Some(write_signal_tx);
+        let release_handle = writer.clone();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let reader = s2c.clone();
+        std::thread::spawn(move || {
+            let transport = Transport::new(reader, writer, false);
+            // id 1: enqueued, then the writer thread blocks on it forever.
+            let result = transport.request("ping", json!({}), Duration::from_secs(10));
+            done_tx.send(result).unwrap();
+        });
+
+        // Wait until the writer thread picked up the request frame (so the
+        // pending entry exists), then flood the reader with server->client
+        // requests: auto-replies must be dropped, never block the reader.
+        write_signal_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("writer never saw the request frame");
+        for i in 0..(WRITE_QUEUE_CAPACITY * 2) {
+            inject(
+                &s2c,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 1000 + i,
+                    "method": "workspace/configuration",
+                    "params": { "items": [] },
+                }),
+            );
+        }
+        // The response to our request must still be dispatched.
+        inject(&s2c, &json!({ "jsonrpc": "2.0", "id": 1, "result": 42 }));
+
+        let result = done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reader deadlocked against the full write queue");
+        assert_eq!(result.unwrap(), json!(42));
+
+        release_handle.release();
+        s2c.close();
+    }
+
+    #[test]
+    fn oversized_content_length_is_a_framing_error() {
+        let len = MAX_CONTENT_LENGTH + 1;
+        let framed = format!("Content-Length: {len}\r\n\r\nx");
+        let mut reader = std::io::Cursor::new(framed.into_bytes());
+        assert!(read_message(&mut reader).is_none());
+
+        // Sanity: a normal message still parses.
+        let body = br#"{"jsonrpc":"2.0","id":1,"result":null}"#;
+        let mut ok = Vec::new();
+        ok.extend_from_slice(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes());
+        ok.extend_from_slice(body);
+        let mut reader = std::io::Cursor::new(ok);
+        assert!(read_message(&mut reader).is_some());
     }
 }

--- a/src/lsp/transport.rs
+++ b/src/lsp/transport.rs
@@ -1,0 +1,583 @@
+//! Hand-rolled JSON-RPC 2.0 transport with LSP `Content-Length` framing.
+//!
+//! Deliberately synchronous: the indexing path is sync (rayon + rusqlite), so
+//! the transport uses a background reader thread plus `mpsc` channels instead
+//! of an async runtime. Generic over `Read`/`Write` so it is unit-testable
+//! with in-memory pipes.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// Transport-level failures surfaced to the client layer.
+#[derive(Debug)]
+pub enum TransportError {
+    /// No response arrived within the deadline.
+    Timeout,
+    /// The peer closed the connection (EOF/broken pipe) or the transport was
+    /// already shut down.
+    Closed,
+    /// The server answered with a JSON-RPC error object.
+    Rpc(String),
+    /// A message could not be written.
+    Io(String),
+}
+
+impl std::fmt::Display for TransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransportError::Timeout => write!(f, "request timed out"),
+            TransportError::Closed => write!(f, "connection closed"),
+            TransportError::Rpc(e) => write!(f, "server error: {e}"),
+            TransportError::Io(e) => write!(f, "write failed: {e}"),
+        }
+    }
+}
+
+type Pending = Arc<Mutex<HashMap<i64, mpsc::Sender<Result<Value, TransportError>>>>>;
+type SharedWriter = Arc<Mutex<Box<dyn Write + Send>>>;
+
+/// Framed JSON-RPC connection over arbitrary byte streams.
+pub struct Transport {
+    writer: SharedWriter,
+    pending: Pending,
+    next_id: AtomicI64,
+    alive: Arc<AtomicBool>,
+    reader_handle: Option<JoinHandle<()>>,
+}
+
+impl Transport {
+    /// Start a transport over the given streams. Spawns the background reader
+    /// thread immediately.
+    pub fn new<R, W>(reader: R, writer: W, verbose: bool) -> Self
+    where
+        R: Read + Send + 'static,
+        W: Write + Send + 'static,
+    {
+        let writer: SharedWriter = Arc::new(Mutex::new(Box::new(writer)));
+        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let alive = Arc::new(AtomicBool::new(true));
+
+        let reader_handle = {
+            let writer = Arc::clone(&writer);
+            let pending = Arc::clone(&pending);
+            let alive = Arc::clone(&alive);
+            std::thread::spawn(move || {
+                reader_loop(reader, writer, pending, &alive, verbose);
+            })
+        };
+
+        Self {
+            writer,
+            pending,
+            next_id: AtomicI64::new(1),
+            alive,
+            reader_handle: Some(reader_handle),
+        }
+    }
+
+    /// Whether the reader thread still considers the connection open.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+
+    /// Send a request and wait up to `timeout` for its response.
+    pub fn request(
+        &self,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value, TransportError> {
+        if !self.is_alive() {
+            return Err(TransportError::Closed);
+        }
+
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let (tx, rx) = mpsc::channel();
+        self.pending.lock().unwrap().insert(id, tx);
+
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+
+        if let Err(e) = write_message(&self.writer, &message) {
+            self.pending.lock().unwrap().remove(&id);
+            return Err(e);
+        }
+
+        match rx.recv_timeout(timeout) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                self.pending.lock().unwrap().remove(&id);
+                Err(TransportError::Timeout)
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(TransportError::Closed),
+        }
+    }
+
+    /// Send a notification (no response expected).
+    pub fn notify(&self, method: &str, params: Value) -> Result<(), TransportError> {
+        if !self.is_alive() {
+            return Err(TransportError::Closed);
+        }
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        write_message(&self.writer, &message)?;
+        Ok(())
+    }
+
+    /// Drop the connection: marks the transport closed and detaches the
+    /// reader thread (it exits on EOF once the peer goes away).
+    pub fn close(&mut self) {
+        self.alive.store(false, Ordering::SeqCst);
+        self.pending.lock().unwrap().clear();
+        // The reader thread blocks on `read` until the peer closes its end
+        // (the caller kills the child process); don't join, just detach.
+        if let Some(handle) = self.reader_handle.take() {
+            drop(handle);
+        }
+    }
+}
+
+impl Drop for Transport {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+/// Write one `Content-Length`-framed JSON-RPC message.
+fn write_message(writer: &SharedWriter, message: &Value) -> Result<(), TransportError> {
+    let body = serde_json::to_vec(message).map_err(|e| TransportError::Io(e.to_string()))?;
+    let mut w = writer.lock().unwrap();
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    w.write_all(header.as_bytes())
+        .and_then(|_| w.write_all(&body))
+        .and_then(|_| w.flush())
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                TransportError::Closed
+            } else {
+                TransportError::Io(e.to_string())
+            }
+        })
+}
+
+/// Read one framed message; `None` on EOF or malformed framing.
+pub(crate) fn read_message<R: BufRead>(reader: &mut R) -> Option<Value> {
+    let mut content_length: Option<usize> = None;
+
+    // Headers: `Name: value\r\n` pairs terminated by an empty line.
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None; // EOF
+        }
+        let line = line.trim_end();
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = value.trim().parse().ok();
+            }
+        }
+    }
+
+    let len = content_length?;
+    let mut body = vec![0u8; len];
+    reader.read_exact(&mut body).ok()?;
+    serde_json::from_slice(&body).ok()
+}
+
+/// Background loop: parse incoming messages and dispatch them.
+fn reader_loop<R: Read>(
+    reader: R,
+    writer: SharedWriter,
+    pending: Pending,
+    alive: &AtomicBool,
+    verbose: bool,
+) {
+    let mut reader = BufReader::new(reader);
+
+    while alive.load(Ordering::SeqCst) {
+        let Some(message) = read_message(&mut reader) else {
+            break; // EOF or framing error: connection is gone
+        };
+
+        let has_method = message.get("method").is_some();
+        let id = message.get("id").cloned();
+
+        match (has_method, id) {
+            // Server -> client request: auto-reply so the server never stalls.
+            (true, Some(id)) => {
+                let method = message["method"].as_str().unwrap_or("");
+                let result = auto_reply(method, message.get("params"));
+                let reply = json!({ "jsonrpc": "2.0", "id": id, "result": result });
+                if write_message(&writer, &reply).is_err() {
+                    break;
+                }
+            }
+            // Notification: dropped (logged under verbose for log messages).
+            (true, None) => {
+                if verbose {
+                    let method = message["method"].as_str().unwrap_or("");
+                    if method == "window/logMessage" || method == "window/showMessage" {
+                        let text = message
+                            .pointer("/params/message")
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        eprintln!("lsp: {text}");
+                    }
+                }
+            }
+            // Response to one of our requests.
+            (false, Some(id)) => {
+                if let Some(id) = id.as_i64() {
+                    if let Some(tx) = pending.lock().unwrap().remove(&id) {
+                        let outcome = if let Some(error) = message.get("error") {
+                            let text = error
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                                .unwrap_or_else(|| error.to_string());
+                            Err(TransportError::Rpc(text))
+                        } else {
+                            Ok(message.get("result").cloned().unwrap_or(Value::Null))
+                        };
+                        let _ = tx.send(outcome);
+                    }
+                }
+            }
+            (false, None) => {} // malformed; ignore
+        }
+    }
+
+    alive.store(false, Ordering::SeqCst);
+    // Wake up any in-flight requests so they fail fast instead of timing out.
+    pending.lock().unwrap().clear();
+}
+
+/// Canned replies for server -> client requests we don't implement.
+fn auto_reply(method: &str, params: Option<&Value>) -> Value {
+    match method {
+        // Reply with one `null` per requested configuration item.
+        "workspace/configuration" => {
+            let count = params
+                .and_then(|p| p.get("items"))
+                .and_then(Value::as_array)
+                .map(|items| items.len())
+                .unwrap_or(1);
+            Value::Array(vec![Value::Null; count])
+        }
+        // Acknowledged with a null result.
+        "client/registerCapability"
+        | "client/unregisterCapability"
+        | "window/workDoneProgress/create" => Value::Null,
+        "workspace/workspaceFolders" => Value::Null,
+        _ => Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Condvar;
+
+    /// A blocking in-memory byte pipe (one direction).
+    #[derive(Clone)]
+    struct Pipe {
+        inner: Arc<(Mutex<PipeState>, Condvar)>,
+    }
+
+    struct PipeState {
+        buf: VecDeque<u8>,
+        closed: bool,
+    }
+
+    impl Pipe {
+        fn new() -> Self {
+            Pipe {
+                inner: Arc::new((
+                    Mutex::new(PipeState {
+                        buf: VecDeque::new(),
+                        closed: false,
+                    }),
+                    Condvar::new(),
+                )),
+            }
+        }
+
+        fn close(&self) {
+            let (lock, cvar) = &*self.inner;
+            lock.lock().unwrap().closed = true;
+            cvar.notify_all();
+        }
+    }
+
+    impl Read for Pipe {
+        fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+            let (lock, cvar) = &*self.inner;
+            let mut state = lock.lock().unwrap();
+            while state.buf.is_empty() && !state.closed {
+                state = cvar.wait(state).unwrap();
+            }
+            if state.buf.is_empty() {
+                return Ok(0); // EOF
+            }
+            let n = out.len().min(state.buf.len());
+            for slot in out.iter_mut().take(n) {
+                *slot = state.buf.pop_front().unwrap();
+            }
+            Ok(n)
+        }
+    }
+
+    impl Write for Pipe {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            let (lock, cvar) = &*self.inner;
+            let mut state = lock.lock().unwrap();
+            if state.closed {
+                return Err(std::io::Error::from(std::io::ErrorKind::BrokenPipe));
+            }
+            state.buf.extend(data.iter().copied());
+            cvar.notify_all();
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Spawn a scripted peer: reads framed messages from `incoming` and
+    /// passes them to `handler`, writing any returned messages to `outgoing`.
+    fn spawn_peer<F>(incoming: Pipe, outgoing: Pipe, mut handler: F) -> JoinHandle<Vec<Value>>
+    where
+        F: FnMut(&Value) -> Option<Value> + Send + 'static,
+    {
+        std::thread::spawn(move || {
+            let mut received = Vec::new();
+            let mut reader = BufReader::new(incoming);
+            let mut out = outgoing;
+            while let Some(msg) = read_message(&mut reader) {
+                if let Some(reply) = handler(&msg) {
+                    let body = serde_json::to_vec(&reply).unwrap();
+                    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+                    out.write_all(header.as_bytes()).unwrap();
+                    out.write_all(&body).unwrap();
+                }
+                received.push(msg);
+            }
+            received
+        })
+    }
+
+    /// Transport connected to a scripted in-memory peer.
+    fn transport_with_peer<F>(handler: F) -> (Transport, Pipe, Pipe, JoinHandle<Vec<Value>>)
+    where
+        F: FnMut(&Value) -> Option<Value> + Send + 'static,
+    {
+        let client_to_server = Pipe::new();
+        let server_to_client = Pipe::new();
+        let peer = spawn_peer(client_to_server.clone(), server_to_client.clone(), handler);
+        let transport = Transport::new(server_to_client.clone(), client_to_server.clone(), false);
+        (transport, client_to_server, server_to_client, peer)
+    }
+
+    #[test]
+    fn request_response_roundtrip_and_correlation() {
+        let (transport, c2s, s2c, peer) = transport_with_peer(|msg| {
+            // Echo the request id back with a method-specific payload.
+            let id = msg.get("id")?.clone();
+            let method = msg["method"].as_str().unwrap_or("");
+            Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "echo": method },
+            }))
+        });
+
+        let a = transport
+            .request("alpha", json!({}), Duration::from_secs(2))
+            .unwrap();
+        let b = transport
+            .request("beta", json!({"x": 1}), Duration::from_secs(2))
+            .unwrap();
+        assert_eq!(a["echo"], "alpha");
+        assert_eq!(b["echo"], "beta");
+
+        c2s.close();
+        s2c.close();
+        let received = peer.join().unwrap();
+        assert_eq!(received.len(), 2);
+        assert_eq!(received[0]["method"], "alpha");
+        assert_eq!(received[0]["jsonrpc"], "2.0");
+        assert_eq!(received[1]["params"]["x"], 1);
+        drop(transport);
+    }
+
+    #[test]
+    fn timeout_when_server_never_responds() {
+        let (transport, c2s, s2c, peer) = transport_with_peer(|_| None);
+
+        let err = transport
+            .request("hang", json!({}), Duration::from_millis(100))
+            .unwrap_err();
+        assert!(matches!(err, TransportError::Timeout), "got {err:?}");
+
+        c2s.close();
+        s2c.close();
+        peer.join().unwrap();
+        drop(transport);
+    }
+
+    #[test]
+    fn rpc_error_is_surfaced() {
+        let (transport, c2s, s2c, peer) = transport_with_peer(|msg| {
+            let id = msg.get("id")?.clone();
+            Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": -32601, "message": "method not found" },
+            }))
+        });
+
+        let err = transport
+            .request("nope", json!({}), Duration::from_secs(2))
+            .unwrap_err();
+        match err {
+            TransportError::Rpc(text) => assert!(text.contains("method not found")),
+            other => panic!("expected Rpc error, got {other:?}"),
+        }
+
+        c2s.close();
+        s2c.close();
+        peer.join().unwrap();
+        drop(transport);
+    }
+
+    #[test]
+    fn auto_replies_to_server_requests() {
+        // The peer sends a workspace/configuration request as soon as it sees
+        // our request, then answers our request afterwards.
+        let (transport, c2s, s2c, peer) = transport_with_peer(|msg| {
+            let id = msg.get("id")?.clone();
+            if msg["method"] == "first" {
+                // Two messages: a server->client request, then our response.
+                // spawn_peer writes only one message per handler call, so
+                // pack them by returning the server request first and the
+                // response on a later call is not possible; instead reply to
+                // "first" directly and let the dedicated test below cover the
+                // config request path.
+                Some(json!({"jsonrpc": "2.0", "id": id, "result": null}))
+            } else {
+                None
+            }
+        });
+
+        // Inject a server->client request by writing it straight onto the
+        // server->client pipe.
+        {
+            let server_request = json!({
+                "jsonrpc": "2.0",
+                "id": 999,
+                "method": "workspace/configuration",
+                "params": { "items": [ {"section": "a"}, {"section": "b"} ] },
+            });
+            let body = serde_json::to_vec(&server_request).unwrap();
+            let mut s2c_writer = s2c.clone();
+            s2c_writer
+                .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+                .unwrap();
+            s2c_writer.write_all(&body).unwrap();
+        }
+
+        // Our own request still completes (correlation by id skips the auto-
+        // reply traffic).
+        transport
+            .request("first", json!({}), Duration::from_secs(2))
+            .unwrap();
+
+        c2s.close();
+        s2c.close();
+        let received = peer.join().unwrap();
+        // The peer saw our request plus the auto-reply to id 999 with one
+        // null per configuration item.
+        let reply = received
+            .iter()
+            .find(|m| m.get("id").and_then(Value::as_i64) == Some(999))
+            .expect("auto-reply for workspace/configuration");
+        assert_eq!(reply["result"], json!([null, null]));
+        drop(transport);
+    }
+
+    #[test]
+    fn eof_marks_transport_closed() {
+        let (transport, c2s, s2c, peer) = transport_with_peer(|_| None);
+        s2c.close();
+        c2s.close();
+        peer.join().unwrap();
+
+        // Give the reader thread a moment to observe EOF.
+        for _ in 0..100 {
+            if !transport.is_alive() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(!transport.is_alive());
+        let err = transport
+            .request("late", json!({}), Duration::from_millis(100))
+            .unwrap_err();
+        assert!(matches!(err, TransportError::Closed));
+        drop(transport);
+    }
+
+    #[test]
+    fn notifications_are_dropped_without_stalling() {
+        let (transport, c2s, s2c, peer) = transport_with_peer(|msg| {
+            let id = msg.get("id")?.clone();
+            Some(json!({"jsonrpc": "2.0", "id": id, "result": 42}))
+        });
+
+        // A notification from the server must not disturb correlation.
+        {
+            let notification = json!({
+                "jsonrpc": "2.0",
+                "method": "window/logMessage",
+                "params": { "type": 3, "message": "hello" },
+            });
+            let body = serde_json::to_vec(&notification).unwrap();
+            let mut s2c_writer = s2c.clone();
+            s2c_writer
+                .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+                .unwrap();
+            s2c_writer.write_all(&body).unwrap();
+        }
+
+        let value = transport
+            .request("ping", json!({}), Duration::from_secs(2))
+            .unwrap();
+        assert_eq!(value, json!(42));
+
+        transport.notify("initialized", json!({})).unwrap();
+
+        c2s.close();
+        s2c.close();
+        let received = peer.join().unwrap();
+        assert!(received.iter().any(|m| m["method"] == "initialized"));
+        drop(transport);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,15 @@ fn resolve_embed_provider(
 /// Exit codes: 0 = clean, 1 = findings, 2 = operational error,
 /// 3 = version requirement not met (`ctx harness compat` only).
 fn main() -> ExitCode {
+    // Hidden test mode: when CTX_INTERNAL_MOCK_LSP points at a scenario file,
+    // the binary acts as a scripted mock language server over stdio (used by
+    // the LSP backend integration tests). Checked before clap parsing so no
+    // CLI surface is involved.
+    if let Some(path) = std::env::var_os("CTX_INTERNAL_MOCK_LSP") {
+        ctx::lsp::mock::run_stdio_mock(std::path::Path::new(&path));
+        return ExitCode::SUCCESS;
+    }
+
     // The OS-provided main thread stack is too small on some platforms (notably
     // Windows, which defaults to ~1 MiB) for this program's parsing/graph-walking
     // call depth; run on a thread with a larger, explicit stack instead.

--- a/tests/lsp_cli.rs
+++ b/tests/lsp_cli.rs
@@ -1,0 +1,439 @@
+//! End-to-end CLI tests for the LSP extraction backend.
+//!
+//! The ctx test binary doubles as a scripted mock language server: when
+//! `CTX_INTERNAL_MOCK_LSP` points at a scenario JSON file it speaks
+//! Content-Length framed JSON-RPC over stdio instead of running a command
+//! (see `src/lsp/mock.rs`). Each test registers that mock in
+//! `.ctx/config.toml` and drives a real `ctx index` run.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn ctx(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ctx"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run ctx binary")
+}
+
+fn write(dir: &Path, rel: &str, content: &str) {
+    let path = dir.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+/// Write a `[lsp.<language>]` block that spawns the ctx binary in mock mode.
+fn write_mock_lsp_config(
+    root: &Path,
+    language: &str,
+    backend: &str,
+    extensions: &str,
+    scenario: &Path,
+) {
+    // TOML literal strings ('...') keep Windows backslashes intact.
+    let config = format!(
+        r#"
+[lsp.{language}]
+command = '{command}'
+{extensions}
+backend = "{backend}"
+env = {{ CTX_INTERNAL_MOCK_LSP = '{scenario}' }}
+"#,
+        command = env!("CARGO_BIN_EXE_ctx"),
+        scenario = scenario.display(),
+    );
+    write(root, ".ctx/config.toml", &config);
+}
+
+const KOTLIN_SOURCE: &str = "class Greeter {\n    fun greet(who: String): String {\n        return \"hi \" + who\n    }\n}\nfun topLevel() {}\n";
+
+/// documentSymbol scenario response matching `KOTLIN_SOURCE`.
+fn kotlin_document_symbols() -> serde_json::Value {
+    serde_json::json!([
+        {
+            "name": "Greeter",
+            "kind": 5,
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 4, "character": 1 } },
+            "selectionRange": { "start": { "line": 0, "character": 6 }, "end": { "line": 0, "character": 13 } },
+            "children": [
+                {
+                    "name": "greet",
+                    "detail": "fun greet(who: String): String",
+                    "kind": 6,
+                    "range": { "start": { "line": 1, "character": 4 }, "end": { "line": 3, "character": 5 } },
+                    "selectionRange": { "start": { "line": 1, "character": 8 }, "end": { "line": 1, "character": 13 } }
+                }
+            ]
+        },
+        {
+            "name": "topLevel",
+            "kind": 12,
+            "range": { "start": { "line": 5, "character": 0 }, "end": { "line": 5, "character": 18 } },
+            "selectionRange": { "start": { "line": 5, "character": 4 }, "end": { "line": 5, "character": 12 } }
+        }
+    ])
+}
+
+/// Scratch area outside the indexed repo for scenario + hits files.
+fn scenario_dir() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+#[test]
+fn dynamic_language_indexes_via_mock_server() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+    let hits_path = scratch.path().join("hits.log");
+
+    write(root, "src/main.kt", KOTLIN_SOURCE);
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            "server_name": "ctx-mock-kotlin",
+            "hits_file": hits_path,
+            "document_symbols": { "src/main.kt": kotlin_document_symbols() },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_mock_lsp_config(
+        root,
+        "kotlin",
+        "lsp",
+        "extensions = [\"kt\"]",
+        &scenario_path,
+    );
+
+    // Exit code 0 and the kotlin file is indexed.
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The mock server was actually spoken to.
+    let hits = fs::read_to_string(&hits_path).unwrap_or_default();
+    assert!(hits.contains("initialize"), "hits: {hits}");
+    assert!(hits.contains("textDocument/documentSymbol"), "hits: {hits}");
+
+    // `ctx query files` lists the dynamic-language file.
+    let out = ctx(root, &["query", "files"]);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("src/main.kt"), "stdout: {stdout}");
+
+    // `ctx query find` returns the LSP-extracted symbols.
+    let out = ctx(root, &["query", "find", "greet"]);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("greet"), "stdout: {stdout}");
+    assert!(stdout.contains("main.kt"), "stdout: {stdout}");
+
+    // The stored file record carries the dynamic language name (files.language
+    // is free-form TEXT, so kotlin flows through `ctx sql` unchanged).
+    #[cfg(feature = "duckdb")]
+    {
+        let out = ctx(
+            root,
+            &[
+                "sql",
+                "--json",
+                "SELECT language FROM v1.files WHERE path = 'src/main.kt'",
+            ],
+        );
+        assert_eq!(out.status.code(), Some(0));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("kotlin"), "stdout: {stdout}");
+    }
+
+    // Library-level check: the LSP symbols are real index rows.
+    let db = ctx::index::open_database(root).unwrap();
+    let symbols = db.find_symbols("greet", 10).unwrap();
+    assert!(
+        symbols
+            .iter()
+            .any(|s| s.file_path == "src/main.kt" && s.name == "greet"),
+        "symbols: {symbols:?}"
+    );
+
+    // The status sidecar reports the healthy server, and stays out of the
+    // index itself.
+    let status = fs::read_to_string(root.join(".ctx/lsp_status.json")).unwrap();
+    let status: serde_json::Value = serde_json::from_str(&status).unwrap();
+    assert_eq!(status["servers"][0]["language"], "kotlin");
+    assert_eq!(status["servers"][0]["state"], "healthy");
+    assert_eq!(status["servers"][0]["server_name"], "ctx-mock-kotlin");
+    let out = ctx(root, &["query", "files"]);
+    assert!(!String::from_utf8_lossy(&out.stdout).contains("lsp_status.json"));
+}
+
+#[test]
+fn hybrid_backend_resolves_cross_file_call_via_definition() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+
+    // `helper` is defined in two files, so the SQL resolution passes leave
+    // the bare-name call from app.py unresolved (ambiguous). The mock's
+    // definition response points at util.py.
+    write(root, "app.py", "def main():\n    return helper()\n");
+    write(root, "util.py", "def helper():\n    return 1\n");
+    write(root, "other.py", "def helper():\n    return 2\n");
+
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            // Wildcard position match: any definition request in app.py
+            // resolves to util.py's `helper` (0-based line 0).
+            "definitions": {
+                "app.py": { "path": "util.py", "line": 0, "character": 4 }
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_mock_lsp_config(root, "python", "hybrid", "", &scenario_path);
+
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The ambiguous call is now resolved to util.py's helper.
+    let db = ctx::index::open_database(root).unwrap();
+    let call_edge = db
+        .get_incoming_edges("helper")
+        .unwrap()
+        .into_iter()
+        .find(|e| e.kind == ctx::db::EdgeKind::Calls)
+        .expect("expected a calls edge for helper");
+    let target_id = call_edge
+        .target_id
+        .as_deref()
+        .expect("the ambiguous cross-file call must be LSP-resolved, not NULL");
+    assert!(
+        target_id.starts_with("util.py::helper"),
+        "expected util.py's helper, got {target_id}"
+    );
+
+    // Same result through the public SQL surface.
+    #[cfg(feature = "duckdb")]
+    {
+        let out = ctx(
+            root,
+            &[
+                "sql",
+                "--json",
+                "SELECT target_id FROM v1.edges WHERE target_name = 'helper' AND kind = 'calls'",
+            ],
+        );
+        assert_eq!(out.status.code(), Some(0));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("util.py::helper"),
+            "expected the edge to resolve to util.py::helper: {stdout}"
+        );
+    }
+
+    // Tree-sitter still did the extraction (hybrid): symbols exist for all files.
+    let out = ctx(root, &["query", "find", "helper"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("util.py"), "stdout: {stdout}");
+    assert!(stdout.contains("other.py"), "stdout: {stdout}");
+}
+
+#[test]
+fn missing_server_binary_falls_back_to_tree_sitter() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    write(
+        root,
+        "src/app.py",
+        "def compute_total(x):\n    return x + 1\n",
+    );
+    // No scenario needed: the command never spawns.
+    write(
+        root,
+        ".ctx/config.toml",
+        r#"
+[lsp.python]
+command = "definitely-not-on-path-xyz"
+backend = "lsp"
+"#,
+    );
+
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "LSP failures never break indexing"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("falling back"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("definitely-not-on-path-xyz"),
+        "stderr: {stderr}"
+    );
+
+    // Tree-sitter extracted the symbols instead.
+    let out = ctx(root, &["query", "find", "compute_total"]);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("compute_total"), "stdout: {stdout}");
+
+    // Status sidecar records the failure.
+    let status = fs::read_to_string(root.join(".ctx/lsp_status.json")).unwrap();
+    assert!(status.contains("\"state\": \"failed\""), "status: {status}");
+}
+
+#[test]
+fn server_crash_after_initialize_falls_back_gracefully() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+
+    write(
+        root,
+        "src/app.py",
+        "def compute_total(x):\n    return x + 1\n",
+    );
+    fs::write(
+        &scenario_path,
+        serde_json::json!({ "exit_after_initialize": true }).to_string(),
+    )
+    .unwrap();
+    write_mock_lsp_config(root, "python", "lsp", "", &scenario_path);
+
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("falling back"), "stderr: {stderr}");
+
+    // Fallback produced tree-sitter symbols.
+    let out = ctx(root, &["query", "find", "compute_total"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("compute_total"), "stdout: {stdout}");
+}
+
+#[test]
+fn incremental_reindex_spawns_no_server() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+    let hits_path = scratch.path().join("hits.log");
+
+    write(root, "src/main.kt", KOTLIN_SOURCE);
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            "hits_file": hits_path,
+            "document_symbols": { "src/main.kt": kotlin_document_symbols() },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_mock_lsp_config(
+        root,
+        "kotlin",
+        "lsp",
+        "extensions = [\"kt\"]",
+        &scenario_path,
+    );
+
+    // First run talks to the server.
+    let out = ctx(root, &["index"]);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(fs::read_to_string(&hits_path)
+        .unwrap_or_default()
+        .contains("initialize"));
+
+    // Second run: nothing changed, so no file is reindexed and the server is
+    // never spawned again.
+    fs::remove_file(&hits_path).unwrap();
+    let out = ctx(root, &["index"]);
+    assert_eq!(out.status.code(), Some(0));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Indexed 0 files"), "stderr: {stderr}");
+    assert!(
+        !hits_path.exists() || fs::read_to_string(&hits_path).unwrap().is_empty(),
+        "no LSP traffic expected on an incremental no-op run"
+    );
+
+    // Editing the file re-runs Stage A for exactly that file.
+    write(
+        root,
+        "src/main.kt",
+        &KOTLIN_SOURCE.replace("topLevel", "topLevelV2"),
+    );
+    let out = ctx(root, &["index"]);
+    assert_eq!(out.status.code(), Some(0));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Indexed 1 files"), "stderr: {stderr}");
+    assert!(fs::read_to_string(&hits_path)
+        .unwrap_or_default()
+        .contains("textDocument/documentSymbol"));
+}
+
+/// Optional smoke test against a real language server. Run explicitly with
+/// `cargo test --test lsp_cli -- --ignored` on a machine with
+/// `pyright-langserver` installed; skips silently when the binary is absent.
+#[test]
+#[ignore = "requires pyright-langserver on PATH"]
+fn real_pyright_extracts_python_symbols() {
+    let has_pyright = Command::new("pyright-langserver")
+        .arg("--version")
+        .output()
+        .is_ok();
+    if !has_pyright {
+        eprintln!("pyright-langserver not found; skipping");
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    write(
+        root,
+        "app.py",
+        "class Greeter:\n    def greet(self, who):\n        return f\"hi {who}\"\n",
+    );
+    write(
+        root,
+        ".ctx/config.toml",
+        r#"
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+backend = "lsp"
+"#,
+    );
+
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let out = ctx(root, &["query", "find", "greet"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("greet"), "stdout: {stdout}");
+}

--- a/tests/lsp_cli.rs
+++ b/tests/lsp_cli.rs
@@ -392,6 +392,290 @@ fn incremental_reindex_spawns_no_server() {
         .contains("textDocument/documentSymbol"));
 }
 
+/// A dynamic-language file indexed while its server is unusable must be
+/// retried on the next run (the empty record is stored with a poisoned hash),
+/// not skipped forever because the content hash still matches.
+#[test]
+fn degraded_dynamic_file_reindexes_once_server_recovers() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+
+    write(root, "src/main.kt", KOTLIN_SOURCE);
+
+    // Run 1: the configured server binary does not exist -> the kotlin file
+    // is stored with zero symbols (no tree-sitter grammar to fall back to).
+    write(
+        root,
+        ".ctx/config.toml",
+        r#"
+[lsp.kotlin]
+command = "definitely-not-on-path-xyz"
+extensions = ["kt"]
+backend = "lsp"
+"#,
+    );
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    {
+        let db = ctx::index::open_database(root).unwrap();
+        assert!(
+            db.find_symbols("greet", 10).unwrap().is_empty(),
+            "run 1 has no server and no fallback: zero symbols expected"
+        );
+        // The file record itself exists (incremental bookkeeping + deletion
+        // cleanup), with a poisoned hash so the next run retries it.
+        let hash = db.get_file_hash("src/main.kt").unwrap().unwrap();
+        assert!(
+            hash.starts_with("lsp-degraded:"),
+            "degraded record must carry a poisoned hash, got {hash}"
+        );
+    }
+
+    // Run 2: the server is healthy again (mock with real symbols). The file
+    // content is unchanged — before the fix this run skipped the file forever.
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            "server_name": "ctx-mock-kotlin",
+            "document_symbols": { "src/main.kt": kotlin_document_symbols() },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_mock_lsp_config(
+        root,
+        "kotlin",
+        "lsp",
+        "extensions = [\"kt\"]",
+        &scenario_path,
+    );
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Indexed 1 files"),
+        "the degraded file must be re-indexed: {stderr}"
+    );
+
+    // The retry produced real symbols and a healthy status sidecar.
+    let db = ctx::index::open_database(root).unwrap();
+    let symbols = db.find_symbols("greet", 10).unwrap();
+    assert!(
+        symbols
+            .iter()
+            .any(|s| s.file_path == "src/main.kt" && s.name == "greet"),
+        "symbols: {symbols:?}"
+    );
+    let hash = db.get_file_hash("src/main.kt").unwrap().unwrap();
+    assert!(
+        !hash.starts_with("lsp-degraded:"),
+        "healthy extraction must store the real hash, got {hash}"
+    );
+    let status = fs::read_to_string(root.join(".ctx/lsp_status.json")).unwrap();
+    let status: serde_json::Value = serde_json::from_str(&status).unwrap();
+    assert_eq!(status["servers"][0]["state"], "healthy");
+}
+
+/// Stage B must ask `textDocument/definition` at the callee identifier, not
+/// at the start of the call expression (the receiver for method calls), and
+/// must only write targets whose symbol name matches the edge's callee name.
+#[test]
+fn stage_b_definition_targets_callee_identifier() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+
+    // `obj.helper()`: tree-sitter records the call edge at the start of the
+    // whole call expression — column 11, the receiver `obj`. The callee
+    // identifier `helper` starts at column 15. `helper` is defined in two
+    // files so the SQL passes leave the edge unresolved for Stage B.
+    write(root, "app.py", "def main():\n    return obj.helper()\n");
+    write(root, "util.py", "def helper():\n    return 1\n");
+    write(root, "other.py", "def helper():\n    return 2\n");
+
+    // Position-sensitive mock: the receiver position resolves to the WRONG
+    // symbol (`main` in app.py), the callee-identifier position to the right
+    // one. Only the column adjustment reaches the second mapping.
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            "definitions": {
+                "app.py:1:11": { "path": "app.py", "line": 0 },
+                "app.py:1:15": { "path": "util.py", "line": 0, "character": 4 },
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_mock_lsp_config(root, "python", "hybrid", "", &scenario_path);
+
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let db = ctx::index::open_database(root).unwrap();
+    let call_edge = db
+        .get_incoming_edges("helper")
+        .unwrap()
+        .into_iter()
+        .find(|e| e.kind == ctx::db::EdgeKind::Calls)
+        .expect("expected a calls edge for helper");
+    let target_id = call_edge
+        .target_id
+        .as_deref()
+        .expect("the method call must be resolved via the callee identifier");
+    assert!(
+        target_id.starts_with("util.py::helper"),
+        "expected util.py's helper (right names match), got {target_id}"
+    );
+}
+
+/// When the server's definition answer names a different symbol than the
+/// edge's callee, Stage B must leave the edge unresolved instead of writing
+/// a wrong target (which would never be corrected).
+#[test]
+fn stage_b_rejects_definition_with_mismatched_name() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+
+    write(root, "app.py", "def main():\n    return obj.helper()\n");
+    write(root, "util.py", "def helper():\n    return 1\n");
+    write(root, "other.py", "def helper():\n    return 2\n");
+
+    // Every definition request in app.py resolves to app.py line 0 — the
+    // symbol `main`, whose name does not match the callee `helper`.
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            "definitions": {
+                "app.py": { "path": "app.py", "line": 0 },
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_mock_lsp_config(root, "python", "hybrid", "", &scenario_path);
+
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let db = ctx::index::open_database(root).unwrap();
+    let call_edge = db
+        .get_incoming_edges("helper")
+        .unwrap()
+        .into_iter()
+        .find(|e| e.kind == ctx::db::EdgeKind::Calls)
+        .expect("expected a calls edge for helper");
+    assert_eq!(
+        call_edge.target_id, None,
+        "a name-mismatched definition target must be rejected, got {:?}",
+        call_edge.target_id
+    );
+}
+
+/// A server that answers `initialize` and then hangs must be declared failed
+/// after three consecutive request timeouts, fall back to tree-sitter, and
+/// never break the run.
+#[test]
+fn unresponsive_server_fails_after_three_timeouts_and_falls_back() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = scenario_dir();
+    let scenario_path = scratch.path().join("scenario.json");
+    let hits_path = scratch.path().join("hits.log");
+
+    // Three files -> three documentSymbol timeouts -> three strikes.
+    write(root, "a.py", "def alpha_fn():\n    return 1\n");
+    write(root, "b.py", "def beta_fn():\n    return 2\n");
+    write(root, "c.py", "def gamma_fn():\n    return 3\n");
+
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            "never_respond": true,
+            "hits_file": hits_path,
+        })
+        .to_string(),
+    )
+    .unwrap();
+    // Explicit timeout_ms keeps the test fast (no 60s warmup extension).
+    let config = format!(
+        r#"
+[lsp.python]
+command = '{command}'
+backend = "lsp"
+timeout_ms = 200
+env = {{ CTX_INTERNAL_MOCK_LSP = '{scenario}' }}
+"#,
+        command = env!("CARGO_BIN_EXE_ctx"),
+        scenario = scenario_path.display(),
+    );
+    write(root, ".ctx/config.toml", &config);
+
+    let out = ctx(root, &["index"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "LSP failures never break indexing; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("consecutive request timeouts"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("falling back"), "stderr: {stderr}");
+
+    // The handshake did happen (the hang is post-initialize).
+    let hits = fs::read_to_string(&hits_path).unwrap_or_default();
+    assert!(hits.contains("initialize"), "hits: {hits}");
+
+    // Tree-sitter fallback still extracted the symbols.
+    let db = ctx::index::open_database(root).unwrap();
+    for name in ["alpha_fn", "beta_fn", "gamma_fn"] {
+        assert!(
+            !db.find_symbols(name, 10).unwrap().is_empty(),
+            "tree-sitter fallback must provide {name}"
+        );
+    }
+
+    // Status sidecar records the failure.
+    let status = fs::read_to_string(root.join(".ctx/lsp_status.json")).unwrap();
+    let status: serde_json::Value = serde_json::from_str(&status).unwrap();
+    assert_eq!(status["servers"][0]["state"], "failed");
+    assert!(
+        status["servers"][0]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("consecutive request timeouts"),
+        "status: {status}"
+    );
+}
+
 /// Optional smoke test against a real language server. Run explicitly with
 /// `cargo test --test lsp_cli -- --ignored` on a machine with
 /// `pyright-langserver` installed; skips silently when the binary is absent.


### PR DESCRIPTION
## Summary

Adds the Language Server Protocol as a pluggable extraction backend alongside the built-in tree-sitter parsers (AGE-10, workstream 1). Any user can register any stdio language server declaratively in `.ctx/config.toml` — no Rust changes — with per-language backend selection and graceful fallback:

```toml
[lsp.python]
command = "pyright-langserver"
args = ["--stdio"]
extensions = ["py", "pyi"]
root_markers = ["pyproject.toml", ".git"]
capabilities = ["documentSymbol", "definition", "references", "callHierarchy"]
backend = "hybrid"   # tree-sitter | lsp | hybrid (default)
```

- **`src/lsp/` subsystem**: hand-rolled synchronous JSON-RPC stdio transport (no tokio in the index path), generic client (initialize handshake, documentSymbol/definition/callHierarchy/implementation, warmup grace, timeouts, crash handling), DocumentSymbol→Symbol / callHierarchy→Calls mapping into the existing schema, and a scripted mock LSP server (hidden `CTX_INTERNAL_MOCK_LSP` mode of the ctx binary) for deterministic tests.
- **Indexer integration**: files partition by backend; tree-sitter+hybrid go through the unchanged rayon path; pure-LSP files run a serial Stage A; after the existing SQL resolver, a Stage B resolves remaining `target_id IS NULL` edges via `textDocument/definition` with direct DB updates (deliberately bypassing `rewrite_id`, which would corrupt cross-file ids). Watch mode keeps servers warm and now reindexes dynamic languages.
- **Zero-cost when unconfigured**: no `[lsp.*]` config → no processes spawned, no behavior change. No cargo feature gate; compiles under `--all-features` and `--no-default-features`.
- **Never a hard failure**: missing/crashed server warns once per language and falls back to tree-sitter (builtin languages) or stores an empty file record (dynamic languages); exit codes unaffected.
- **No schema change**: `SCHEMA_VERSION` stays 2; server name/version + negotiated capabilities recorded in a `.ctx/lsp_status.json` sidecar. No CLI surface change (`governance/contracts/cli.json` untouched); `ctx lsp` commands come in a follow-up PR.

Part of [AGE-10](https://linear.app/itkonsult/issue/AGE-10). Companion PRs: #74 (registry client groundwork), [ctx-lsp-registry](https://github.com/agentis-tools/ctx-lsp-registry) (community registry, already live).

## Testing

- 28 new unit tests (transport framing/correlation/timeouts/auto-replies, extraction kind table, config validation) + `tests/lsp_cli.rs` end-to-end via the mock server: dynamic language (.kt) indexed purely via config; hybrid Stage B resolving a cross-file call tree-sitter leaves unresolved; missing binary → warning + fallback + exit 0; crash-after-initialize → same; incremental rerun spawns no server. Plus an `#[ignore]`d real-pyright smoke test.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — pass
- `cargo test --locked --all-features` and `--no-default-features` — pass
- `python3 scripts/check-governance.py check`, versioning unittests — pass
- Not run: the release-build steps of `scripts/ci.sh` (LTO build + contract capture); the CLI surface is unchanged so the snapshot cannot drift, but flagging for CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)