### PR TITLE
feat: add ctx lsp command group wired to the community registry (AGE-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--server <NAME>` to override the recommended server), `ctx lsp list`
   shows configured servers (`--available` lists the registry), `ctx lsp
   update` refreshes entries carrying `source = "registry"` provenance with a
-  per-key diff, and `ctx lsp doctor` health-checks every configured server
-  (PATH lookup, initialize handshake, capability diff; exit 1 on failures).
-  All four support the global `--json` flag.
+  per-key diff while preserving user-added keys (`timeout_ms`, `env`, ...),
+  and `ctx lsp doctor` health-checks every configured server (PATH lookup,
+  initialize handshake, capability diff; a malformed config file or invalid
+  `[lsp.*]` blocks are reported as failures; exit 1 on failures). All four
+  support the global `--json` flag.
 - Pluggable LSP extraction backend: any stdio language server can be registered
   declaratively under `[lsp.<language>]` in `.ctx/config.toml`, with per-language
   backend selection (`tree-sitter` (default) / `lsp` / `hybrid`), lazy server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ctx lsp` command group for community-registry LSP management: `ctx lsp add
+  <language>` installs a curated `[lsp.<language>]` entry into
+  `.ctx/config.toml` after confirmation (`--yes`/`-y` for non-interactive use,
+  `--server <NAME>` to override the recommended server), `ctx lsp list`
+  shows configured servers (`--available` lists the registry), `ctx lsp
+  update` refreshes entries carrying `source = "registry"` provenance with a
+  per-key diff, and `ctx lsp doctor` health-checks every configured server
+  (PATH lookup, initialize handshake, capability diff; exit 1 on failures).
+  All four support the global `--json` flag.
 - Pluggable LSP extraction backend: any stdio language server can be registered
   declaratively under `[lsp.<language>]` in `.ctx/config.toml`, with per-language
   backend selection (`tree-sitter` (default) / `lsp` / `hybrid`), lazy server

--- a/governance/contracts/cli.json
+++ b/governance/contracts/cli.json
@@ -30,6 +30,7 @@
         "harness",
         "hotspots",
         "index",
+        "lsp",
         "map",
         "query",
         "review",
@@ -343,6 +344,105 @@
         "--stats": "--stats Print stats (file count, total size, time taken)",
         "--verbose": "-v, --verbose Show verbose output",
         "--watch": "-w, --watch Watch for changes and reindex automatically"
+      },
+      "subcommands": []
+    },
+    "ctx lsp": {
+      "options": {
+        "--count-only": "--count-only Only count tokens, don't output file contents",
+        "--encoding": "--encoding <ENCODING> Tokenizer encoding to use (cl100k_base, o200k_base, p50k_base) [default: cl100k_base]",
+        "--format": "-f, --format <FORMAT> Output format Possible values: - xml - markdown - md - plain - text: Plain text (used by `ctx map`; alias for plain elsewhere) - json [default: xml]",
+        "--help": "-h, --help Print help (see a summary with '-h')",
+        "--ignore": "-i, --ignore <IGNORE_PATTERNS> Additional ignore patterns (can be repeated)",
+        "--json": "--json Emit machine-readable JSON to stdout (see docs/json-output.md)",
+        "--max-tokens": "--max-tokens <MAX_TOKENS> Maximum tokens to include in output (omits files to fit budget, does not truncate file contents)",
+        "--no-default-ignores": "--no-default-ignores Disable built-in ignore patterns",
+        "--no-gitignore": "--no-gitignore Disable .gitignore pattern matching",
+        "--no-stream": "--no-stream Buffer all output before printing (instead of streaming)",
+        "--no-tree": "--no-tree Disable project tree in output",
+        "--show-sizes": "--show-sizes Show file sizes in project tree",
+        "--stats": "--stats Print stats (file count, total size, time taken)"
+      },
+      "subcommands": [
+        "add",
+        "doctor",
+        "list",
+        "update"
+      ]
+    },
+    "ctx lsp add": {
+      "options": {
+        "--count-only": "--count-only Only count tokens, don't output file contents",
+        "--encoding": "--encoding <ENCODING> Tokenizer encoding to use (cl100k_base, o200k_base, p50k_base) [default: cl100k_base]",
+        "--format": "-f, --format <FORMAT> Output format Possible values: - xml - markdown - md - plain - text: Plain text (used by `ctx map`; alias for plain elsewhere) - json [default: xml]",
+        "--help": "-h, --help Print help (see a summary with '-h')",
+        "--ignore": "-i, --ignore <IGNORE_PATTERNS> Additional ignore patterns (can be repeated)",
+        "--json": "--json Emit machine-readable JSON to stdout (see docs/json-output.md)",
+        "--max-tokens": "--max-tokens <MAX_TOKENS> Maximum tokens to include in output (omits files to fit budget, does not truncate file contents)",
+        "--no-default-ignores": "--no-default-ignores Disable built-in ignore patterns",
+        "--no-gitignore": "--no-gitignore Disable .gitignore pattern matching",
+        "--no-stream": "--no-stream Buffer all output before printing (instead of streaming)",
+        "--no-tree": "--no-tree Disable project tree in output",
+        "--server": "--server <NAME> Pick a specific server instead of the registry's recommended one",
+        "--show-sizes": "--show-sizes Show file sizes in project tree",
+        "--stats": "--stats Print stats (file count, total size, time taken)",
+        "--yes": "-y, --yes Skip the confirmation prompt (required in non-interactive use)"
+      },
+      "subcommands": []
+    },
+    "ctx lsp doctor": {
+      "options": {
+        "--count-only": "--count-only Only count tokens, don't output file contents",
+        "--encoding": "--encoding <ENCODING> Tokenizer encoding to use (cl100k_base, o200k_base, p50k_base) [default: cl100k_base]",
+        "--format": "-f, --format <FORMAT> Output format Possible values: - xml - markdown - md - plain - text: Plain text (used by `ctx map`; alias for plain elsewhere) - json [default: xml]",
+        "--help": "-h, --help Print help (see a summary with '-h')",
+        "--ignore": "-i, --ignore <IGNORE_PATTERNS> Additional ignore patterns (can be repeated)",
+        "--json": "--json Emit machine-readable JSON to stdout (see docs/json-output.md)",
+        "--max-tokens": "--max-tokens <MAX_TOKENS> Maximum tokens to include in output (omits files to fit budget, does not truncate file contents)",
+        "--no-default-ignores": "--no-default-ignores Disable built-in ignore patterns",
+        "--no-gitignore": "--no-gitignore Disable .gitignore pattern matching",
+        "--no-stream": "--no-stream Buffer all output before printing (instead of streaming)",
+        "--no-tree": "--no-tree Disable project tree in output",
+        "--show-sizes": "--show-sizes Show file sizes in project tree",
+        "--stats": "--stats Print stats (file count, total size, time taken)"
+      },
+      "subcommands": []
+    },
+    "ctx lsp list": {
+      "options": {
+        "--available": "--available List available registry entries instead of configured ones",
+        "--count-only": "--count-only Only count tokens, don't output file contents",
+        "--encoding": "--encoding <ENCODING> Tokenizer encoding to use (cl100k_base, o200k_base, p50k_base) [default: cl100k_base]",
+        "--format": "-f, --format <FORMAT> Output format Possible values: - xml - markdown - md - plain - text: Plain text (used by `ctx map`; alias for plain elsewhere) - json [default: xml]",
+        "--help": "-h, --help Print help (see a summary with '-h')",
+        "--ignore": "-i, --ignore <IGNORE_PATTERNS> Additional ignore patterns (can be repeated)",
+        "--json": "--json Emit machine-readable JSON to stdout (see docs/json-output.md)",
+        "--max-tokens": "--max-tokens <MAX_TOKENS> Maximum tokens to include in output (omits files to fit budget, does not truncate file contents)",
+        "--no-default-ignores": "--no-default-ignores Disable built-in ignore patterns",
+        "--no-gitignore": "--no-gitignore Disable .gitignore pattern matching",
+        "--no-stream": "--no-stream Buffer all output before printing (instead of streaming)",
+        "--no-tree": "--no-tree Disable project tree in output",
+        "--show-sizes": "--show-sizes Show file sizes in project tree",
+        "--stats": "--stats Print stats (file count, total size, time taken)"
+      },
+      "subcommands": []
+    },
+    "ctx lsp update": {
+      "options": {
+        "--count-only": "--count-only Only count tokens, don't output file contents",
+        "--encoding": "--encoding <ENCODING> Tokenizer encoding to use (cl100k_base, o200k_base, p50k_base) [default: cl100k_base]",
+        "--format": "-f, --format <FORMAT> Output format Possible values: - xml - markdown - md - plain - text: Plain text (used by `ctx map`; alias for plain elsewhere) - json [default: xml]",
+        "--help": "-h, --help Print help (see a summary with '-h')",
+        "--ignore": "-i, --ignore <IGNORE_PATTERNS> Additional ignore patterns (can be repeated)",
+        "--json": "--json Emit machine-readable JSON to stdout (see docs/json-output.md)",
+        "--max-tokens": "--max-tokens <MAX_TOKENS> Maximum tokens to include in output (omits files to fit budget, does not truncate file contents)",
+        "--no-default-ignores": "--no-default-ignores Disable built-in ignore patterns",
+        "--no-gitignore": "--no-gitignore Disable .gitignore pattern matching",
+        "--no-stream": "--no-stream Buffer all output before printing (instead of streaming)",
+        "--no-tree": "--no-tree Disable project tree in output",
+        "--show-sizes": "--show-sizes Show file sizes in project tree",
+        "--stats": "--stats Print stats (file count, total size, time taken)",
+        "--yes": "-y, --yes Apply changes without prompting"
       },
       "subcommands": []
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -794,6 +794,32 @@ EXAMPLES:
         cmd: HarnessCommand,
     },
 
+    /// Manage LSP-backed language support (community registry)
+    ///
+    /// `add` installs a curated `[lsp.<language>]` block from the community
+    /// LSP registry into `.ctx/config.toml`, `list` shows configured (or
+    /// available) servers, `update` refreshes registry-sourced entries, and
+    /// `doctor` health-checks every configured server.
+    #[command(after_help = r#"EXIT CODES:
+    0    success (including "already configured" and "up to date")
+    1    doctor found problems (missing binary, failed handshake)
+    2    operational error (network failure, unknown language, refusal,
+         stdin is not a TTY and --yes was not given)
+
+EXAMPLES:
+    ctx lsp add python                  # install the recommended python server
+    ctx lsp add python --server pylsp   # pick a specific server
+    ctx lsp add python --yes            # skip the confirmation prompt
+    ctx lsp list                        # show configured servers
+    ctx lsp list --available            # show what the registry offers
+    ctx lsp update --yes                # refresh registry-sourced entries
+    ctx lsp doctor                      # health-check configured servers
+"#)]
+    Lsp {
+        #[command(subcommand)]
+        cmd: LspCommand,
+    },
+
     /// Update ctx to the latest GitHub release (or a pinned version)
     ///
     /// Downloads the release artifact for this platform, verifies its
@@ -946,6 +972,58 @@ pub enum HarnessCommand {
     ///
     /// Exit codes: 0 = healthy (info-level notes only), 1 = problems found
     /// (errors or warnings), 2 = operational error.
+    Doctor,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum LspCommand {
+    /// Add a language server from the community registry to .ctx/config.toml
+    ///
+    /// Shows the curated server (command, install hint, homepage) and asks
+    /// for confirmation before writing anything. Entries written by this
+    /// command carry `source = "registry"` provenance so `ctx lsp update`
+    /// can refresh them later; hand-written entries are never touched.
+    Add {
+        /// Language to add (e.g. "python")
+        language: String,
+
+        /// Pick a specific server instead of the registry's recommended one
+        #[arg(long, value_name = "NAME")]
+        server: Option<String>,
+
+        /// Skip the confirmation prompt (required in non-interactive use)
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+
+    /// Show configured language servers
+    List {
+        /// List available registry entries instead of configured ones
+        #[arg(long)]
+        available: bool,
+    },
+
+    /// Refresh registry-sourced entries in .ctx/config.toml
+    ///
+    /// Re-fetches each registry-managed `[lsp.<language>]` entry (marked
+    /// `source = "registry"`), shows a per-key diff against the current
+    /// config, and rewrites the entry after confirmation. Hand-written
+    /// entries are never updated.
+    Update {
+        /// Only refresh this language
+        language: Option<String>,
+
+        /// Apply changes without prompting
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+
+    /// Health-check configured language servers
+    ///
+    /// Probes every `[lsp.<language>]` entry: binary on PATH, spawn +
+    /// initialize handshake, and whether the requested capabilities were
+    /// advertised. Exit codes: 0 = all servers pass, 1 = at least one
+    /// failure, 2 = operational error.
     Doctor,
 }
 

--- a/src/commands/lsp.rs
+++ b/src/commands/lsp.rs
@@ -16,13 +16,13 @@
 use std::io::{IsTerminal, Write};
 use std::path::Path;
 
-use ctx::config::CtxConfig;
 use ctx::config_edit::{
     from_registry, registry_owned_languages, upsert_lsp_entry, LspConfigEntry, SOURCE_REGISTRY,
 };
 use ctx::error::{CtxError, Result};
 use ctx::exit::Outcome;
 use ctx::lsp::status::{doctor, find_executable, LspHealthReport};
+use ctx::lsp::LspConfig;
 use ctx::lsp::LspServerConfig;
 use ctx::lsp_registry::{
     fetch_index, fetch_language, install_hint_for_current_os, registry_base_url,
@@ -56,7 +56,7 @@ fn run_add(
     yes: bool,
     json: bool,
 ) -> Result<Outcome> {
-    let config = CtxConfig::load(root);
+    let config = LspConfig::load(root);
     let existing = config.lsp.get(language);
 
     // A hand-written entry is never touched; refuse before any network call.
@@ -186,7 +186,7 @@ fn run_add(
 // ============================================================================
 
 fn run_list(root: &Path, available: bool, json: bool) -> Result<Outcome> {
-    let config = CtxConfig::load(root);
+    let config = LspConfig::load(root);
 
     if available {
         let base = registry_base_url();
@@ -282,7 +282,7 @@ fn source_label(cfg: &LspServerConfig) -> &'static str {
 
 fn run_update(root: &Path, language: Option<&str>, yes: bool, json: bool) -> Result<Outcome> {
     let owned = registry_owned_languages(root)?;
-    let config = CtxConfig::load(root);
+    let config = LspConfig::load(root);
 
     let targets: Vec<String> = match language {
         Some(lang) if owned.iter().any(|l| l == lang) => vec![lang.to_string()],
@@ -449,7 +449,7 @@ fn entry_matches_config(current: &LspServerConfig, proposed: &LspConfigEntry) ->
 // ============================================================================
 
 fn run_doctor(root: &Path, json: bool) -> Result<Outcome> {
-    let config = CtxConfig::load(root);
+    let config = LspConfig::load(root);
     if config.lsp.is_empty() {
         if json {
             ctx::json::emit(

--- a/src/commands/lsp.rs
+++ b/src/commands/lsp.rs
@@ -17,11 +17,13 @@ use std::io::{IsTerminal, Write};
 use std::path::Path;
 
 use ctx::config_edit::{
-    from_registry, registry_owned_languages, upsert_lsp_entry, LspConfigEntry, SOURCE_REGISTRY,
+    from_registry, lsp_entry_extra_keys, lsp_entry_matches, lsp_entry_registry_owned,
+    refresh_lsp_entry, registry_owned_languages, upsert_lsp_entry, LspConfigEntry, SOURCE_REGISTRY,
 };
 use ctx::error::{CtxError, Result};
 use ctx::exit::Outcome;
-use ctx::lsp::status::{doctor, find_executable, LspHealthReport};
+use ctx::lsp::config::LspConfigLoad;
+use ctx::lsp::status::{doctor_verbose, find_executable, LspHealthReport};
 use ctx::lsp::LspConfig;
 use ctx::lsp::LspServerConfig;
 use ctx::lsp_registry::{
@@ -56,27 +58,30 @@ fn run_add(
     yes: bool,
     json: bool,
 ) -> Result<Outcome> {
-    let config = LspConfig::load(root);
-    let existing = config.lsp.get(language);
-
-    // A hand-written entry is never touched; refuse before any network call.
-    if let Some(current) = existing {
-        if current.source.as_deref() != Some(SOURCE_REGISTRY) {
-            return Err(CtxError::Other(format!(
-                "[lsp.{language}] already exists in .ctx/config.toml and is not registry-managed \
-                 (no `source = \"registry\"` provenance); edit it manually, or remove it and \
-                 re-run 'ctx lsp add {language}'"
-            )));
-        }
+    // Existence/ownership is checked on the raw toml_edit document (not the
+    // serde-typed config, which falls back to empty defaults on type errors)
+    // so a hand-written entry is never touched — even one serde cannot type,
+    // like `command = 3`. Refuse before any network call.
+    let existing = lsp_entry_registry_owned(root, language)?;
+    if existing == Some(false) {
+        return Err(CtxError::Other(format!(
+            "[lsp.{language}] already exists in .ctx/config.toml and is not registry-managed \
+             (no `source = \"{SOURCE_REGISTRY}\"` provenance); fix or remove the entry, then \
+             re-run 'ctx lsp add {language}'"
+        )));
     }
 
     let base = registry_base_url();
     let index = fetch_index(&base)?;
     if !index.languages.contains_key(language) {
         let available: Vec<&str> = index.languages.keys().map(String::as_str).collect();
-        return Err(CtxError::Other(format!(
-            "language '{language}' is not in the LSP registry; available languages: {}",
+        let available = if available.is_empty() {
+            "(none)".to_string()
+        } else {
             available.join(", ")
+        };
+        return Err(CtxError::Other(format!(
+            "language '{language}' is not in the LSP registry; available languages: {available}"
         )));
     }
 
@@ -86,8 +91,8 @@ fn run_add(
     let source_url = format!("{}/registry/{language}.toml", base.trim_end_matches('/'));
 
     // Registry-managed and identical to what we would write: nothing to do.
-    if let Some(current) = existing {
-        if entry_matches_config(current, &proposed) {
+    if existing == Some(true) {
+        if lsp_entry_matches(root, language, &proposed)? {
             if json {
                 ctx::json::emit(
                     "lsp.add",
@@ -108,8 +113,9 @@ fn run_add(
         }
         return Err(CtxError::Other(format!(
             "[lsp.{language}] in .ctx/config.toml differs from the registry entry for server \
-             '{}'; run 'ctx lsp update {language}' to refresh it, or edit it manually",
-            spec.name
+             '{name}'; remove the entry (or edit .ctx/config.toml), then re-run \
+             'ctx lsp add {language} --server {name}'",
+            name = spec.name
         )));
     }
 
@@ -313,6 +319,8 @@ fn run_update(root: &Path, language: Option<&str>, yes: bool, json: bool) -> Res
 
     let base = registry_base_url();
     let mut results: Vec<serde_json::Value> = Vec::new();
+    let mut updated = 0usize;
+    let mut skipped = 0usize;
 
     for lang in &targets {
         let current = config.lsp.get(lang).ok_or_else(|| {
@@ -346,18 +354,35 @@ fn run_update(root: &Path, language: Option<&str>, yes: bool, json: bool) -> Res
             continue;
         }
 
+        // Extra keys the user added to the table (timeout_ms, env, ...) are
+        // preserved by the write below; say so in the consent output.
+        let extra_keys = lsp_entry_extra_keys(root, lang)?;
         if !json {
             println!("{lang}: registry entry for server {} changed:", spec.name);
             for (key, from, to) in &changes {
                 println!("  {key}: {from} -> {to}");
             }
+            if !extra_keys.is_empty() {
+                println!("  (preserving user keys: {})", extra_keys.join(", "));
+            }
         }
+        // Declining one language skips it and continues with the rest;
+        // only a needed-but-impossible prompt (non-TTY without --yes)
+        // aborts with exit 2, via `confirm` returning Err.
         if !confirm(&format!("Update [lsp.{lang}]?"), yes, json)? {
-            return Err(CtxError::Other(format!(
-                "aborted: [lsp.{lang}] not updated"
-            )));
+            skipped += 1;
+            if !json {
+                println!("skipped [lsp.{lang}]");
+            }
+            results.push(serde_json::json!({
+                "language": lang,
+                "server": spec.name,
+                "status": "skipped",
+            }));
+            continue;
         }
-        upsert_lsp_entry(root, lang, &fresh)?;
+        refresh_lsp_entry(root, lang, &fresh)?;
+        updated += 1;
         if !json {
             println!("updated [lsp.{lang}] in .ctx/config.toml");
         }
@@ -375,6 +400,7 @@ fn run_update(root: &Path, language: Option<&str>, yes: bool, json: bool) -> Res
             "server": spec.name,
             "status": "updated",
             "changes": change_map,
+            "preserved_keys": extra_keys,
         }));
     }
 
@@ -383,6 +409,8 @@ fn run_update(root: &Path, language: Option<&str>, yes: bool, json: bool) -> Res
             "lsp.update",
             serde_json::json!({ "registry": base, "languages": results }),
         )?;
+    } else if updated + skipped > 0 {
+        println!("updated {updated}, skipped {skipped}");
     }
     Ok(Outcome::Clean)
 }
@@ -437,19 +465,44 @@ fn diff_entry(
     changes
 }
 
-/// Whether the configured entry already matches what `ctx lsp add` would
-/// write (registry provenance included).
-fn entry_matches_config(current: &LspServerConfig, proposed: &LspConfigEntry) -> bool {
-    current.source.as_deref() == Some(proposed.source.as_str())
-        && diff_entry(current, proposed).is_empty()
-}
-
 // ============================================================================
 // doctor
 // ============================================================================
 
 fn run_doctor(root: &Path, json: bool) -> Result<Outcome> {
-    let config = LspConfig::load(root);
+    // The diagnostic loader distinguishes "no config" from "config the
+    // fault-tolerant loader would silently drop": a malformed file is a
+    // finding, not an empty bill of health.
+    let config = match LspConfig::load_diagnostic(root) {
+        LspConfigLoad::Absent => LspConfig::default(),
+        LspConfigLoad::Loaded(config) => config,
+        LspConfigLoad::Malformed(error) => {
+            if json {
+                ctx::json::emit(
+                    "lsp.doctor",
+                    serde_json::json!({
+                        "healthy": false,
+                        "summary": { "pass": 0, "warn": 0, "fail": 1 },
+                        "servers": [{
+                            "status": "fail",
+                            "error": format!(".ctx/config.toml cannot be loaded: {error}"),
+                        }],
+                    }),
+                )?;
+            } else {
+                println!("FAIL .ctx/config.toml cannot be loaded:");
+                for line in error.trim_end().lines() {
+                    println!("     {line}");
+                }
+                println!(
+                    "     hint: fix (or remove) the broken configuration, then re-run \
+                     'ctx lsp doctor'"
+                );
+            }
+            return Ok(Outcome::Findings);
+        }
+    };
+
     if config.lsp.is_empty() {
         if json {
             ctx::json::emit(
@@ -466,15 +519,18 @@ fn run_doctor(root: &Path, json: bool) -> Result<Outcome> {
         return Ok(Outcome::Clean);
     }
 
-    let reports = doctor(root, &config);
+    // Blocks dropped by validation (empty command, missing extensions, ...)
+    // count as failures alongside the probe reports.
+    let (reports, dropped) = doctor_verbose(root, &config);
     let statuses: Vec<&'static str> = reports.iter().map(report_status).collect();
     let pass = statuses.iter().filter(|s| **s == "pass").count();
     let warn = statuses.iter().filter(|s| **s == "warn").count();
-    let fail = statuses.iter().filter(|s| **s == "fail").count();
+    let fail = statuses.iter().filter(|s| **s == "fail").count() + dropped.len();
     let healthy = fail == 0;
+    let total = reports.len() + dropped.len();
 
     if json {
-        let servers: Vec<serde_json::Value> = reports
+        let mut servers: Vec<serde_json::Value> = reports
             .iter()
             .zip(&statuses)
             .map(|(report, status)| {
@@ -488,6 +544,13 @@ fn run_doctor(root: &Path, json: bool) -> Result<Outcome> {
                 value
             })
             .collect();
+        servers.extend(dropped.iter().map(|block| {
+            serde_json::json!({
+                "language": block.language,
+                "status": "fail",
+                "error": format!("invalid [lsp.{}] block: {}", block.language, block.reason),
+            })
+        }));
         ctx::json::emit(
             "lsp.doctor",
             serde_json::json!({
@@ -500,11 +563,17 @@ fn run_doctor(root: &Path, json: bool) -> Result<Outcome> {
         for (report, status) in reports.iter().zip(&statuses) {
             print_report(report, status);
         }
+        for block in &dropped {
+            println!(
+                "FAIL {}: invalid [lsp.{}] block in .ctx/config.toml: {}",
+                block.language, block.language, block.reason
+            );
+            println!("     hint: fix or remove the block, then re-run 'ctx lsp doctor'");
+        }
         println!();
         println!(
-            "{} server{}: {pass} pass, {warn} warn, {fail} fail",
-            reports.len(),
-            if reports.len() == 1 { "" } else { "s" }
+            "{total} server{}: {pass} pass, {warn} warn, {fail} fail",
+            if total == 1 { "" } else { "s" }
         );
     }
 

--- a/src/commands/lsp.rs
+++ b/src/commands/lsp.rs
@@ -1,0 +1,622 @@
+//! `ctx lsp` -- community-registry LSP server management CLI.
+//!
+//! Thin wrapper around [`ctx::lsp_registry`] (fetch curated manifests),
+//! [`ctx::config_edit`] (format-preserving `.ctx/config.toml` writes), and
+//! [`ctx::lsp::status`] (health probes):
+//!
+//! - `add` installs a curated `[lsp.<language>]` entry after confirmation,
+//! - `list` shows configured (or `--available` registry) servers,
+//! - `update` refreshes entries carrying `source = "registry"` provenance,
+//! - `doctor` probes every configured server end to end.
+//!
+//! Exit codes: 0 = success (including "already configured" / "up to date"),
+//! 1 = doctor found failures, 2 = operational error (network, unknown
+//! language, refusal, prompt needed but stdin is not a TTY).
+
+use std::io::{IsTerminal, Write};
+use std::path::Path;
+
+use ctx::config::CtxConfig;
+use ctx::config_edit::{
+    from_registry, registry_owned_languages, upsert_lsp_entry, LspConfigEntry, SOURCE_REGISTRY,
+};
+use ctx::error::{CtxError, Result};
+use ctx::exit::Outcome;
+use ctx::lsp::status::{doctor, find_executable, LspHealthReport};
+use ctx::lsp::LspServerConfig;
+use ctx::lsp_registry::{
+    fetch_index, fetch_language, install_hint_for_current_os, registry_base_url,
+};
+
+use crate::cli::LspCommand;
+
+/// Run `ctx lsp <SUBCOMMAND>` in the current directory.
+pub fn run_lsp(cmd: LspCommand, json: bool) -> Result<Outcome> {
+    let root = std::env::current_dir()?;
+    match cmd {
+        LspCommand::Add {
+            language,
+            server,
+            yes,
+        } => run_add(&root, &language, server.as_deref(), yes, json),
+        LspCommand::List { available } => run_list(&root, available, json),
+        LspCommand::Update { language, yes } => run_update(&root, language.as_deref(), yes, json),
+        LspCommand::Doctor => run_doctor(&root, json),
+    }
+}
+
+// ============================================================================
+// add
+// ============================================================================
+
+fn run_add(
+    root: &Path,
+    language: &str,
+    server: Option<&str>,
+    yes: bool,
+    json: bool,
+) -> Result<Outcome> {
+    let config = CtxConfig::load(root);
+    let existing = config.lsp.get(language);
+
+    // A hand-written entry is never touched; refuse before any network call.
+    if let Some(current) = existing {
+        if current.source.as_deref() != Some(SOURCE_REGISTRY) {
+            return Err(CtxError::Other(format!(
+                "[lsp.{language}] already exists in .ctx/config.toml and is not registry-managed \
+                 (no `source = \"registry\"` provenance); edit it manually, or remove it and \
+                 re-run 'ctx lsp add {language}'"
+            )));
+        }
+    }
+
+    let base = registry_base_url();
+    let index = fetch_index(&base)?;
+    if !index.languages.contains_key(language) {
+        let available: Vec<&str> = index.languages.keys().map(String::as_str).collect();
+        return Err(CtxError::Other(format!(
+            "language '{language}' is not in the LSP registry; available languages: {}",
+            available.join(", ")
+        )));
+    }
+
+    let entry = fetch_language(&base, language)?;
+    let spec = entry.server(server)?;
+    let proposed = from_registry(&entry, spec);
+    let source_url = format!("{}/registry/{language}.toml", base.trim_end_matches('/'));
+
+    // Registry-managed and identical to what we would write: nothing to do.
+    if let Some(current) = existing {
+        if entry_matches_config(current, &proposed) {
+            if json {
+                ctx::json::emit(
+                    "lsp.add",
+                    serde_json::json!({
+                        "language": language,
+                        "server": spec.name,
+                        "status": "already_configured",
+                    }),
+                )?;
+            } else {
+                println!(
+                    "[lsp.{language}] is already configured from the registry (server {}); \
+                     nothing to do",
+                    spec.name
+                );
+            }
+            return Ok(Outcome::Clean);
+        }
+        return Err(CtxError::Other(format!(
+            "[lsp.{language}] in .ctx/config.toml differs from the registry entry for server \
+             '{}'; run 'ctx lsp update {language}' to refresh it, or edit it manually",
+            spec.name
+        )));
+    }
+
+    let install_hint = install_hint_for_current_os(spec).map(str::to_string);
+    let binary_found = find_executable(&spec.command).is_some();
+
+    if !json {
+        println!("Registry entry for {language} ({source_url}):");
+        println!(
+            "  server:   {}{}",
+            spec.name,
+            if spec.recommended {
+                " (recommended)"
+            } else {
+                ""
+            }
+        );
+        println!("  command:  {}", command_line(&spec.command, &spec.args));
+        if let Some(hint) = &install_hint {
+            println!("  install:  {hint}");
+        }
+        if let Some(homepage) = &spec.homepage {
+            println!("  homepage: {homepage}");
+        }
+        println!();
+        println!("This writes [lsp.{language}] to .ctx/config.toml (backend \"hybrid\").");
+    }
+
+    if !confirm("Proceed?", yes, json)? {
+        return Err(CtxError::Other(
+            "aborted: nothing written to .ctx/config.toml".to_string(),
+        ));
+    }
+
+    upsert_lsp_entry(root, language, &proposed)?;
+
+    if !binary_found {
+        eprintln!("warning: `{}` is not on PATH", spec.command);
+        if let Some(hint) = &install_hint {
+            eprintln!("         install it with: {hint}");
+        }
+        eprintln!("         then verify with 'ctx lsp doctor'");
+    }
+
+    if json {
+        ctx::json::emit(
+            "lsp.add",
+            serde_json::json!({
+                "language": language,
+                "server": spec.name,
+                "command": spec.command,
+                "args": spec.args,
+                "backend": proposed.backend,
+                "source": proposed.source,
+                "registry_url": source_url,
+                "install_hint": install_hint,
+                "homepage": spec.homepage,
+                "binary_found": binary_found,
+                "status": "added",
+            }),
+        )?;
+    } else {
+        println!(
+            "wrote [lsp.{language}] to .ctx/config.toml (server {}, backend {})",
+            spec.name, proposed.backend
+        );
+        println!("run 'ctx index' to reindex with the new language server");
+    }
+    Ok(Outcome::Clean)
+}
+
+// ============================================================================
+// list
+// ============================================================================
+
+fn run_list(root: &Path, available: bool, json: bool) -> Result<Outcome> {
+    let config = CtxConfig::load(root);
+
+    if available {
+        let base = registry_base_url();
+        let index = fetch_index(&base)?;
+        if json {
+            let languages: Vec<serde_json::Value> = index
+                .languages
+                .iter()
+                .map(|(lang, info)| {
+                    serde_json::json!({
+                        "language": lang,
+                        "recommended": info.recommended,
+                        "servers": info.servers,
+                        "configured": config.lsp.contains_key(lang),
+                    })
+                })
+                .collect();
+            ctx::json::emit(
+                "lsp.list",
+                serde_json::json!({
+                    "available": true,
+                    "registry": base,
+                    "languages": languages,
+                }),
+            )?;
+        } else if index.languages.is_empty() {
+            println!("the LSP registry lists no languages ({base})");
+        } else {
+            println!("Available languages in the LSP registry ({base}):");
+            for (lang, info) in &index.languages {
+                let mark = if config.lsp.contains_key(lang) {
+                    "  [configured]"
+                } else {
+                    ""
+                };
+                println!("  {lang}  (recommended server: {}){mark}", info.recommended);
+            }
+            println!();
+            println!("install one with 'ctx lsp add <language>'");
+        }
+        return Ok(Outcome::Clean);
+    }
+
+    if json {
+        let servers: Vec<serde_json::Value> = config
+            .lsp
+            .iter()
+            .map(|(lang, cfg)| {
+                serde_json::json!({
+                    "language": lang,
+                    "command": cfg.command,
+                    "args": cfg.args,
+                    "backend": cfg.backend.as_str(),
+                    "source": source_label(cfg),
+                    "source_server": cfg.source_server,
+                })
+            })
+            .collect();
+        ctx::json::emit(
+            "lsp.list",
+            serde_json::json!({ "available": false, "servers": servers }),
+        )?;
+    } else if config.lsp.is_empty() {
+        println!("no LSP servers configured; try 'ctx lsp list --available'");
+    } else {
+        for (lang, cfg) in &config.lsp {
+            let source = match (source_label(cfg), cfg.source_server.as_deref()) {
+                ("registry", Some(server)) if !server.is_empty() => format!("registry ({server})"),
+                (label, _) => label.to_string(),
+            };
+            println!(
+                "{lang}: `{}` (backend {}, source {source})",
+                command_line(&cfg.command, &cfg.args),
+                cfg.backend.as_str()
+            );
+        }
+    }
+    Ok(Outcome::Clean)
+}
+
+/// `"registry"` for registry-provenance entries, `"manual"` otherwise.
+fn source_label(cfg: &LspServerConfig) -> &'static str {
+    if cfg.source.as_deref() == Some(SOURCE_REGISTRY) {
+        "registry"
+    } else {
+        "manual"
+    }
+}
+
+// ============================================================================
+// update
+// ============================================================================
+
+fn run_update(root: &Path, language: Option<&str>, yes: bool, json: bool) -> Result<Outcome> {
+    let owned = registry_owned_languages(root)?;
+    let config = CtxConfig::load(root);
+
+    let targets: Vec<String> = match language {
+        Some(lang) if owned.iter().any(|l| l == lang) => vec![lang.to_string()],
+        Some(lang) if config.lsp.contains_key(lang) => {
+            return Err(CtxError::Other(format!(
+                "[lsp.{lang}] in .ctx/config.toml is user-owned (no `source = \"registry\"` \
+                 provenance); 'ctx lsp update' only refreshes registry-installed entries — \
+                 edit it manually instead"
+            )));
+        }
+        Some(lang) => {
+            return Err(CtxError::Other(format!(
+                "no [lsp.{lang}] entry in .ctx/config.toml; run 'ctx lsp add {lang}' to \
+                 install one"
+            )));
+        }
+        None => owned,
+    };
+
+    if targets.is_empty() {
+        if json {
+            ctx::json::emit("lsp.update", serde_json::json!({ "languages": [] }))?;
+        } else {
+            println!("no registry-managed LSP entries in .ctx/config.toml; nothing to update");
+        }
+        return Ok(Outcome::Clean);
+    }
+
+    let base = registry_base_url();
+    let mut results: Vec<serde_json::Value> = Vec::new();
+
+    for lang in &targets {
+        let current = config.lsp.get(lang).ok_or_else(|| {
+            CtxError::Other(format!(
+                "[lsp.{lang}] could not be loaded from .ctx/config.toml; fix the entry \
+                 manually and re-run"
+            ))
+        })?;
+
+        let entry = fetch_language(&base, lang)?;
+        let source_server = current.source_server.as_deref().unwrap_or("");
+        // Fall back to the recommended server when the provenance key is
+        // missing/empty (older or hand-repaired entries).
+        let spec = entry.server(if source_server.is_empty() {
+            None
+        } else {
+            Some(source_server)
+        })?;
+        let fresh = from_registry(&entry, spec);
+        let changes = diff_entry(current, &fresh);
+
+        if changes.is_empty() {
+            if !json {
+                println!("{lang}: up to date (server {})", spec.name);
+            }
+            results.push(serde_json::json!({
+                "language": lang,
+                "server": spec.name,
+                "status": "up_to_date",
+            }));
+            continue;
+        }
+
+        if !json {
+            println!("{lang}: registry entry for server {} changed:", spec.name);
+            for (key, from, to) in &changes {
+                println!("  {key}: {from} -> {to}");
+            }
+        }
+        if !confirm(&format!("Update [lsp.{lang}]?"), yes, json)? {
+            return Err(CtxError::Other(format!(
+                "aborted: [lsp.{lang}] not updated"
+            )));
+        }
+        upsert_lsp_entry(root, lang, &fresh)?;
+        if !json {
+            println!("updated [lsp.{lang}] in .ctx/config.toml");
+        }
+        let change_map: serde_json::Map<String, serde_json::Value> = changes
+            .iter()
+            .map(|(key, from, to)| {
+                (
+                    key.to_string(),
+                    serde_json::json!({ "from": from, "to": to }),
+                )
+            })
+            .collect();
+        results.push(serde_json::json!({
+            "language": lang,
+            "server": spec.name,
+            "status": "updated",
+            "changes": change_map,
+        }));
+    }
+
+    if json {
+        ctx::json::emit(
+            "lsp.update",
+            serde_json::json!({ "registry": base, "languages": results }),
+        )?;
+    }
+    Ok(Outcome::Clean)
+}
+
+/// Per-key diff between the configured entry and a freshly fetched one.
+/// Values are rendered as display strings (shared by text and JSON output).
+fn diff_entry(
+    current: &LspServerConfig,
+    fresh: &LspConfigEntry,
+) -> Vec<(&'static str, String, String)> {
+    let mut changes = Vec::new();
+    let mut push = |key: &'static str, from: String, to: String| {
+        if from != to {
+            changes.push((key, from, to));
+        }
+    };
+    push(
+        "command",
+        format!("{:?}", current.command),
+        format!("{:?}", fresh.command),
+    );
+    push(
+        "args",
+        format!("{:?}", current.args),
+        format!("{:?}", fresh.args),
+    );
+    push(
+        "extensions",
+        format!("{:?}", current.extensions),
+        format!("{:?}", fresh.extensions),
+    );
+    push(
+        "root_markers",
+        format!("{:?}", current.root_markers),
+        format!("{:?}", fresh.root_markers),
+    );
+    push(
+        "capabilities",
+        format!("{:?}", current.capabilities),
+        format!("{:?}", fresh.capabilities),
+    );
+    push(
+        "backend",
+        format!("{:?}", current.backend.as_str()),
+        format!("{:?}", fresh.backend),
+    );
+    push(
+        "source_server",
+        format!("{:?}", current.source_server.as_deref().unwrap_or("")),
+        format!("{:?}", fresh.source_server),
+    );
+    changes
+}
+
+/// Whether the configured entry already matches what `ctx lsp add` would
+/// write (registry provenance included).
+fn entry_matches_config(current: &LspServerConfig, proposed: &LspConfigEntry) -> bool {
+    current.source.as_deref() == Some(proposed.source.as_str())
+        && diff_entry(current, proposed).is_empty()
+}
+
+// ============================================================================
+// doctor
+// ============================================================================
+
+fn run_doctor(root: &Path, json: bool) -> Result<Outcome> {
+    let config = CtxConfig::load(root);
+    if config.lsp.is_empty() {
+        if json {
+            ctx::json::emit(
+                "lsp.doctor",
+                serde_json::json!({
+                    "healthy": true,
+                    "summary": { "pass": 0, "warn": 0, "fail": 0 },
+                    "servers": [],
+                }),
+            )?;
+        } else {
+            println!("no LSP servers configured; try 'ctx lsp list --available'");
+        }
+        return Ok(Outcome::Clean);
+    }
+
+    let reports = doctor(root, &config);
+    let statuses: Vec<&'static str> = reports.iter().map(report_status).collect();
+    let pass = statuses.iter().filter(|s| **s == "pass").count();
+    let warn = statuses.iter().filter(|s| **s == "warn").count();
+    let fail = statuses.iter().filter(|s| **s == "fail").count();
+    let healthy = fail == 0;
+
+    if json {
+        let servers: Vec<serde_json::Value> = reports
+            .iter()
+            .zip(&statuses)
+            .map(|(report, status)| {
+                let mut value = serde_json::to_value(report).unwrap_or(serde_json::Value::Null);
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert(
+                        "status".to_string(),
+                        serde_json::Value::String((*status).to_string()),
+                    );
+                }
+                value
+            })
+            .collect();
+        ctx::json::emit(
+            "lsp.doctor",
+            serde_json::json!({
+                "healthy": healthy,
+                "summary": { "pass": pass, "warn": warn, "fail": fail },
+                "servers": servers,
+            }),
+        )?;
+    } else {
+        for (report, status) in reports.iter().zip(&statuses) {
+            print_report(report, status);
+        }
+        println!();
+        println!(
+            "{} server{}: {pass} pass, {warn} warn, {fail} fail",
+            reports.len(),
+            if reports.len() == 1 { "" } else { "s" }
+        );
+    }
+
+    Ok(if healthy {
+        Outcome::Clean
+    } else {
+        Outcome::Findings
+    })
+}
+
+/// `fail` when the binary is missing or the handshake failed, `warn` when
+/// requested capabilities were not advertised, `pass` otherwise.
+fn report_status(report: &LspHealthReport) -> &'static str {
+    if !report.binary_found || !report.handshake_ok {
+        "fail"
+    } else if !report.missing_capabilities.is_empty() {
+        "warn"
+    } else {
+        "pass"
+    }
+}
+
+fn print_report(report: &LspHealthReport, status: &str) {
+    let tag = status.to_uppercase();
+    if !report.binary_found {
+        println!(
+            "{tag} {}: `{}` not found on PATH",
+            report.language, report.command
+        );
+        println!(
+            "     hint: install the server (see 'ctx lsp list --available'), then re-run \
+             'ctx lsp doctor'"
+        );
+        return;
+    }
+    if !report.handshake_ok {
+        println!(
+            "{tag} {}: `{}` failed the initialize handshake{}",
+            report.language,
+            report.command,
+            report
+                .error
+                .as_deref()
+                .map(|e| format!(" ({e})"))
+                .unwrap_or_default()
+        );
+        for line in &report.stderr {
+            println!("     stderr: {line}");
+        }
+        return;
+    }
+
+    let server = match (&report.server_name, &report.server_version) {
+        (Some(name), Some(version)) => format!(" ({name} {version})"),
+        (Some(name), None) => format!(" ({name})"),
+        _ => String::new(),
+    };
+    if report.missing_capabilities.is_empty() {
+        println!(
+            "{tag} {}: `{}` handshake ok{server}, capabilities ok",
+            report.language, report.command
+        );
+    } else {
+        println!(
+            "{tag} {}: `{}` handshake ok{server}, missing capabilities: {}",
+            report.language,
+            report.command,
+            report.missing_capabilities.join(", ")
+        );
+        println!(
+            "     hint: the server does not advertise everything the config requests; \
+             extraction may be degraded"
+        );
+    }
+}
+
+// ============================================================================
+// shared helpers
+// ============================================================================
+
+/// Render a command plus its arguments as one shell-style line.
+fn command_line(command: &str, args: &[String]) -> String {
+    let mut line = command.to_string();
+    for arg in args {
+        line.push(' ');
+        line.push_str(arg);
+    }
+    line
+}
+
+/// Ask for confirmation on stdin. `--yes` bypasses the prompt; JSON mode and
+/// non-interactive stdin refuse instead of hanging (exit code 2 via `Err`).
+fn confirm(question: &str, yes: bool, json: bool) -> Result<bool> {
+    if yes {
+        return Ok(true);
+    }
+    if json {
+        return Err(CtxError::Other(
+            "--json mode never prompts; pass --yes to confirm".to_string(),
+        ));
+    }
+    if !std::io::stdin().is_terminal() {
+        return Err(CtxError::Other(
+            "stdin is not a TTY; pass --yes to confirm non-interactively".to_string(),
+        ));
+    }
+    eprint!("{question} [y/N] ");
+    std::io::stderr().flush()?;
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer)?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod harness;
 pub mod hotspots;
 pub mod index;
 pub mod interactive;
+pub mod lsp;
 pub mod map;
 pub mod query;
 pub mod score;
@@ -38,6 +39,7 @@ pub use index::{run_index, IndexConfig};
 #[cfg(feature = "mcp")]
 pub use interactive::run_serve;
 pub use interactive::run_shell;
+pub use lsp::run_lsp;
 pub use map::{run_map, MapFormat};
 pub use query::run_query;
 pub use score::run_score;

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -14,7 +14,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use toml_edit::{value, Array, DocumentMut, Item, Table};
+use toml_edit::{value, Array, DocumentMut, Item, Table, TableLike};
 
 use crate::config::CONFIG_FILE;
 use crate::error::{CtxError, Result};
@@ -75,12 +75,28 @@ pub fn from_registry(entry: &LanguageEntry, server: &ServerSpec) -> LspConfigEnt
     }
 }
 
+/// Keys `ctx lsp add`/`ctx lsp update` manage in a `[lsp.<lang>]` table.
+/// Anything else on the table is a user customization (`timeout_ms`, `env`,
+/// `initialization_options`, ...) that tooling must never remove.
+const CANONICAL_KEYS: [&str; 8] = [
+    "command",
+    "args",
+    "extensions",
+    "root_markers",
+    "capabilities",
+    "backend",
+    "source",
+    "source_server",
+];
+
 /// Insert or replace `[lsp.<lang>]` in `<root>/.ctx/config.toml`.
 ///
 /// Creates `.ctx/` and the config file when absent. Everything outside the
 /// touched table — comments, formatting, unknown keys, other `[lsp.*]`
 /// tables — is preserved byte-for-byte. The file is written atomically
-/// (temp file in `.ctx/` + rename).
+/// (temp file in `.ctx/` + rename). Used by the `ctx lsp add` path (fresh
+/// entries); `ctx lsp update` uses [`refresh_lsp_entry`] instead so user
+/// customizations on the table survive.
 pub fn upsert_lsp_entry(root: &Path, lang: &str, entry: &LspConfigEntry) -> Result<()> {
     let path = config_path(root);
     fs::create_dir_all(path.parent().expect("config path has a parent"))?;
@@ -88,6 +104,31 @@ pub fn upsert_lsp_entry(root: &Path, lang: &str, entry: &LspConfigEntry) -> Resu
 
     let lsp = lsp_table_mut(&mut doc, &path)?;
     lsp.insert(lang, Item::Table(entry_table(entry)));
+
+    write_atomic(&path, doc.to_string().as_bytes())
+}
+
+/// Like [`upsert_lsp_entry`], but when `[lsp.<lang>]` already exists only
+/// the canonical keys are (re)written: extra keys the user added to the
+/// table (`timeout_ms`, `env`, `initialization_options`, ...) are left
+/// untouched, as are their positions. Missing canonical keys are appended.
+pub fn refresh_lsp_entry(root: &Path, lang: &str, entry: &LspConfigEntry) -> Result<()> {
+    let path = config_path(root);
+    fs::create_dir_all(path.parent().expect("config path has a parent"))?;
+    let mut doc = load_document(&path)?;
+
+    let lsp = lsp_table_mut(&mut doc, &path)?;
+    match lsp.get_mut(lang).and_then(Item::as_table_like_mut) {
+        Some(existing) => {
+            let canonical = entry_table(entry);
+            for (key, item) in canonical.iter() {
+                existing.insert(key, item.clone());
+            }
+        }
+        None => {
+            lsp.insert(lang, Item::Table(entry_table(entry)));
+        }
+    }
 
     write_atomic(&path, doc.to_string().as_bytes())
 }
@@ -131,6 +172,109 @@ pub fn registry_owned_languages(root: &Path) -> Result<Vec<String>> {
         }
     }
     Ok(owned)
+}
+
+/// Raw (`toml_edit`-level) ownership check for `[lsp.<lang>]`, so entries
+/// serde cannot type (e.g. `command = 3`) are still visible to `ctx lsp add`
+/// and are never silently replaced.
+///
+/// - `Ok(None)`: no config file, or no `[lsp.<lang>]` entry.
+/// - `Ok(Some(true))`: the entry carries `source = "registry"` provenance.
+/// - `Ok(Some(false))`: hand-written — no registry provenance, including
+///   non-table values and type-broken tables.
+pub fn lsp_entry_registry_owned(root: &Path, lang: &str) -> Result<Option<bool>> {
+    let path = config_path(root);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let doc = load_document(&path)?;
+    let Some(item) = raw_lsp_item(&doc, lang) else {
+        return Ok(None);
+    };
+    let source = item
+        .as_table_like()
+        .and_then(|t| t.get("source"))
+        .and_then(Item::as_str);
+    Ok(Some(source == Some(SOURCE_REGISTRY)))
+}
+
+/// Whether the raw `[lsp.<lang>]` table matches `entry` on the canonical
+/// keys. Missing keys compare against defaults (empty string/array, backend
+/// `"hybrid"`); a key of the wrong type never matches; extra user keys are
+/// ignored. `Ok(false)` when the file or entry is absent.
+pub fn lsp_entry_matches(root: &Path, lang: &str, entry: &LspConfigEntry) -> Result<bool> {
+    let path = config_path(root);
+    if !path.exists() {
+        return Ok(false);
+    }
+    let doc = load_document(&path)?;
+    let Some(table) = raw_lsp_item(&doc, lang).and_then(Item::as_table_like) else {
+        return Ok(false);
+    };
+    Ok(
+        raw_str(table, "command", "") == Some(entry.command.as_str())
+            && raw_str(table, "backend", "hybrid") == Some(entry.backend.as_str())
+            && raw_str(table, "source", "") == Some(entry.source.as_str())
+            && raw_str(table, "source_server", "") == Some(entry.source_server.as_str())
+            && raw_str_array(table, "args").as_deref() == Some(entry.args.as_slice())
+            && raw_str_array(table, "extensions").as_deref() == Some(entry.extensions.as_slice())
+            && raw_str_array(table, "root_markers").as_deref()
+                == Some(entry.root_markers.as_slice())
+            && raw_str_array(table, "capabilities").as_deref()
+                == Some(entry.capabilities.as_slice()),
+    )
+}
+
+/// Non-canonical keys present on the raw `[lsp.<lang>]` table — user
+/// customizations [`refresh_lsp_entry`] preserves. Empty when the file or
+/// entry is absent.
+pub fn lsp_entry_extra_keys(root: &Path, lang: &str) -> Result<Vec<String>> {
+    let path = config_path(root);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let doc = load_document(&path)?;
+    let Some(table) = raw_lsp_item(&doc, lang).and_then(Item::as_table_like) else {
+        return Ok(Vec::new());
+    };
+    Ok(table
+        .iter()
+        .map(|(key, _)| key)
+        .filter(|key| !CANONICAL_KEYS.contains(key))
+        .map(str::to_string)
+        .collect())
+}
+
+/// The raw `[lsp.<lang>]` item from the parsed document, if any.
+fn raw_lsp_item<'a>(doc: &'a DocumentMut, lang: &str) -> Option<&'a Item> {
+    doc.get("lsp")
+        .and_then(Item::as_table_like)
+        .and_then(|t| t.get(lang))
+}
+
+/// String value of `key`, or `default` when the key is absent.
+/// `None` when the key exists with a non-string value.
+fn raw_str<'a>(table: &'a dyn TableLike, key: &str, default: &'a str) -> Option<&'a str> {
+    match table.get(key) {
+        None => Some(default),
+        Some(item) => item.as_str(),
+    }
+}
+
+/// String-array value of `key`, or empty when the key is absent.
+/// `None` when the key exists but is not an array of strings.
+fn raw_str_array(table: &dyn TableLike, key: &str) -> Option<Vec<String>> {
+    match table.get(key) {
+        None => Some(Vec::new()),
+        Some(item) => {
+            let array = item.as_array()?;
+            let mut out = Vec::with_capacity(array.len());
+            for value in array {
+                out.push(value.as_str()?.to_string());
+            }
+            Some(out)
+        }
+    }
 }
 
 fn config_path(root: &Path) -> PathBuf {
@@ -343,6 +487,137 @@ source = "manual"
         // Missing file is a no-op.
         let empty = tempfile::tempdir().unwrap();
         assert!(!remove_lsp_entry(empty.path(), "python").unwrap());
+    }
+
+    #[test]
+    fn refresh_preserves_user_keys_and_updates_canonical() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+source = "registry"
+source_server = "pyright"
+# tuned for the monorepo
+timeout_ms = 15000
+env = { JAVA_HOME = "/opt/java" }
+"#,
+        )
+        .unwrap();
+
+        let mut entry = sample_entry();
+        entry.args = vec!["--stdio".to_string(), "--verbose".to_string()];
+        refresh_lsp_entry(dir.path(), "python", &entry).unwrap();
+
+        let text = fs::read_to_string(&path).unwrap();
+        // Canonical drift is applied...
+        assert!(
+            text.contains(r#"args = ["--stdio", "--verbose"]"#),
+            "{text}"
+        );
+        // ...missing canonical keys are added...
+        assert!(text.contains(r#"backend = "hybrid""#), "{text}");
+        // ...and user customizations survive byte-for-byte.
+        assert!(text.contains("timeout_ms = 15000\n"), "{text}");
+        assert!(
+            text.contains("env = { JAVA_HOME = \"/opt/java\" }\n"),
+            "{text}"
+        );
+        assert!(text.contains("# tuned for the monorepo\n"), "{text}");
+    }
+
+    #[test]
+    fn refresh_creates_entry_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        refresh_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        let text = fs::read_to_string(config_path(dir.path())).unwrap();
+        assert_eq!(text, PYTHON_TABLE);
+    }
+
+    #[test]
+    fn raw_registry_ownership_sees_type_broken_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        // No file at all.
+        assert_eq!(
+            lsp_entry_registry_owned(dir.path(), "python").unwrap(),
+            None
+        );
+
+        let path = config_path(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        // Hand-written, serde-typable.
+        fs::write(&path, "[lsp.python]\ncommand = \"my-pylsp\"\n").unwrap();
+        assert_eq!(
+            lsp_entry_registry_owned(dir.path(), "python").unwrap(),
+            Some(false)
+        );
+        assert_eq!(lsp_entry_registry_owned(dir.path(), "go").unwrap(), None);
+
+        // Hand-written, type-broken (valid TOML, invalid type): still seen.
+        fs::write(&path, "[lsp.python]\ncommand = 3\n").unwrap();
+        assert_eq!(
+            lsp_entry_registry_owned(dir.path(), "python").unwrap(),
+            Some(false)
+        );
+
+        // Registry-owned.
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        assert_eq!(
+            lsp_entry_registry_owned(dir.path(), "python").unwrap(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn raw_entry_matching_ignores_extra_keys_and_rejects_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        let entry = sample_entry();
+        assert!(!lsp_entry_matches(dir.path(), "python", &entry).unwrap());
+
+        upsert_lsp_entry(dir.path(), "python", &entry).unwrap();
+        assert!(lsp_entry_matches(dir.path(), "python", &entry).unwrap());
+
+        // Extra user keys do not break "identical".
+        let path = config_path(dir.path());
+        let mut text = fs::read_to_string(&path).unwrap();
+        text.push_str("timeout_ms = 15000\n");
+        fs::write(&path, &text).unwrap();
+        assert!(lsp_entry_matches(dir.path(), "python", &entry).unwrap());
+
+        // Canonical drift is a mismatch.
+        let mut drifted = entry.clone();
+        drifted.args.push("--verbose".to_string());
+        assert!(!lsp_entry_matches(dir.path(), "python", &drifted).unwrap());
+
+        // A type-broken canonical key never matches.
+        fs::write(&path, "[lsp.python]\ncommand = 3\nsource = \"registry\"\n").unwrap();
+        assert!(!lsp_entry_matches(dir.path(), "python", &entry).unwrap());
+    }
+
+    #[test]
+    fn extra_keys_lists_only_non_canonical_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(lsp_entry_extra_keys(dir.path(), "python")
+            .unwrap()
+            .is_empty());
+
+        upsert_lsp_entry(dir.path(), "python", &sample_entry()).unwrap();
+        assert!(lsp_entry_extra_keys(dir.path(), "python")
+            .unwrap()
+            .is_empty());
+
+        let path = config_path(dir.path());
+        let mut text = fs::read_to_string(&path).unwrap();
+        text.push_str("timeout_ms = 15000\nenv = { JAVA_HOME = \"/opt/java\" }\n");
+        fs::write(&path, &text).unwrap();
+        assert_eq!(
+            lsp_entry_extra_keys(dir.path(), "python").unwrap(),
+            ["timeout_ms", "env"]
+        );
     }
 
     #[test]

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -7,11 +7,9 @@
 //! The only writer today manages `[lsp.<lang>]` tables installed from the
 //! community LSP registry ([`crate::lsp_registry`]). Registry-owned tables are
 //! marked with `source = "registry"` / `source_server = "<name>"` provenance
-//! keys so a future `ctx lsp update` can tell curated entries apart from
-//! hand-written ones.
-//!
-//! This module is internal groundwork for the future `ctx lsp` commands; it
-//! has no CLI surface yet.
+//! keys so `ctx lsp update` can tell curated entries apart from hand-written
+//! ones. `ctx lsp add` and `ctx lsp update` are the CLI surface over this
+//! module.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/lsp/config.rs
+++ b/src/lsp/config.rs
@@ -61,6 +61,39 @@ impl LspConfig {
             }
         }
     }
+
+    /// Diagnostic loader used by `ctx lsp doctor`: distinguishes an absent
+    /// config file from a malformed one so broken configuration surfaces as
+    /// a failure instead of silently reading as "nothing configured".
+    ///
+    /// [`LspConfig::load`] keeps its never-fatal fall-back-to-defaults
+    /// semantics for the indexer; this does not change them.
+    pub fn load_diagnostic(root: &Path) -> LspConfigLoad {
+        let path = root
+            .join(crate::index::CTX_DIR)
+            .join(crate::config::CONFIG_FILE);
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return LspConfigLoad::Absent,
+            Err(e) => return LspConfigLoad::Malformed(e.to_string()),
+        };
+        match toml::from_str(&text) {
+            Ok(config) => LspConfigLoad::Loaded(config),
+            Err(e) => LspConfigLoad::Malformed(e.to_string()),
+        }
+    }
+}
+
+/// Outcome of [`LspConfig::load_diagnostic`].
+#[derive(Debug)]
+pub enum LspConfigLoad {
+    /// No `.ctx/config.toml`: nothing is configured.
+    Absent,
+    /// The file parsed (possibly with zero `[lsp.*]` blocks).
+    Loaded(LspConfig),
+    /// The file exists but cannot be parsed or typed; the fault-tolerant
+    /// [`LspConfig::load`] would fall back to defaults here.
+    Malformed(String),
 }
 
 /// Per-language extraction backend selection.
@@ -147,14 +180,35 @@ pub(crate) fn builtin_extensions(language: &str) -> Option<&'static [&'static st
 pub(crate) fn validate(
     lsp: &BTreeMap<String, LspServerConfig>,
 ) -> (BTreeMap<String, LspServerConfig>, BTreeMap<String, String>) {
+    let (servers, extension_claims, _) = validate_verbose(lsp);
+    (servers, extension_claims)
+}
+
+/// `[lsp.*]` blocks dropped by validation, as `(language, reason)` pairs.
+pub(crate) type DroppedBlocks = Vec<(String, String)>;
+
+/// [`validate`], additionally reporting the dropped blocks as
+/// `(language, reason)` pairs so `ctx lsp doctor` can surface them as
+/// failures. Warnings are still printed; existing callers of [`validate`]
+/// behave exactly as before.
+pub(crate) fn validate_verbose(
+    lsp: &BTreeMap<String, LspServerConfig>,
+) -> (
+    BTreeMap<String, LspServerConfig>,
+    BTreeMap<String, String>,
+    DroppedBlocks,
+) {
     let mut servers: BTreeMap<String, LspServerConfig> = BTreeMap::new();
     let mut extension_claims: BTreeMap<String, String> = BTreeMap::new();
+    let mut dropped: Vec<(String, String)> = Vec::new();
 
     for (language, raw) in lsp {
         let mut cfg = raw.clone();
 
         if cfg.command.trim().is_empty() {
-            eprintln!("Warning: ignoring [lsp.{language}] in .ctx/config.toml: `command` is empty");
+            let reason = "`command` is empty".to_string();
+            eprintln!("Warning: ignoring [lsp.{language}] in .ctx/config.toml: {reason}");
+            dropped.push((language.clone(), reason));
             continue;
         }
 
@@ -172,10 +226,9 @@ pub(crate) fn validate(
                     cfg.extensions = defaults.iter().map(|e| e.to_string()).collect();
                 }
                 None => {
-                    eprintln!(
-                        "Warning: ignoring [lsp.{language}] in .ctx/config.toml: \
-                         `extensions` is required for non-builtin languages"
-                    );
+                    let reason = "`extensions` is required for non-builtin languages".to_string();
+                    eprintln!("Warning: ignoring [lsp.{language}] in .ctx/config.toml: {reason}");
+                    dropped.push((language.clone(), reason));
                     continue;
                 }
             }
@@ -198,7 +251,7 @@ pub(crate) fn validate(
         servers.insert(language.clone(), cfg);
     }
 
-    (servers, extension_claims)
+    (servers, extension_claims, dropped)
 }
 
 #[cfg(test)]
@@ -402,5 +455,66 @@ command = 42
                 .lsp
                 .is_empty()
         );
+    }
+
+    fn write_config(dir: &Path, contents: &str) {
+        let ctx_dir = dir.join(crate::index::CTX_DIR);
+        std::fs::create_dir_all(&ctx_dir).unwrap();
+        std::fs::write(ctx_dir.join(crate::config::CONFIG_FILE), contents).unwrap();
+    }
+
+    #[test]
+    fn load_diagnostic_distinguishes_absent_loaded_and_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            LspConfig::load_diagnostic(dir.path()),
+            LspConfigLoad::Absent
+        ));
+
+        write_config(dir.path(), "[lsp.kotlin]\ncommand = \"kls\"\n");
+        match LspConfig::load_diagnostic(dir.path()) {
+            LspConfigLoad::Loaded(config) => assert_eq!(config.lsp.len(), 1),
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+
+        // Valid TOML, invalid type: the fault-tolerant loader falls back to
+        // defaults, the diagnostic one reports Malformed.
+        write_config(dir.path(), "[lsp.kotlin]\ncommand = 3\n");
+        assert!(matches!(
+            LspConfig::load_diagnostic(dir.path()),
+            LspConfigLoad::Malformed(_)
+        ));
+
+        // Not TOML at all.
+        write_config(dir.path(), "this is not valid toml : : :");
+        assert!(matches!(
+            LspConfig::load_diagnostic(dir.path()),
+            LspConfigLoad::Malformed(_)
+        ));
+    }
+
+    #[test]
+    fn validate_verbose_reports_dropped_blocks_with_reasons() {
+        let lsp = parse(
+            r#"
+[lsp.kotlin]
+command = ""
+extensions = ["kt"]
+
+[lsp.mystery]
+command = "mystery-ls"
+
+[lsp.python]
+command = "pyright-langserver"
+"#,
+        );
+        let (servers, _, dropped) = validate_verbose(&lsp);
+        assert_eq!(servers.len(), 1);
+        assert!(servers.contains_key("python"));
+        assert_eq!(dropped.len(), 2);
+        assert_eq!(dropped[0].0, "kotlin");
+        assert!(dropped[0].1.contains("`command` is empty"), "{dropped:?}");
+        assert_eq!(dropped[1].0, "mystery");
+        assert!(dropped[1].1.contains("`extensions`"), "{dropped:?}");
     }
 }

--- a/src/lsp/status.rs
+++ b/src/lsp/status.rs
@@ -97,14 +97,39 @@ pub struct LspHealthReport {
     pub error: Option<String>,
 }
 
+/// A `[lsp.<language>]` block dropped by config validation, with the reason.
+/// `ctx lsp doctor` surfaces each one as a failure instead of letting broken
+/// configuration vanish from the report.
+#[derive(Debug, Clone, Serialize)]
+pub struct DroppedLspBlock {
+    /// Language key of the dropped `[lsp.<language>]` block.
+    pub language: String,
+    /// Why validation dropped it.
+    pub reason: String,
+}
+
 /// Probe every configured server: PATH check, spawn + handshake, capability
 /// diff, recent stderr. Never fatal; one report per valid `[lsp.*]` block.
 pub fn doctor(root: &Path, lsp_config: &config::LspConfig) -> Vec<LspHealthReport> {
-    let (servers, _) = config::validate(&lsp_config.lsp);
-    servers
+    doctor_verbose(root, lsp_config).0
+}
+
+/// Like [`doctor`], but also returns the `[lsp.*]` blocks validation dropped
+/// (empty `command`, missing `extensions`, ...) so callers can report them.
+pub fn doctor_verbose(
+    root: &Path,
+    lsp_config: &config::LspConfig,
+) -> (Vec<LspHealthReport>, Vec<DroppedLspBlock>) {
+    let (servers, _, dropped) = config::validate_verbose(&lsp_config.lsp);
+    let reports = servers
         .iter()
         .map(|(language, cfg)| probe_server(root, language, cfg))
-        .collect()
+        .collect();
+    let dropped = dropped
+        .into_iter()
+        .map(|(language, reason)| DroppedLspBlock { language, reason })
+        .collect();
+    (reports, dropped)
 }
 
 fn probe_server(root: &Path, language: &str, cfg: &LspServerConfig) -> LspHealthReport {
@@ -250,6 +275,23 @@ capabilities = ["documentSymbol", "definition"]
             vec!["documentSymbol", "definition"]
         );
         assert!(report.error.as_deref().unwrap().contains("not found"));
+    }
+
+    #[test]
+    fn doctor_verbose_reports_dropped_blocks() {
+        let cfg: config::LspConfig = toml::from_str(
+            r#"
+[lsp.kotlin]
+command = ""
+extensions = ["kt"]
+"#,
+        )
+        .unwrap();
+        let (reports, dropped) = doctor_verbose(Path::new("/tmp"), &cfg);
+        assert!(reports.is_empty());
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].language, "kotlin");
+        assert!(dropped[0].reason.contains("`command` is empty"));
     }
 
     #[test]

--- a/src/lsp/status.rs
+++ b/src/lsp/status.rs
@@ -5,8 +5,7 @@
 //! touching the SQLite schema. `.ctx/` is never indexed, so the sidecar never
 //! shows up in query results.
 //!
-//! [`doctor`] powers a future `ctx lsp doctor` command; it has no CLI wiring
-//! in this crate yet.
+//! [`doctor`] powers the `ctx lsp doctor` command.
 
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -69,8 +68,7 @@ pub(crate) fn write_status_file(root: &Path, entries: &[LspStatusEntry]) -> std:
     std::fs::write(ctx_dir.join(STATUS_FILE), text)
 }
 
-/// Result of probing one configured server (consumed by a future
-/// `ctx lsp doctor`).
+/// Result of probing one configured server (consumed by `ctx lsp doctor`).
 #[derive(Debug, Clone, Serialize)]
 pub struct LspHealthReport {
     pub language: String,
@@ -178,7 +176,9 @@ fn capability_key(name: &str) -> String {
 }
 
 /// Resolve a command to an executable path (explicit path or PATH search).
-fn find_executable(command: &str) -> Option<PathBuf> {
+/// Also used by `ctx lsp add` to warn when a freshly installed server's
+/// binary is not available yet.
+pub fn find_executable(command: &str) -> Option<PathBuf> {
     let candidate = Path::new(command);
     if candidate.components().count() > 1 {
         return if candidate.is_file() {

--- a/src/lsp_registry.rs
+++ b/src/lsp_registry.rs
@@ -12,8 +12,8 @@
 //! deliberately *not* a config key: the registry location is a distribution
 //! concern, not a per-project setting.
 //!
-//! This module is internal groundwork for the future `ctx lsp` commands; it
-//! has no CLI surface yet.
+//! The `ctx lsp` commands (`add`, `list --available`, `update`) are the CLI
+//! surface over this client.
 
 use std::collections::BTreeMap;
 use std::time::Duration;

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,6 +347,11 @@ fn run(args: Args) -> Result<Outcome> {
             // problems; compat exits 3 on version mismatch).
             return commands::run_harness(cmd, json);
         }
+        Some(Command::Lsp { cmd }) => {
+            // LSP registry command: returns its own Outcome (doctor exits 1
+            // when a configured server fails its health probe).
+            return commands::run_lsp(cmd, json);
+        }
         Some(Command::SelfUpdate { version }) => {
             // Update command: returns its own Outcome (Clean when updated or
             // already up to date; any failure maps to exit 2 in main).

--- a/tests/lsp_registry.rs
+++ b/tests/lsp_registry.rs
@@ -1,0 +1,489 @@
+//! End-to-end CLI tests for `ctx lsp add|list|update|doctor`.
+//!
+//! A local [`MockServer`] plays the community LSP registry (`/index.toml`,
+//! `/registry/python.toml`) and `CTX_LSP_REGISTRY_BASE_URL` points the child
+//! ctx process at it. The doctor tests reuse the scripted mock language
+//! server built into the ctx binary (`CTX_INTERNAL_MOCK_LSP`, see
+//! `src/lsp/mock.rs` and `tests/lsp_cli.rs`).
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use ctx::testutil::MockServer;
+
+const INDEX_TOML: &str = r#"
+schema_version = 1
+
+[languages.python]
+recommended = "pyright"
+servers = ["pyright"]
+
+[languages.go]
+recommended = "gopls"
+servers = ["gopls"]
+"#;
+
+const PYTHON_TOML: &str = r#"
+schema_version = 1
+language = "python"
+extensions = ["py", "pyi"]
+root_markers = ["pyproject.toml", "setup.py", "setup.cfg", ".git"]
+
+[[servers]]
+name = "pyright"
+recommended = true
+command = "pyright-langserver"
+args = ["--stdio"]
+capabilities = ["documentSymbol", "references", "callHierarchy"]
+homepage = "https://github.com/microsoft/pyright"
+notes = "Fast, actively maintained."
+
+[servers.install]
+default = "npm install -g pyright"
+macos = "brew install pyright"
+"#;
+
+/// Drifted variant of `PYTHON_TOML`: the curated args gained `--verbose`.
+const PYTHON_TOML_DRIFTED: &str = r#"
+schema_version = 1
+language = "python"
+extensions = ["py", "pyi"]
+root_markers = ["pyproject.toml", "setup.py", "setup.cfg", ".git"]
+
+[[servers]]
+name = "pyright"
+recommended = true
+command = "pyright-langserver"
+args = ["--stdio", "--verbose"]
+capabilities = ["documentSymbol", "references", "callHierarchy"]
+homepage = "https://github.com/microsoft/pyright"
+
+[servers.install]
+default = "npm install -g pyright"
+"#;
+
+fn registry_server() -> MockServer {
+    let server = MockServer::start();
+    server.add_route("/index.toml", "text/plain; charset=utf-8", INDEX_TOML);
+    server.add_route(
+        "/registry/python.toml",
+        "text/plain; charset=utf-8",
+        PYTHON_TOML,
+    );
+    server
+}
+
+/// Run the ctx binary in `dir` against the mock registry at `base`.
+fn ctx(dir: &Path, base: &str, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ctx"))
+        .args(args)
+        .current_dir(dir)
+        .env("CTX_LSP_REGISTRY_BASE_URL", base)
+        .env("CTX_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("failed to run ctx binary")
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+fn config_text(root: &Path) -> String {
+    fs::read_to_string(root.join(".ctx/config.toml")).expect("config file exists")
+}
+
+fn write(dir: &Path, rel: &str, content: &str) {
+    let path = dir.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+/// Parse the single JSON envelope a `--json` invocation must print.
+fn parse_envelope(out: &Output, command: &str) -> serde_json::Value {
+    let text = stdout(out);
+    let value: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON ({e}): {text}"));
+    assert_eq!(value["command"], command, "envelope: {value}");
+    value
+}
+
+// ============================================================================
+// add
+// ============================================================================
+
+#[test]
+fn add_with_yes_writes_registry_entry_and_is_idempotent() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let out = ctx(root, &server.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    let text = config_text(root);
+    assert!(text.contains("[lsp.python]"), "config: {text}");
+    assert!(text.contains("command = \"pyright-langserver\""), "{text}");
+    assert!(text.contains("backend = \"hybrid\""), "{text}");
+    assert!(text.contains("source = \"registry\""), "{text}");
+    assert!(text.contains("source_server = \"pyright\""), "{text}");
+    let output = stdout(&out);
+    assert!(output.contains("wrote [lsp.python]"), "stdout: {output}");
+    assert!(output.contains("ctx index"), "stdout: {output}");
+    // pyright-langserver is not installed in CI: the install hint is
+    // surfaced as a warning instead of blocking the write.
+    if !stderr(&out).is_empty() {
+        assert!(
+            stderr(&out).contains("pyright-langserver"),
+            "{}",
+            stderr(&out)
+        );
+    }
+
+    // Second identical add: exit 0, nothing rewritten.
+    let before = config_text(root);
+    let out = ctx(root, &server.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(
+        stdout(&out).contains("already configured"),
+        "stdout: {}",
+        stdout(&out)
+    );
+    assert_eq!(config_text(root), before);
+}
+
+#[test]
+fn add_refuses_manually_configured_language() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let manual = "[lsp.python]\ncommand = \"my-pylsp\"\n";
+    write(root, ".ctx/config.toml", manual);
+
+    let out = ctx(root, &server.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    let err = stderr(&out);
+    assert!(err.contains("not registry-managed"), "stderr: {err}");
+    // The hand-written entry is untouched.
+    assert_eq!(config_text(root), manual);
+    // Refused before any network call.
+    assert_eq!(server.hits(), 0);
+}
+
+#[test]
+fn add_without_yes_and_no_tty_exits_2() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    // Child stdin is closed (not a TTY): the prompt must refuse, not hang.
+    let out = ctx(root, &server.url(), &["lsp", "add", "python"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    assert!(stderr(&out).contains("--yes"), "stderr: {}", stderr(&out));
+    assert!(!root.join(".ctx/config.toml").exists());
+
+    // JSON mode never prompts either.
+    let out = ctx(root, &server.url(), &["--json", "lsp", "add", "python"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    assert!(stderr(&out).contains("--yes"), "stderr: {}", stderr(&out));
+    assert!(!root.join(".ctx/config.toml").exists());
+}
+
+#[test]
+fn add_unknown_language_lists_available_languages() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let out = ctx(root, &server.url(), &["lsp", "add", "cobol", "--yes"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    let err = stderr(&out);
+    assert!(err.contains("'cobol'"), "stderr: {err}");
+    assert!(err.contains("python"), "stderr: {err}");
+    assert!(err.contains("go"), "stderr: {err}");
+}
+
+#[test]
+fn add_json_reports_what_was_written() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let out = ctx(
+        root,
+        &server.url(),
+        &["--json", "lsp", "add", "python", "--yes"],
+    );
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    let value = parse_envelope(&out, "lsp.add");
+    assert_eq!(value["data"]["status"], "added");
+    assert_eq!(value["data"]["language"], "python");
+    assert_eq!(value["data"]["server"], "pyright");
+    assert_eq!(value["data"]["command"], "pyright-langserver");
+    assert_eq!(value["data"]["backend"], "hybrid");
+    assert!(config_text(root).contains("[lsp.python]"));
+}
+
+// ============================================================================
+// list
+// ============================================================================
+
+#[test]
+fn list_reports_empty_and_configured_states() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    // Empty state is friendly.
+    let out = ctx(root, &server.url(), &["lsp", "list"]);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stdout(&out).contains("no LSP servers configured"),
+        "stdout: {}",
+        stdout(&out)
+    );
+
+    // Configured state shows language, command, backend, and provenance.
+    let out = ctx(root, &server.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    let out = ctx(root, &server.url(), &["lsp", "list"]);
+    assert_eq!(out.status.code(), Some(0));
+    let output = stdout(&out);
+    assert!(output.contains("python"), "stdout: {output}");
+    assert!(output.contains("pyright-langserver --stdio"), "{output}");
+    assert!(output.contains("hybrid"), "{output}");
+    assert!(output.contains("registry (pyright)"), "{output}");
+
+    // JSON variant parses and carries the same data.
+    let out = ctx(root, &server.url(), &["--json", "lsp", "list"]);
+    assert_eq!(out.status.code(), Some(0));
+    let value = parse_envelope(&out, "lsp.list");
+    let servers = value["data"]["servers"].as_array().unwrap();
+    assert_eq!(servers.len(), 1);
+    assert_eq!(servers[0]["language"], "python");
+    assert_eq!(servers[0]["command"], "pyright-langserver");
+    assert_eq!(servers[0]["backend"], "hybrid");
+    assert_eq!(servers[0]["source"], "registry");
+}
+
+#[test]
+fn list_available_marks_configured_languages() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let out = ctx(root, &server.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+
+    let out = ctx(root, &server.url(), &["lsp", "list", "--available"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    let output = stdout(&out);
+    assert!(output.contains("pyright"), "stdout: {output}");
+    assert!(output.contains("gopls"), "stdout: {output}");
+    // python is configured, go is not.
+    for line in output.lines() {
+        if line.contains("python") {
+            assert!(line.contains("[configured]"), "line: {line}");
+        }
+        if line.contains("  go ") || line.trim_start().starts_with("go ") {
+            assert!(!line.contains("[configured]"), "line: {line}");
+        }
+    }
+
+    // JSON variant carries the configured flag.
+    let out = ctx(
+        root,
+        &server.url(),
+        &["--json", "lsp", "list", "--available"],
+    );
+    assert_eq!(out.status.code(), Some(0));
+    let value = parse_envelope(&out, "lsp.list");
+    let languages = value["data"]["languages"].as_array().unwrap();
+    let python = languages
+        .iter()
+        .find(|l| l["language"] == "python")
+        .unwrap();
+    assert_eq!(python["configured"], true);
+    assert_eq!(python["recommended"], "pyright");
+    let go = languages.iter().find(|l| l["language"] == "go").unwrap();
+    assert_eq!(go["configured"], false);
+}
+
+// ============================================================================
+// update
+// ============================================================================
+
+#[test]
+fn update_applies_registry_drift_then_reports_up_to_date() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    // Install from the original registry.
+    let original = registry_server();
+    let out = ctx(root, &original.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(!config_text(root).contains("--verbose"));
+
+    // The registry entry drifts (args gained --verbose).
+    let drifted = MockServer::start();
+    drifted.add_route(
+        "/registry/python.toml",
+        "text/plain; charset=utf-8",
+        PYTHON_TOML_DRIFTED,
+    );
+
+    let out = ctx(root, &drifted.url(), &["lsp", "update", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    let output = stdout(&out);
+    assert!(output.contains("updated [lsp.python]"), "stdout: {output}");
+    assert!(output.contains("args"), "stdout: {output}");
+    assert!(config_text(root).contains("--verbose"));
+
+    // Re-running against the same registry is a no-op.
+    let out = ctx(root, &drifted.url(), &["lsp", "update", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(
+        stdout(&out).contains("up to date"),
+        "stdout: {}",
+        stdout(&out)
+    );
+
+    // JSON variant reports the same status.
+    let out = ctx(root, &drifted.url(), &["--json", "lsp", "update", "--yes"]);
+    assert_eq!(out.status.code(), Some(0));
+    let value = parse_envelope(&out, "lsp.update");
+    assert_eq!(value["data"]["languages"][0]["language"], "python");
+    assert_eq!(value["data"]["languages"][0]["status"], "up_to_date");
+}
+
+#[test]
+fn update_user_owned_language_exits_2() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    write(root, ".ctx/config.toml", "[lsp.go]\ncommand = \"gopls\"\n");
+
+    let out = ctx(root, &server.url(), &["lsp", "update", "go", "--yes"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    assert!(
+        stderr(&out).contains("user-owned"),
+        "stderr: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn update_with_nothing_registry_managed_is_a_clean_noop() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let out = ctx(root, &server.url(), &["lsp", "update", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(
+        stdout(&out).contains("nothing to update"),
+        "stdout: {}",
+        stdout(&out)
+    );
+    // No registry traffic without registry-managed entries.
+    assert_eq!(server.hits(), 0);
+}
+
+// ============================================================================
+// doctor
+// ============================================================================
+
+#[test]
+fn doctor_with_no_config_is_clean() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let out = ctx(root, "http://127.0.0.1:9", &["lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    assert!(
+        stdout(&out).contains("no LSP servers configured"),
+        "stdout: {}",
+        stdout(&out)
+    );
+}
+
+#[test]
+fn doctor_missing_binary_fails_with_exit_1() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    write(
+        root,
+        ".ctx/config.toml",
+        r#"
+[lsp.python]
+command = "definitely-not-on-path-xyz"
+capabilities = ["documentSymbol"]
+"#,
+    );
+
+    let out = ctx(root, "http://127.0.0.1:9", &["lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(1), "stderr: {}", stderr(&out));
+    let output = stdout(&out);
+    assert!(output.contains("FAIL"), "stdout: {output}");
+    assert!(output.contains("not found on PATH"), "stdout: {output}");
+
+    // JSON variant reports the failure.
+    let out = ctx(root, "http://127.0.0.1:9", &["--json", "lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(1));
+    let value = parse_envelope(&out, "lsp.doctor");
+    assert_eq!(value["data"]["healthy"], false);
+    assert_eq!(value["data"]["servers"][0]["status"], "fail");
+    assert_eq!(value["data"]["servers"][0]["binary_found"], false);
+}
+
+#[test]
+fn doctor_with_mock_server_passes() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = tempfile::tempdir().unwrap();
+    let scenario_path = scratch.path().join("scenario.json");
+    fs::write(
+        &scenario_path,
+        serde_json::json!({ "server_name": "ctx-mock-doctor" }).to_string(),
+    )
+    .unwrap();
+
+    // The ctx binary doubles as a scripted language server when
+    // CTX_INTERNAL_MOCK_LSP is set (same trick as tests/lsp_cli.rs). TOML
+    // literal strings keep Windows backslashes intact.
+    let config = format!(
+        r#"
+[lsp.kotlin]
+command = '{command}'
+extensions = ["kt"]
+backend = "lsp"
+capabilities = ["documentSymbol", "definition"]
+env = {{ CTX_INTERNAL_MOCK_LSP = '{scenario}' }}
+"#,
+        command = env!("CARGO_BIN_EXE_ctx"),
+        scenario = scenario_path.display(),
+    );
+    write(root, ".ctx/config.toml", &config);
+
+    let out = ctx(root, "http://127.0.0.1:9", &["lsp", "doctor"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        stdout(&out),
+        stderr(&out)
+    );
+    let output = stdout(&out);
+    assert!(output.contains("PASS"), "stdout: {output}");
+    assert!(output.contains("ctx-mock-doctor"), "stdout: {output}");
+
+    let out = ctx(root, "http://127.0.0.1:9", &["--json", "lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(0));
+    let value = parse_envelope(&out, "lsp.doctor");
+    assert_eq!(value["data"]["healthy"], true);
+    assert_eq!(value["data"]["servers"][0]["status"], "pass");
+    assert_eq!(value["data"]["servers"][0]["handshake_ok"], true);
+}

--- a/tests/lsp_registry.rs
+++ b/tests/lsp_registry.rs
@@ -174,6 +174,74 @@ fn add_refuses_manually_configured_language() {
 }
 
 #[test]
+fn add_refuses_type_broken_hand_written_entry() {
+    let server = registry_server();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    // Valid TOML, invalid type: the serde loader falls back to empty
+    // defaults, but the raw-document ownership check must still see the
+    // hand-written entry and refuse to touch it.
+    let broken = "[lsp.python]\ncommand = 3\n";
+    write(root, ".ctx/config.toml", broken);
+
+    let out = ctx(root, &server.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    let err = stderr(&out);
+    assert!(err.contains("not registry-managed"), "stderr: {err}");
+    assert!(err.contains("fix or remove"), "stderr: {err}");
+    // The type-broken entry is byte-identical.
+    assert_eq!(config_text(root), broken);
+    // Refused before any network call.
+    assert_eq!(server.hits(), 0);
+}
+
+#[test]
+fn add_over_drifted_registry_entry_suggests_removal() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let original = registry_server();
+    let out = ctx(root, &original.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    let before = config_text(root);
+
+    // Same server, drifted registry content: re-running add must not offer
+    // the dead-end 'ctx lsp update' hint (update keys off source_server),
+    // but point at removing the entry and re-adding with --server.
+    let drifted = MockServer::start();
+    drifted.add_route("/index.toml", "text/plain; charset=utf-8", INDEX_TOML);
+    drifted.add_route(
+        "/registry/python.toml",
+        "text/plain; charset=utf-8",
+        PYTHON_TOML_DRIFTED,
+    );
+    let out = ctx(root, &drifted.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    let err = stderr(&out);
+    assert!(err.contains("remove the entry"), "stderr: {err}");
+    assert!(err.contains("--server pyright"), "stderr: {err}");
+    assert!(!err.contains("ctx lsp update"), "stderr: {err}");
+    assert_eq!(config_text(root), before);
+}
+
+#[test]
+fn add_unknown_language_with_empty_registry_prints_none() {
+    let server = MockServer::start();
+    server.add_route(
+        "/index.toml",
+        "text/plain; charset=utf-8",
+        "schema_version = 1\n",
+    );
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let out = ctx(root, &server.url(), &["lsp", "add", "cobol", "--yes"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    let err = stderr(&out);
+    assert!(err.contains("available languages: (none)"), "stderr: {err}");
+}
+
+#[test]
 fn add_without_yes_and_no_tty_exits_2() {
     let server = registry_server();
     let temp = tempfile::tempdir().unwrap();
@@ -360,6 +428,73 @@ fn update_applies_registry_drift_then_reports_up_to_date() {
 }
 
 #[test]
+fn update_preserves_user_keys_on_registry_entry() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let original = registry_server();
+    let out = ctx(root, &original.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+
+    // The user tunes the registry-managed entry with legal config keys.
+    let mut text = config_text(root);
+    text.push_str("timeout_ms = 15000\nenv = { JAVA_HOME = \"/opt/java\" }\n");
+    fs::write(root.join(".ctx/config.toml"), &text).unwrap();
+
+    let drifted = MockServer::start();
+    drifted.add_route(
+        "/registry/python.toml",
+        "text/plain; charset=utf-8",
+        PYTHON_TOML_DRIFTED,
+    );
+    let out = ctx(root, &drifted.url(), &["lsp", "update", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+    let output = stdout(&out);
+    assert!(output.contains("updated [lsp.python]"), "stdout: {output}");
+    assert!(
+        output.contains("preserving user keys: timeout_ms, env"),
+        "stdout: {output}"
+    );
+    assert!(output.contains("updated 1, skipped 0"), "stdout: {output}");
+
+    let text = config_text(root);
+    // Canonical drift applied...
+    assert!(text.contains("--verbose"), "config: {text}");
+    // ...user customizations preserved byte-for-byte.
+    assert!(text.contains("timeout_ms = 15000\n"), "config: {text}");
+    assert!(
+        text.contains("env = { JAVA_HOME = \"/opt/java\" }\n"),
+        "config: {text}"
+    );
+    assert!(text.contains("source = \"registry\""), "config: {text}");
+}
+
+#[test]
+fn update_json_without_yes_with_pending_changes_exits_2_with_empty_stdout() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    let original = registry_server();
+    let out = ctx(root, &original.url(), &["lsp", "add", "python", "--yes"]);
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+
+    let drifted = MockServer::start();
+    drifted.add_route(
+        "/registry/python.toml",
+        "text/plain; charset=utf-8",
+        PYTHON_TOML_DRIFTED,
+    );
+    // --json never prompts: pending changes without --yes refuse with exit 2
+    // and print nothing to stdout (no partial JSON envelope).
+    let out = ctx(root, &drifted.url(), &["--json", "lsp", "update"]);
+    assert_eq!(out.status.code(), Some(2), "stdout: {}", stdout(&out));
+    assert!(stdout(&out).is_empty(), "stdout: {}", stdout(&out));
+    assert!(stderr(&out).contains("--yes"), "stderr: {}", stderr(&out));
+    // Nothing was written.
+    assert!(!config_text(root).contains("--verbose"));
+}
+
+#[test]
 fn update_user_owned_language_exits_2() {
     let server = registry_server();
     let temp = tempfile::tempdir().unwrap();
@@ -437,6 +572,152 @@ capabilities = ["documentSymbol"]
     assert_eq!(value["data"]["healthy"], false);
     assert_eq!(value["data"]["servers"][0]["status"], "fail");
     assert_eq!(value["data"]["servers"][0]["binary_found"], false);
+}
+
+#[test]
+fn doctor_malformed_config_fails_with_exit_1() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    // Valid TOML, invalid type: the fault-tolerant loader would silently
+    // fall back to "nothing configured"; doctor must fail instead.
+    write(root, ".ctx/config.toml", "[lsp.python]\ncommand = 3\n");
+
+    let out = ctx(root, "http://127.0.0.1:9", &["lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(1), "stdout: {}", stdout(&out));
+    let output = stdout(&out);
+    assert!(output.contains("FAIL"), "stdout: {output}");
+    assert!(output.contains("cannot be loaded"), "stdout: {output}");
+
+    let out = ctx(root, "http://127.0.0.1:9", &["--json", "lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(1));
+    let value = parse_envelope(&out, "lsp.doctor");
+    assert_eq!(value["data"]["healthy"], false);
+    assert_eq!(value["data"]["summary"]["fail"], 1);
+    assert_eq!(value["data"]["servers"][0]["status"], "fail");
+    assert!(
+        value["data"]["servers"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("cannot be loaded"),
+        "envelope: {value}"
+    );
+
+    // Whole-file TOML syntax errors fail the same way.
+    write(root, ".ctx/config.toml", "this is not : valid toml : :");
+    let out = ctx(root, "http://127.0.0.1:9", &["lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(1), "stdout: {}", stdout(&out));
+    assert!(stdout(&out).contains("FAIL"), "stdout: {}", stdout(&out));
+}
+
+#[test]
+fn doctor_invalid_blocks_fail_with_exit_1() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    // Both blocks parse but are dropped by validation: empty command, and a
+    // non-builtin language without extensions.
+    write(
+        root,
+        ".ctx/config.toml",
+        r#"
+[lsp.python]
+command = ""
+
+[lsp.mystery]
+command = "mystery-ls"
+"#,
+    );
+
+    let out = ctx(root, "http://127.0.0.1:9", &["lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(1), "stdout: {}", stdout(&out));
+    let output = stdout(&out);
+    assert!(
+        output.contains("FAIL python: invalid [lsp.python] block"),
+        "stdout: {output}"
+    );
+    assert!(output.contains("`command` is empty"), "stdout: {output}");
+    assert!(
+        output.contains("FAIL mystery: invalid [lsp.mystery] block"),
+        "stdout: {output}"
+    );
+    assert!(output.contains("`extensions`"), "stdout: {output}");
+    assert!(
+        output.contains("2 servers: 0 pass, 0 warn, 2 fail"),
+        "stdout: {output}"
+    );
+
+    let out = ctx(root, "http://127.0.0.1:9", &["--json", "lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(1));
+    let value = parse_envelope(&out, "lsp.doctor");
+    assert_eq!(value["data"]["healthy"], false);
+    assert_eq!(value["data"]["summary"]["fail"], 2);
+    let servers = value["data"]["servers"].as_array().unwrap();
+    assert_eq!(servers.len(), 2);
+    for server in servers {
+        assert_eq!(server["status"], "fail", "envelope: {value}");
+        assert!(
+            server["error"].as_str().unwrap().contains("invalid [lsp."),
+            "envelope: {value}"
+        );
+    }
+}
+
+#[test]
+fn doctor_warns_when_capability_missing() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let scratch = tempfile::tempdir().unwrap();
+    let scenario_path = scratch.path().join("scenario.json");
+    // The mock server advertises documentSymbol only; the config also
+    // requests definition -> WARN bucket, exit 0.
+    fs::write(
+        &scenario_path,
+        serde_json::json!({
+            "server_name": "ctx-mock-warn",
+            "capabilities": { "documentSymbolProvider": true },
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let config = format!(
+        r#"
+[lsp.kotlin]
+command = '{command}'
+extensions = ["kt"]
+backend = "lsp"
+capabilities = ["documentSymbol", "definition"]
+env = {{ CTX_INTERNAL_MOCK_LSP = '{scenario}' }}
+"#,
+        command = env!("CARGO_BIN_EXE_ctx"),
+        scenario = scenario_path.display(),
+    );
+    write(root, ".ctx/config.toml", &config);
+
+    let out = ctx(root, "http://127.0.0.1:9", &["lsp", "doctor"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        stdout(&out),
+        stderr(&out)
+    );
+    let output = stdout(&out);
+    assert!(output.contains("WARN"), "stdout: {output}");
+    assert!(output.contains("definition"), "stdout: {output}");
+    assert!(
+        output.contains("1 server: 0 pass, 1 warn, 0 fail"),
+        "stdout: {output}"
+    );
+
+    let out = ctx(root, "http://127.0.0.1:9", &["--json", "lsp", "doctor"]);
+    assert_eq!(out.status.code(), Some(0));
+    let value = parse_envelope(&out, "lsp.doctor");
+    assert_eq!(value["data"]["healthy"], true);
+    assert_eq!(value["data"]["servers"][0]["status"], "warn");
+    assert_eq!(
+        value["data"]["servers"][0]["missing_capabilities"][0],
+        "definition"
+    );
 }
 
 #[test]

--- a/tests/lsp_registry_client.rs
+++ b/tests/lsp_registry_client.rs
@@ -2,10 +2,11 @@
 //! fetch manifests from a local mock HTTP server, map the chosen server to a
 //! config entry, and upsert it into a temp `.ctx/config.toml`.
 //!
-//! No CLI surface exists yet (it lands in a later PR), so these tests
-//! exercise the library functions directly, passing the mock server's URL as
-//! the explicit base. The `CTX_LSP_REGISTRY_BASE_URL` env override itself is
-//! covered by a unit test on the pure resolution helper in `lsp_registry`.
+//! These tests exercise the library functions directly, passing the mock
+//! server's URL as the explicit base; the `ctx lsp` CLI surface on top of
+//! them is covered end to end in `tests/lsp_registry.rs`. The
+//! `CTX_LSP_REGISTRY_BASE_URL` env override itself is covered by a unit test
+//! on the pure resolution helper in `lsp_registry`.
 
 use std::fs;
 


### PR DESCRIPTION
## Summary

Adds the user-facing `ctx lsp` command group (AGE-10, workstream 2), wiring the community registry ([ctx-lsp-registry](https://github.com/agentis-tools/ctx-lsp-registry)) to `.ctx/config.toml`:

- `ctx lsp add <language> [--server NAME] [-y]` — fetches the curated entry, shows the exact server command, install hint (per-OS), and homepage, and asks for confirmation before writing anything. Entries carry `source = "registry"` provenance; hand-written entries are refused (pointer to `ctx lsp update`). Missing binary still writes config with a prominent install hint + `ctx lsp doctor` pointer. Never executes anything at add time.
- `ctx lsp list [--available]` — configured servers, or the registry catalogue with configured ones marked.
- `ctx lsp update [language] [-y]` — refreshes only registry-owned entries, showing a per-key diff as the consent step; user-owned tables are never touched.
- `ctx lsp doctor` — PATH check, spawn + initialize handshake probe, requested-vs-advertised capability diff; PASS/WARN/FAIL lines; exit 1 on FAIL.
- Global `--json` supported on all four (`lsp.add` etc. envelopes); JSON mode never prompts.
- Exit codes: 0 success, 1 doctor findings, 2 operational (network, unknown language, refusal, non-TTY without `--yes`).

CLI contract snapshot regenerated (`governance/contracts/cli.json`, purely additive).

**Stacked PR**: base is `johan/age-10-lsp-backend` (#75) and the branch also merges `johan/age-10-lsp-registry-client` (#74). Merge #75 and #74 first, then retarget this to `main` — the diff shown here includes #74's commits until then.

Part of [AGE-10](https://linear.app/itkonsult/issue/AGE-10).

## Testing

- 13 new end-to-end tests (`tests/lsp_registry.rs`): add happy path/idempotent/hand-written-refusal/unknown-language/non-TTY, list both modes + JSON, update drift/up-to-date/user-owned, doctor FAIL on missing binary and PASS against the scripted mock LSP server.
- `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --locked` under `--all-features` and `--no-default-features`, governance + versioning checks, contract `capture`+`check` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)