### PR TITLE
docs: pluggable LSP support and the ctx lsp command group (AGE-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server failures never fail an indexing run.
 
 ### Documentation
+- Documented the pluggable LSP support: a `ctx lsp` command reference
+  (`docs/commands/lsp.md`), an "Add a Language via LSP" guide covering manual
+  `[lsp.<language>]` authoring, backend modes, fallback behavior, and
+  troubleshooting (`docs/lsp-languages.md`), the full `[lsp.<language>]` key
+  reference in `docs/configuration.md`, and the LSP path in
+  `docs/language-support.md` — all mirrored to the documentation site.
 - Updated verified cookbook guidance for snapshot backfill coverage, semantic context completeness,
   harness regeneration after binary upgrades, and unresolved map focus behavior (#64).
 - Added symptom-first cookbook routing, per-recipe quick paths, canonical cross-cutting concepts,

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Welcome to the ctx documentation. **ctx** is a fast CLI tool that generates AI-r
 * [Code Intelligence](code-intelligence.md) - Indexing, searching, and analyzing
 * [Configuration](configuration.md) - Ignore files and settings
 * [Language Support](language-support.md) - Supported languages and their features
+* [Add a Language via LSP](lsp-languages.md) - Index any language through its language server
 * [Architecture](architecture.md) - How ctx works under the hood
 * [Packaging and Distribution](packaging.md) - Release assets and package-manager maintenance
 * [Privacy Policy](privacy.md) - How ctx and its plugins handle information

--- a/docs/commands/lsp.md
+++ b/docs/commands/lsp.md
@@ -1,0 +1,243 @@
+# ctx lsp
+
+Manage LSP-backed language support from the community registry.
+
+## Synopsis
+
+```bash
+ctx lsp add <LANGUAGE> [--server <NAME>] [--yes] [--json]
+ctx lsp list [--available] [--json]
+ctx lsp update [LANGUAGE] [--yes] [--json]
+ctx lsp doctor [--json]
+```
+
+## Description
+
+The `lsp` command manages `[lsp.<language>]` blocks in `.ctx/config.toml` — the declarative registrations that let `ctx index` extract symbols through any stdio language server (see [Add a language via LSP](../lsp-languages.md)). `add` installs a curated entry from the community LSP registry, `list` shows what is configured (or available), `update` refreshes registry-installed entries, and `doctor` health-checks every configured server.
+
+The registry lives in a separate repository, [`agentis-tools/ctx-lsp-registry`](https://github.com/agentis-tools/ctx-lsp-registry). ctx fetches its raw TOML manifests over HTTPS from the pinned `v1` branch (10-second timeout per fetch). Entries whose `schema_version` is newer than the running binary understands are rejected with a message telling you to upgrade ctx.
+
+## Trust model
+
+`ctx lsp add` **never executes anything**. It writes a TOML block to `.ctx/config.toml` — nothing else:
+
+- The command, arguments, install hint, and homepage from the registry are **shown to you first**, and nothing is written until you confirm (`--yes` skips the prompt).
+- The install hint (e.g. `npm install -g pyright`) is printed for you to run yourself; ctx never installs a server.
+- The server binary itself is only ever executed later, by `ctx index` (when a matching file is indexed) or by `ctx lsp doctor` (as an explicit health probe).
+- Hand-written `[lsp.<language>]` entries are never touched: `add` refuses to overwrite them and `update` refuses to refresh them. Only entries carrying the `source = "registry"` provenance key are managed by these commands.
+- Config writes are format-preserving and atomic: comments, formatting, and unrelated tables in `.ctx/config.toml` survive byte-for-byte.
+
+The registry base URL can be overridden with the `CTX_LSP_REGISTRY_BASE_URL` environment variable (for mirrors or testing). It is deliberately an environment variable and not a config key: where manifests come from is a distribution concern, not a per-project setting.
+
+## `add <LANGUAGE>`
+
+Fetches the registry entry for `LANGUAGE`, shows the curated server, and writes `[lsp.<LANGUAGE>]` to `.ctx/config.toml` after confirmation:
+
+```text
+$ ctx lsp add python
+Registry entry for python (https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1/registry/python.toml):
+  server:   pyright (recommended)
+  command:  pyright-langserver --stdio
+  install:  npm install -g pyright
+  homepage: https://github.com/microsoft/pyright
+
+This writes [lsp.python] to .ctx/config.toml (backend "hybrid").
+Proceed? [y/N] y
+wrote [lsp.python] to .ctx/config.toml (server pyright, backend hybrid)
+run 'ctx index' to reindex with the new language server
+```
+
+- `--server <NAME>` picks a specific server from the entry instead of the registry's recommended one.
+- `--yes` / `-y` skips the confirmation prompt. It is **required** in non-interactive use: when stdin is not a TTY, or with `--json` (JSON mode never prompts), the command refuses with exit code 2 instead of hanging.
+- The written entry always uses `backend = "hybrid"` plus `source = "registry"` / `source_server = "<name>"` provenance keys so `ctx lsp update` can manage it later.
+- If the server binary is not on `PATH` yet, the entry is still written and a stderr warning repeats the install hint and points at `ctx lsp doctor`.
+
+Outcomes for an existing `[lsp.<LANGUAGE>]` entry:
+
+| Existing entry | Result |
+|----------------|--------|
+| None | Written after confirmation |
+| Registry-managed, identical | "already configured", exit 0, nothing written |
+| Registry-managed, differs | Error pointing at `ctx lsp update <LANGUAGE>` (exit 2) |
+| Hand-written (no `source = "registry"`) | Refused before any network call (exit 2) |
+
+An unknown language is an error (exit 2) that lists every language the registry does offer.
+
+## `list`
+
+Shows the configured servers from `.ctx/config.toml`:
+
+```text
+$ ctx lsp list
+kotlin: `kotlin-language-server` (backend lsp, source manual)
+python: `pyright-langserver --stdio` (backend hybrid, source registry (pyright))
+```
+
+`source` is `registry (<server>)` for entries installed by `ctx lsp add`, `manual` for hand-written ones. With nothing configured it suggests `ctx lsp list --available`.
+
+`--available` fetches the registry index instead and lists every language it covers, with the recommended server and a `[configured]` marker for languages already present in your config:
+
+```text
+$ ctx lsp list --available
+Available languages in the LSP registry (https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1):
+  kotlin  (recommended server: kotlin-language-server)
+  python  (recommended server: pyright)  [configured]
+
+install one with 'ctx lsp add <language>'
+```
+
+## `update [LANGUAGE]`
+
+Re-fetches each registry-managed entry (marked `source = "registry"`), diffs it key by key against your config, and rewrites it after confirmation:
+
+```text
+$ ctx lsp update
+python: registry entry for server pyright changed:
+  args: ["--stdio", "--verbose"] -> ["--stdio"]
+Update [lsp.python]? [y/N] y
+updated [lsp.python] in .ctx/config.toml
+```
+
+- Without `LANGUAGE`, every registry-managed entry is checked; entries already matching the registry report `up to date`.
+- With `LANGUAGE`, only that entry is refreshed. Naming a hand-written entry is an error (exit 2) — `update` only manages registry-installed entries. Naming a language with no entry at all suggests `ctx lsp add <LANGUAGE>` (exit 2).
+- The server named by the entry's `source_server` provenance key is re-fetched; when that key is missing or empty the registry's recommended server is used.
+- `--yes` / `-y` applies all changes without prompting (required with `--json` or non-TTY stdin).
+- Nothing registry-managed in the config is a clean no-op (exit 0).
+
+## `doctor`
+
+Probes every valid `[lsp.<language>]` entry — including hand-written ones — end to end:
+
+1. **Binary lookup** — the `command` resolves to an executable (explicit path, or `PATH` search).
+2. **Handshake** — the server is spawned and must complete the LSP `initialize` handshake.
+3. **Capability diff** — every capability listed in the entry's `capabilities` array must be advertised by the server. Short names map to their provider keys (`documentSymbol` → `documentSymbolProvider`); names already ending in `Provider`, and `textDocumentSync`, are matched as-is.
+
+```text
+$ ctx lsp doctor
+PASS python: `pyright-langserver` handshake ok (pyright 1.1.400), capabilities ok
+FAIL kotlin: `kotlin-language-server` not found on PATH
+     hint: install the server (see 'ctx lsp list --available'), then re-run 'ctx lsp doctor'
+
+2 servers: 1 pass, 0 warn, 1 fail
+```
+
+Per server the status is `fail` (binary missing or handshake failed), `warn` (handshake ok but requested capabilities not advertised — extraction may be degraded), or `pass`. The exit code is 1 when at least one server **fails**; warnings alone still exit 0. Failed handshakes include the server's recent stderr lines. With nothing configured, `doctor` is a clean no-op.
+
+`doctor` probes servers on demand; the related sidecar `.ctx/lsp_status.json` records what actually happened during the last `ctx index` run (see [Add a language via LSP — Troubleshooting](../lsp-languages.md#troubleshooting)).
+
+## JSON output
+
+All four subcommands support the global `--json` flag and emit the standard envelope (see [JSON output](../json-output.md)). `add` and `update` additionally require `--yes` in JSON mode, because JSON mode never prompts.
+
+```bash
+ctx lsp add python --yes --json
+```
+
+```json
+{
+  "ctx_version": "0.3.5",
+  "command": "lsp.add",
+  "generated_at": "2026-07-15T12:00:00Z",
+  "data": {
+    "language": "python",
+    "server": "pyright",
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "backend": "hybrid",
+    "source": "registry",
+    "registry_url": "https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1/registry/python.toml",
+    "install_hint": "npm install -g pyright",
+    "homepage": "https://github.com/microsoft/pyright",
+    "binary_found": false,
+    "status": "added"
+  }
+}
+```
+
+When the entry already matches the registry, `data` is just `{"language", "server", "status": "already_configured"}`.
+
+```bash
+ctx lsp doctor --json
+```
+
+```json
+{
+  "ctx_version": "0.3.5",
+  "command": "lsp.doctor",
+  "generated_at": "2026-07-15T12:00:00Z",
+  "data": {
+    "healthy": false,
+    "summary": { "pass": 1, "warn": 0, "fail": 1 },
+    "servers": [
+      {
+        "language": "kotlin",
+        "command": "kotlin-language-server",
+        "backend": "hybrid",
+        "binary_found": false,
+        "root_markers_found": [],
+        "handshake_ok": false,
+        "negotiated_capabilities": [],
+        "missing_capabilities": ["documentSymbol"],
+        "stderr": [],
+        "error": "`kotlin-language-server` not found on PATH",
+        "status": "fail"
+      }
+    ]
+  }
+}
+```
+
+`lsp.list` reports `{"available": false, "servers": [...]}` (configured entries) or `{"available": true, "registry": "<base url>", "languages": [...]}` (with `--available`). `lsp.update` reports `{"registry": "<base url>", "languages": [{"language", "server", "status": "up_to_date" | "updated", "changes": {"<key>": {"from", "to"}}}]}`.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — including "already configured" (`add`), "up to date" (`update`), and warnings-only `doctor` runs |
+| 1 | `doctor` found at least one failing server (missing binary or failed handshake) |
+| 2 | Operational error (network failure, unknown language, refused overwrite, aborted confirmation, prompt needed but stdin is not a TTY or `--json` was given without `--yes`) |
+
+## Examples
+
+### Install and verify a language server
+
+```bash
+ctx lsp list --available          # what does the registry offer?
+ctx lsp add python                # review the entry, confirm, write config
+npm install -g pyright            # run the printed install hint yourself
+ctx lsp doctor                    # binary found? handshake ok? capabilities?
+ctx index                         # reindex through the new server
+```
+
+### Pick a non-default server
+
+```bash
+ctx lsp add python --server pylsp
+```
+
+### Keep registry entries fresh
+
+```bash
+ctx lsp update            # diff + confirm every registry-managed entry
+ctx lsp update python -y  # refresh one entry without prompting
+```
+
+### Non-interactive / CI use
+
+```bash
+ctx lsp add python --yes --json
+ctx lsp doctor --json     # exit 1 signals an unhealthy server
+```
+
+### Use a registry mirror
+
+```bash
+CTX_LSP_REGISTRY_BASE_URL=https://mirror.example.com/ctx-lsp-registry ctx lsp add python
+```
+
+## See Also
+
+- [Add a language via LSP](../lsp-languages.md) — the `[lsp.<language>]` config reference, backend modes, and troubleshooting
+- [Language Support](../language-support.md) — built-in tree-sitter languages
+- [Configuration](../configuration.md) — `.ctx/config.toml`
+- [ctx-lsp-registry](https://github.com/agentis-tools/ctx-lsp-registry) — contribute new language entries via that repository's `CONTRIBUTING.md`

--- a/docs/commands/lsp.md
+++ b/docs/commands/lsp.md
@@ -29,6 +29,12 @@ The registry lives in a separate repository, [`agentis-tools/ctx-lsp-registry`](
 
 The registry base URL can be overridden with the `CTX_LSP_REGISTRY_BASE_URL` environment variable (for mirrors or testing). It is deliberately an environment variable and not a config key: where manifests come from is a distribution concern, not a per-project setting.
 
+### Treat `.ctx/config.toml` as executable content
+
+The flip side of declarative registration: `ctx index` **spawns whatever `[lsp.<language>]` blocks the current repository's `.ctx/config.toml` declares** — the configured `command` with its `args` and `env`, run with the repository as working directory — as soon as a matching file is indexed. The `add` confirmation prompt protects entries *you* write; it does not apply to a config that arrives already committed in a checkout.
+
+Before running `ctx index` on a repository you don't trust, review its `.ctx/config.toml` like you would review a build script or git hook. Check the `command` **and** the `env` table — environment variables such as `LD_PRELOAD` or `DYLD_INSERT_LIBRARIES` can make even a familiar-looking binary load repository-local code.
+
 ## `add <LANGUAGE>`
 
 Fetches the registry entry for `LANGUAGE`, shows the curated server, and writes `[lsp.<LANGUAGE>]` to `.ctx/config.toml` after confirmation:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -465,11 +465,13 @@ ctx uses minimal environment variables:
 | `OLLAMA_HOST` | Ollama server URL (default `http://localhost:11434`) | Only for the Ollama provider |
 | `OLLAMA_EMBED_MODEL` | Ollama embedding model (default `nomic-embed-text`) | Only for the Ollama provider |
 | `OLLAMA_API_KEY` | Optional bearer token for a remote/authenticated Ollama host | No |
+| `CTX_LSP_REGISTRY_BASE_URL` | Alternate base URL for the `ctx lsp` community registry (mirrors/testing) | No |
 
 ### Project config (`.ctx/config.toml`)
 
-Per-project defaults live in an optional, committed `.ctx/config.toml`. It currently configures
-the embedding backend used by `ctx embed`, `semantic`, `smart`, and `similar`:
+Per-project defaults live in an optional, committed `.ctx/config.toml`. It configures the
+embedding backend used by `ctx embed`, `semantic`, `smart`, and `similar`, and registers
+language servers for LSP-backed indexing:
 
 ```toml
 [embedding]
@@ -485,6 +487,54 @@ embeddings because vectors from different models are not interchangeable:
 ```bash
 ctx embed --force
 ```
+
+### Language servers (`[lsp.<language>]`)
+
+Each `[lsp.<language>]` table registers a stdio language server that `ctx index` uses to
+extract (or refine) code intelligence for the files it claims. The table key is the language
+name stored on indexed files and symbols:
+
+```toml
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]          # required: kotlin is not a built-in language
+backend = "lsp"                     # tree-sitter | lsp | hybrid (default hybrid)
+
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+# extensions default to the built-in set ("py", "pyi") for built-in language names
+```
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `command` | string | — (required) | Server executable; resolved via `PATH` unless it contains a path separator |
+| `args` | array of strings | `[]` | Arguments passed to the server |
+| `extensions` | array of strings | built-in set for built-in language names | File extensions (without dots) this server claims; required for non-built-in language names |
+| `root_markers` | array of strings | `[]` | Workspace-root marker files; informational, reported by `ctx lsp doctor` |
+| `capabilities` | array of strings | `[]` | Capabilities the server is expected to advertise; checked by `ctx lsp doctor` |
+| `backend` | string | `"hybrid"` | `"tree-sitter"`, `"lsp"`, or `"hybrid"` — see [Add a language via LSP](lsp-languages.md#backend-modes) |
+| `initialization_options` | any value | unset | Passed verbatim as LSP `initializationOptions` |
+| `env` | table of strings | `{}` | Extra environment variables for the server process |
+| `timeout_ms` | integer | `10000` | Per-request timeout in milliseconds |
+| `source` | string | unset | Provenance written by `ctx lsp add` (`"registry"` marks the entry as registry-managed); accepted and ignored by the indexer |
+| `source_server` | string | unset | Provenance written by `ctx lsp add`: the registry server name the entry was installed from |
+
+Entries installed with [`ctx lsp add`](commands/lsp.md) carry the `source` / `source_server`
+provenance keys so `ctx lsp update` can refresh them later; entries without
+`source = "registry"` are treated as hand-written and never touched by those commands.
+
+`[lsp.*]` configuration is **never fatal** to indexing:
+
+- An invalid block (empty `command`, or missing `extensions` for a non-built-in language name)
+  is skipped with a stderr warning; the remaining blocks and the built-in grammars keep working.
+- Unknown keys are tolerated, so configs written by newer ctx versions still load.
+- When two blocks claim the same extension, the first block in table-key order wins and a
+  warning names both blocks.
+- A configured server that is missing or crashes degrades gracefully at index time: warning on
+  stderr, tree-sitter fallback for built-in languages, exit code unaffected.
+
+Without any `[lsp.*]` block the LSP subsystem is completely inert — no server is ever spawned.
 
 ### Architecture policy (`.ctx/rules.toml`)
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -617,6 +617,105 @@ One `files` entry per planned file. `action` is one of `created` (did not exist)
 
 `severity` is `error`, `warning`, or `info`; `hint` is omitted when there is none. `code` is a stable machine-readable identifier: `binary_version`, `harness_not_initialized`, `templates_stale`, `index_missing`, `index_schema`, `index_stale`, `rules_missing`, `rules_invalid`, `hooks_missing`, `hooks_modified`, `settings_not_wired`, `mcp_unavailable`, `mcp_not_wired`. Checks are independent (a missing index and an invalid rules file are both reported in one run). `healthy` is `true` when no check is an error or a warning; exit codes: 0 = healthy, 1 = problems, 2 = operational error.
 
+### `lsp.add`
+
+`ctx lsp add <LANGUAGE> [--server <NAME>] --yes --json`
+
+JSON mode never prompts, so `--yes` is required (exit 2 otherwise).
+
+```json
+{
+  "language": "python",
+  "server": "pyright",
+  "command": "pyright-langserver",
+  "args": ["--stdio"],
+  "backend": "hybrid",
+  "source": "registry",
+  "registry_url": "https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1/registry/python.toml",
+  "install_hint": "npm install -g pyright",
+  "homepage": "https://github.com/microsoft/pyright",
+  "binary_found": true,
+  "status": "added"
+}
+```
+
+`install_hint` and `homepage` are `null` when the registry entry does not provide them. `binary_found` reports whether the server command already resolves to an executable (a `false` is accompanied by a stderr install warning). When the entry is already configured and matches the registry, `data` is just `{"language", "server", "status": "already_configured"}`.
+
+### `lsp.list`
+
+`ctx lsp list [--available] --json`
+
+```json
+{
+  "available": false,
+  "servers": [
+    {
+      "language": "python",
+      "command": "pyright-langserver",
+      "args": ["--stdio"],
+      "backend": "hybrid",
+      "source": "registry",
+      "source_server": "pyright"
+    }
+  ]
+}
+```
+
+`source` is `"registry"` for entries installed by `ctx lsp add`, `"manual"` otherwise. With `--available` the payload is instead `{"available": true, "registry": "<base url>", "languages": [{"language", "recommended", "servers", "configured"}]}` — one row per registry language, with `configured` marking languages already present in `.ctx/config.toml`.
+
+### `lsp.update`
+
+`ctx lsp update [LANGUAGE] --yes --json`
+
+```json
+{
+  "registry": "https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1",
+  "languages": [
+    { "language": "go", "server": "gopls", "status": "up_to_date" },
+    {
+      "language": "python",
+      "server": "pyright",
+      "status": "updated",
+      "changes": {
+        "args": { "from": "[\"--stdio\", \"--verbose\"]", "to": "[\"--stdio\"]" }
+      }
+    }
+  ]
+}
+```
+
+`changes` is present only for `"status": "updated"`, keyed by config key with display-string `from`/`to` values. When nothing in the config is registry-managed the payload is `{"languages": []}`.
+
+### `lsp.doctor`
+
+`ctx lsp doctor --json`
+
+```json
+{
+  "healthy": true,
+  "summary": { "pass": 1, "warn": 0, "fail": 0 },
+  "servers": [
+    {
+      "language": "python",
+      "command": "pyright-langserver",
+      "backend": "hybrid",
+      "binary_found": true,
+      "binary_path": "/usr/local/bin/pyright-langserver",
+      "root_markers_found": ["pyproject.toml"],
+      "handshake_ok": true,
+      "server_name": "pyright",
+      "server_version": "1.1.400",
+      "negotiated_capabilities": ["documentSymbolProvider", "definitionProvider"],
+      "missing_capabilities": [],
+      "stderr": [],
+      "status": "pass"
+    }
+  ]
+}
+```
+
+`status` per server is `fail` (binary missing or handshake failed), `warn` (requested capabilities not advertised), or `pass`. `binary_path`, `server_name`, `server_version`, and `error` are omitted when unknown. `healthy` is `true` when no server fails; exit codes: 0 = no failures (warnings allowed), 1 = at least one failure, 2 = operational error.
+
 ### `self_update`
 
 `ctx self-update [--version X.Y.Z] --json`

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -1,6 +1,6 @@
 # Language Support
 
-ctx uses tree-sitter for parsing, providing accurate symbol extraction across multiple programming languages. This page details what's extracted from each language and how relationships are tracked.
+ctx uses tree-sitter for parsing, providing accurate symbol extraction across multiple programming languages. This page details what's extracted from each language and how relationships are tracked. Languages without a built-in grammar can be added declaratively through any stdio language server — see [Languages beyond the built-in set (LSP)](#languages-beyond-the-built-in-set-lsp).
 
 ## Supported Languages Overview
 
@@ -15,6 +15,34 @@ ctx uses tree-sitter for parsing, providing accurate symbol extraction across mu
 | Solidity | `.sol` | Full | Calls | Full |
 | YAML | `.yaml`, `.yml` | File tracking only | N/A | Partial |
 | Go | `.go` | Planned | Planned | Not yet |
+
+## Languages beyond the built-in set (LSP)
+
+Any language with a stdio language server can be indexed by registering the server under `[lsp.<language>]` in `.ctx/config.toml` — Kotlin, Scala, Ruby, Zig, and so on. ctx then extracts symbols via `textDocument/documentSymbol`, call edges via the call-hierarchy requests, and resolves cross-file references via `textDocument/definition`:
+
+```toml
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]
+backend = "lsp"
+```
+
+For languages covered by the community registry, `ctx lsp add <language>` writes this block for you after showing what it would install. Server failures never break indexing: a missing or crashed server produces a stderr warning and ctx falls back to tree-sitter (built-in languages) or file-only records (dynamic languages).
+
+See [Add a language via LSP](lsp-languages.md) for the full key reference, and [`ctx lsp`](commands/lsp.md) for the registry commands.
+
+### Hybrid mode for built-in languages
+
+The built-in languages above can also be paired with a language server using `backend = "hybrid"` (the default for configured blocks). Tree-sitter still does the extraction — fast and offline — and the server is consulted only afterwards, to resolve cross-file references that static name resolution left unresolved or ambiguous (see [Cross-File Resolution](#cross-file-resolution) below). This tightens the call graph without giving up tree-sitter's speed:
+
+```toml
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+# backend = "hybrid" is the default; extensions default to ["py", "pyi"]
+```
+
+Without any `[lsp.*]` block, nothing changes: no server is ever spawned and indexing behaves exactly as described on this page.
 
 ## Rust
 
@@ -400,6 +428,8 @@ Dependencies of 'myFunction':
   calls externalLib (line 15)         # Unresolved (external)
 ```
 
+Registering a language server with `backend = "hybrid"` narrows this limitation: after tree-sitter extraction, references that stayed unresolved are resolved via the server's `textDocument/definition` (see [Hybrid mode for built-in languages](#hybrid-mode-for-built-in-languages)).
+
 ### Dynamic Calls
 
 Dynamic or computed calls cannot be tracked:
@@ -468,7 +498,9 @@ callback(input);
 
 ## Adding Language Support
 
-To add support for a new language:
+The fastest way to add a language is to register its language server in `.ctx/config.toml` — no code involved; see [Add a language via LSP](lsp-languages.md).
+
+To add **built-in** tree-sitter support for a new language:
 
 1. Add the tree-sitter crate to `Cargo.toml`:
    ```toml
@@ -511,4 +543,4 @@ match extension {
 }
 ```
 
-Unknown extensions are skipped during indexing but included in context generation.
+Unknown extensions are skipped during indexing but included in context generation — unless an `[lsp.<language>]` block in `.ctx/config.toml` claims them, in which case they are indexed through the registered language server.

--- a/docs/lsp-languages.md
+++ b/docs/lsp-languages.md
@@ -1,0 +1,135 @@
+# Add a Language via LSP
+
+ctx ships tree-sitter grammars for a fixed set of languages ([Language Support](language-support.md)). For everything else — Kotlin, Scala, Ruby, Zig, anything with a stdio language server — you can register the server declaratively in `.ctx/config.toml` and `ctx index` extracts symbols, call edges, and cross-file references through it. No plugin, no rebuild.
+
+## Quick start
+
+For languages the community registry covers, one command sets everything up:
+
+```bash
+ctx lsp add python        # shows the curated entry, asks for confirmation
+ctx lsp doctor            # verify: binary found, handshake ok, capabilities ok
+ctx index                 # reindex through the server
+```
+
+`ctx lsp add` writes a `[lsp.<language>]` block to `.ctx/config.toml` and nothing more — it never installs or executes the server itself. If the server binary is missing it prints the install command for you to run. See [`ctx lsp`](commands/lsp.md) for the full command reference and trust model.
+
+## Manual registration
+
+For languages not in the registry, write the block yourself:
+
+```toml
+# .ctx/config.toml
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]        # required: kotlin has no built-in grammar
+backend = "lsp"
+
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+# extensions default to the built-in set ("py", "pyi") for built-in language names
+# backend defaults to "hybrid"
+```
+
+The table key (`kotlin`, `python`, …) is the language name stored on every indexed file and symbol; it flows through `ctx query`, `ctx sql`, and JSON output unchanged.
+
+### Key reference
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `command` | string | — (required) | Executable to spawn. Resolved via `PATH` unless it contains a path separator. |
+| `args` | array of strings | `[]` | Arguments passed to the server (e.g. `["--stdio"]`). |
+| `extensions` | array of strings | built-in set for built-in language names | File extensions (without the dot) this server claims. **Required** when the table key is not a built-in language name. Normalized to lowercase, leading dots stripped. |
+| `root_markers` | array of strings | `[]` | Marker files/dirs identifying a workspace root. Informational; `ctx lsp doctor` reports which ones exist under the project root. |
+| `capabilities` | array of strings | `[]` | Capabilities you expect the server to provide (e.g. `["documentSymbol", "definition"]`). `ctx lsp doctor` warns when the server does not advertise them. |
+| `backend` | `"tree-sitter"` \| `"lsp"` \| `"hybrid"` | `"hybrid"` | Extraction backend for files claimed by this block (see below). |
+| `initialization_options` | any TOML value | unset | Passed through verbatim as LSP `initializationOptions`. |
+| `env` | table of strings | `{}` | Extra environment variables for the server process. |
+| `timeout_ms` | integer | `10000` | Per-request timeout in milliseconds. |
+| `source`, `source_server` | string | unset | Provenance keys written by `ctx lsp add`; accepted and ignored by the indexer. Do not set them by hand — `source = "registry"` marks an entry as managed by `ctx lsp update`. |
+
+Built-in language names with default extension sets: `rust` (`rs`), `typescript` (`ts`), `tsx` (`tsx`), `javascript` (`js`, `mjs`, `cjs`), `jsx` (`jsx`), `python` (`py`, `pyi`), `go` (`go`), `solidity` (`sol`), `yaml` (`yaml`, `yml`).
+
+When two blocks claim the same extension, the first block (in table-key order) wins and a warning names both blocks.
+
+## Backend modes
+
+| `backend` | Symbols and edges from | Cross-file resolution | Use when |
+|-----------|------------------------|-----------------------|----------|
+| `tree-sitter` | Built-in grammar only | SQL name resolution only | You want to keep a registration around without using it. On a language with no built-in grammar this leaves the files unindexed. |
+| `lsp` | The language server (`textDocument/documentSymbol`, call hierarchy) | `textDocument/definition` | The language has no built-in grammar, or you want the server's semantic view (e.g. resolved call hierarchies) even for a built-in language. |
+| `hybrid` (default) | Built-in tree-sitter grammar | `textDocument/definition` for references tree-sitter left unresolved | The language has a built-in grammar. You keep tree-sitter's fast, offline extraction and add LSP precision only where static name resolution was ambiguous (e.g. the same function name defined in several files). |
+
+Two details worth knowing:
+
+- **`hybrid` on a dynamic language degrades to `lsp`.** With no built-in grammar there is nothing for tree-sitter to extract, so hybrid-configured blocks for non-built-in languages use full LSP extraction automatically. In practice: the default backend does the right thing for both kinds of language.
+- **Call edges via LSP need call hierarchy.** In `lsp` mode, `Calls` edges are collected through `callHierarchy/outgoingCalls` and are only gathered when the server advertises `callHierarchyProvider`. Symbols still come through without it.
+
+## Fallback and degradation
+
+LSP failures never fail an indexing run, and the exit code is unaffected:
+
+- **Server missing or crashing:** a warning is printed to stderr once per language per run, then ctx falls back — built-in languages are re-parsed with tree-sitter (full symbols), dynamic languages get a file record with zero symbols (so incremental indexing and deletion cleanup keep working).
+- **Invalid config blocks** (empty `command`, missing `extensions` for a non-built-in language) are skipped with a warning; the remaining blocks and built-in grammars keep working. Unknown keys are tolerated, so configs written by newer ctx versions still load.
+- **Slow servers:** each request gets `timeout_ms` (default 10 s); the first request after `initialize` gets a longer warmup grace period, because many servers index the workspace before answering. After 3 consecutive timeouts the server is declared failed for the rest of the run and the fallback above kicks in.
+
+## Performance
+
+- **Zero cost when unconfigured.** Without any `[lsp.*]` block, the subsystem is completely inert — nothing is spawned and indexing behaves exactly as before.
+- **Per-language opt-in.** Only files whose extension is claimed by a block go through a server; everything else stays on tree-sitter.
+- **Lazy spawn.** A server is started on the first file that needs it, not at startup. An incremental `ctx index` run that finds no changed files in that language never spawns the server at all.
+- **Warm reuse in watch mode.** `ctx index --watch` keeps servers running across file events; a one-shot `ctx index` shuts them down at the end of the run.
+- **First-request warmup.** Expect the first indexed file per server to be slower while the server warms up; subsequent files reuse the running process.
+
+`hybrid` is the cheaper mode for built-in languages: tree-sitter does the bulk extraction and the server is only consulted for edges that stayed unresolved.
+
+## Troubleshooting
+
+Start with the health probe:
+
+```bash
+ctx lsp doctor
+```
+
+It checks, per configured block: the binary resolves (explicit path or `PATH`), the server completes the `initialize` handshake, and every capability listed in `capabilities` was advertised — with the server's recent stderr attached to failed handshakes. Exit code 1 means at least one server failed. See [`ctx lsp doctor`](commands/lsp.md#doctor).
+
+Every `ctx index` run with LSP configured also writes a sidecar, `.ctx/lsp_status.json`, recording what actually happened:
+
+```json
+{
+  "generated_at": 1752580800,
+  "servers": [
+    {
+      "language": "kotlin",
+      "command": "kotlin-language-server",
+      "backend": "lsp",
+      "state": "healthy",
+      "server_name": "kotlin-language-server",
+      "server_version": "1.3.13",
+      "capabilities": ["documentSymbolProvider", "definitionProvider"]
+    }
+  ]
+}
+```
+
+`state` is `healthy`, `failed` (with a `reason`), or `idle` (configured, but no file needed the server this run). The sidecar lives in `.ctx/`, which is never indexed, so it never shows up in query results.
+
+Common cases:
+
+| Symptom | Explanation |
+|---------|-------------|
+| `Warning: LSP server '…' for … …; falling back to tree-sitter` during `ctx index` | The server failed to spawn, crashed, or timed out repeatedly. Indexing continued on the fallback path; run `ctx lsp doctor` for details. |
+| `Warning: ignoring [lsp.<lang>] …: 'extensions' is required for non-builtin languages` | The block's table key is not a built-in language name, so ctx cannot infer which files it claims. Add `extensions = [...]`. |
+| Doctor says `WARN … missing capabilities: …` | The server negotiated fewer capabilities than the config requests; extraction may be degraded (e.g. no call edges without `callHierarchy`). |
+| Dynamic-language files indexed but have no symbols | The server was unavailable, so only file records were stored. Fix the server (see doctor) and re-run `ctx index` after touching the files, or `ctx index --force`. |
+
+## Contributing a registry entry
+
+The curated entries behind `ctx lsp add` live in [`agentis-tools/ctx-lsp-registry`](https://github.com/agentis-tools/ctx-lsp-registry): one TOML file per language, each with one or more `[[servers]]` blocks (exactly one marked `recommended = true`) plus per-OS install hints. If you have a working manual `[lsp.<language>]` block for a language the registry does not cover yet, consider contributing it upstream — see that repository's `CONTRIBUTING.md`.
+
+## See Also
+
+- [`ctx lsp`](commands/lsp.md) — command reference (`add`, `list`, `update`, `doctor`)
+- [Language Support](language-support.md) — the built-in tree-sitter languages
+- [Configuration](configuration.md) — everything else in `.ctx/config.toml`

--- a/docs/lsp-languages.md
+++ b/docs/lsp-languages.md
@@ -124,6 +124,10 @@ Common cases:
 | Doctor says `WARN … missing capabilities: …` | The server negotiated fewer capabilities than the config requests; extraction may be degraded (e.g. no call edges without `callHierarchy`). |
 | Dynamic-language files indexed but have no symbols | The server was unavailable, so only file records were stored. Fix the server (see doctor) and re-run `ctx index` after touching the files, or `ctx index --force`. |
 
+## Security note
+
+`ctx index` spawns the servers the current repository's `.ctx/config.toml` declares — command, args, and `env` — with the repository as working directory. A checkout you didn't write can therefore name any executable. Before indexing an untrusted repository, review its `.ctx/config.toml` like a build script; see the [trust model](commands/lsp.md#trust-model) for details.
+
 ## Contributing a registry entry
 
 The curated entries behind `ctx lsp add` live in [`agentis-tools/ctx-lsp-registry`](https://github.com/agentis-tools/ctx-lsp-registry): one TOML file per language, each with one or more `[[servers]]` blocks (exactly one marked `recommended = true`) plus per-OS install hints. If you have a working manual `[lsp.<language>]` block for a language the registry does not cover yet, consider contributing it upstream — see that repository's `CONTRIBUTING.md`.

--- a/docs/website/docs/commands/lsp.md
+++ b/docs/website/docs/commands/lsp.md
@@ -1,0 +1,249 @@
+---
+id: lsp
+title: ctx lsp
+sidebar_position: 15
+---
+
+# ctx lsp
+
+Manage LSP-backed language support from the community registry.
+
+## Synopsis
+
+```bash
+ctx lsp add <LANGUAGE> [--server <NAME>] [--yes] [--json]
+ctx lsp list [--available] [--json]
+ctx lsp update [LANGUAGE] [--yes] [--json]
+ctx lsp doctor [--json]
+```
+
+## Description
+
+The `lsp` command manages `[lsp.<language>]` blocks in `.ctx/config.toml` — the declarative registrations that let `ctx index` extract symbols through any stdio language server (see [Add a language via LSP](../lsp-languages.md)). `add` installs a curated entry from the community LSP registry, `list` shows what is configured (or available), `update` refreshes registry-installed entries, and `doctor` health-checks every configured server.
+
+The registry lives in a separate repository, [`agentis-tools/ctx-lsp-registry`](https://github.com/agentis-tools/ctx-lsp-registry). ctx fetches its raw TOML manifests over HTTPS from the pinned `v1` branch (10-second timeout per fetch). Entries whose `schema_version` is newer than the running binary understands are rejected with a message telling you to upgrade ctx.
+
+## Trust model
+
+`ctx lsp add` **never executes anything**. It writes a TOML block to `.ctx/config.toml` — nothing else:
+
+- The command, arguments, install hint, and homepage from the registry are **shown to you first**, and nothing is written until you confirm (`--yes` skips the prompt).
+- The install hint (e.g. `npm install -g pyright`) is printed for you to run yourself; ctx never installs a server.
+- The server binary itself is only ever executed later, by `ctx index` (when a matching file is indexed) or by `ctx lsp doctor` (as an explicit health probe).
+- Hand-written `[lsp.<language>]` entries are never touched: `add` refuses to overwrite them and `update` refuses to refresh them. Only entries carrying the `source = "registry"` provenance key are managed by these commands.
+- Config writes are format-preserving and atomic: comments, formatting, and unrelated tables in `.ctx/config.toml` survive byte-for-byte.
+
+The registry base URL can be overridden with the `CTX_LSP_REGISTRY_BASE_URL` environment variable (for mirrors or testing). It is deliberately an environment variable and not a config key: where manifests come from is a distribution concern, not a per-project setting.
+
+## `add <LANGUAGE>`
+
+Fetches the registry entry for `LANGUAGE`, shows the curated server, and writes `[lsp.<LANGUAGE>]` to `.ctx/config.toml` after confirmation:
+
+```text
+$ ctx lsp add python
+Registry entry for python (https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1/registry/python.toml):
+  server:   pyright (recommended)
+  command:  pyright-langserver --stdio
+  install:  npm install -g pyright
+  homepage: https://github.com/microsoft/pyright
+
+This writes [lsp.python] to .ctx/config.toml (backend "hybrid").
+Proceed? [y/N] y
+wrote [lsp.python] to .ctx/config.toml (server pyright, backend hybrid)
+run 'ctx index' to reindex with the new language server
+```
+
+- `--server <NAME>` picks a specific server from the entry instead of the registry's recommended one.
+- `--yes` / `-y` skips the confirmation prompt. It is **required** in non-interactive use: when stdin is not a TTY, or with `--json` (JSON mode never prompts), the command refuses with exit code 2 instead of hanging.
+- The written entry always uses `backend = "hybrid"` plus `source = "registry"` / `source_server = "<name>"` provenance keys so `ctx lsp update` can manage it later.
+- If the server binary is not on `PATH` yet, the entry is still written and a stderr warning repeats the install hint and points at `ctx lsp doctor`.
+
+Outcomes for an existing `[lsp.<LANGUAGE>]` entry:
+
+| Existing entry | Result |
+|----------------|--------|
+| None | Written after confirmation |
+| Registry-managed, identical | "already configured", exit 0, nothing written |
+| Registry-managed, differs | Error pointing at `ctx lsp update <LANGUAGE>` (exit 2) |
+| Hand-written (no `source = "registry"`) | Refused before any network call (exit 2) |
+
+An unknown language is an error (exit 2) that lists every language the registry does offer.
+
+## `list`
+
+Shows the configured servers from `.ctx/config.toml`:
+
+```text
+$ ctx lsp list
+kotlin: `kotlin-language-server` (backend lsp, source manual)
+python: `pyright-langserver --stdio` (backend hybrid, source registry (pyright))
+```
+
+`source` is `registry (<server>)` for entries installed by `ctx lsp add`, `manual` for hand-written ones. With nothing configured it suggests `ctx lsp list --available`.
+
+`--available` fetches the registry index instead and lists every language it covers, with the recommended server and a `[configured]` marker for languages already present in your config:
+
+```text
+$ ctx lsp list --available
+Available languages in the LSP registry (https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1):
+  kotlin  (recommended server: kotlin-language-server)
+  python  (recommended server: pyright)  [configured]
+
+install one with 'ctx lsp add <language>'
+```
+
+## `update [LANGUAGE]`
+
+Re-fetches each registry-managed entry (marked `source = "registry"`), diffs it key by key against your config, and rewrites it after confirmation:
+
+```text
+$ ctx lsp update
+python: registry entry for server pyright changed:
+  args: ["--stdio", "--verbose"] -> ["--stdio"]
+Update [lsp.python]? [y/N] y
+updated [lsp.python] in .ctx/config.toml
+```
+
+- Without `LANGUAGE`, every registry-managed entry is checked; entries already matching the registry report `up to date`.
+- With `LANGUAGE`, only that entry is refreshed. Naming a hand-written entry is an error (exit 2) — `update` only manages registry-installed entries. Naming a language with no entry at all suggests `ctx lsp add <LANGUAGE>` (exit 2).
+- The server named by the entry's `source_server` provenance key is re-fetched; when that key is missing or empty the registry's recommended server is used.
+- `--yes` / `-y` applies all changes without prompting (required with `--json` or non-TTY stdin).
+- Nothing registry-managed in the config is a clean no-op (exit 0).
+
+## `doctor`
+
+Probes every valid `[lsp.<language>]` entry — including hand-written ones — end to end:
+
+1. **Binary lookup** — the `command` resolves to an executable (explicit path, or `PATH` search).
+2. **Handshake** — the server is spawned and must complete the LSP `initialize` handshake.
+3. **Capability diff** — every capability listed in the entry's `capabilities` array must be advertised by the server. Short names map to their provider keys (`documentSymbol` → `documentSymbolProvider`); names already ending in `Provider`, and `textDocumentSync`, are matched as-is.
+
+```text
+$ ctx lsp doctor
+PASS python: `pyright-langserver` handshake ok (pyright 1.1.400), capabilities ok
+FAIL kotlin: `kotlin-language-server` not found on PATH
+     hint: install the server (see 'ctx lsp list --available'), then re-run 'ctx lsp doctor'
+
+2 servers: 1 pass, 0 warn, 1 fail
+```
+
+Per server the status is `fail` (binary missing or handshake failed), `warn` (handshake ok but requested capabilities not advertised — extraction may be degraded), or `pass`. The exit code is 1 when at least one server **fails**; warnings alone still exit 0. Failed handshakes include the server's recent stderr lines. With nothing configured, `doctor` is a clean no-op.
+
+`doctor` probes servers on demand; the related sidecar `.ctx/lsp_status.json` records what actually happened during the last `ctx index` run (see [Add a language via LSP — Troubleshooting](../lsp-languages.md#troubleshooting)).
+
+## JSON output
+
+All four subcommands support the global `--json` flag and emit the standard envelope (see [JSON output](../json-output.md)). `add` and `update` additionally require `--yes` in JSON mode, because JSON mode never prompts.
+
+```bash
+ctx lsp add python --yes --json
+```
+
+```json
+{
+  "ctx_version": "0.3.5",
+  "command": "lsp.add",
+  "generated_at": "2026-07-15T12:00:00Z",
+  "data": {
+    "language": "python",
+    "server": "pyright",
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "backend": "hybrid",
+    "source": "registry",
+    "registry_url": "https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1/registry/python.toml",
+    "install_hint": "npm install -g pyright",
+    "homepage": "https://github.com/microsoft/pyright",
+    "binary_found": false,
+    "status": "added"
+  }
+}
+```
+
+When the entry already matches the registry, `data` is just `{"language", "server", "status": "already_configured"}`.
+
+```bash
+ctx lsp doctor --json
+```
+
+```json
+{
+  "ctx_version": "0.3.5",
+  "command": "lsp.doctor",
+  "generated_at": "2026-07-15T12:00:00Z",
+  "data": {
+    "healthy": false,
+    "summary": { "pass": 1, "warn": 0, "fail": 1 },
+    "servers": [
+      {
+        "language": "kotlin",
+        "command": "kotlin-language-server",
+        "backend": "hybrid",
+        "binary_found": false,
+        "root_markers_found": [],
+        "handshake_ok": false,
+        "negotiated_capabilities": [],
+        "missing_capabilities": ["documentSymbol"],
+        "stderr": [],
+        "error": "`kotlin-language-server` not found on PATH",
+        "status": "fail"
+      }
+    ]
+  }
+}
+```
+
+`lsp.list` reports `{"available": false, "servers": [...]}` (configured entries) or `{"available": true, "registry": "<base url>", "languages": [...]}` (with `--available`). `lsp.update` reports `{"registry": "<base url>", "languages": [{"language", "server", "status": "up_to_date" | "updated", "changes": {"<key>": {"from", "to"}}}]}`.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — including "already configured" (`add`), "up to date" (`update`), and warnings-only `doctor` runs |
+| 1 | `doctor` found at least one failing server (missing binary or failed handshake) |
+| 2 | Operational error (network failure, unknown language, refused overwrite, aborted confirmation, prompt needed but stdin is not a TTY or `--json` was given without `--yes`) |
+
+## Examples
+
+### Install and verify a language server
+
+```bash
+ctx lsp list --available          # what does the registry offer?
+ctx lsp add python                # review the entry, confirm, write config
+npm install -g pyright            # run the printed install hint yourself
+ctx lsp doctor                    # binary found? handshake ok? capabilities?
+ctx index                         # reindex through the new server
+```
+
+### Pick a non-default server
+
+```bash
+ctx lsp add python --server pylsp
+```
+
+### Keep registry entries fresh
+
+```bash
+ctx lsp update            # diff + confirm every registry-managed entry
+ctx lsp update python -y  # refresh one entry without prompting
+```
+
+### Non-interactive / CI use
+
+```bash
+ctx lsp add python --yes --json
+ctx lsp doctor --json     # exit 1 signals an unhealthy server
+```
+
+### Use a registry mirror
+
+```bash
+CTX_LSP_REGISTRY_BASE_URL=https://mirror.example.com/ctx-lsp-registry ctx lsp add python
+```
+
+## See Also
+
+- [Add a language via LSP](../lsp-languages.md) — the `[lsp.<language>]` config reference, backend modes, and troubleshooting
+- [Language Support](../language-support.md) — built-in tree-sitter languages
+- [Configuration](../configuration.md) — `.ctx/config.toml`
+- [ctx-lsp-registry](https://github.com/agentis-tools/ctx-lsp-registry) — contribute new language entries via that repository's `CONTRIBUTING.md`

--- a/docs/website/docs/commands/lsp.md
+++ b/docs/website/docs/commands/lsp.md
@@ -35,6 +35,12 @@ The registry lives in a separate repository, [`agentis-tools/ctx-lsp-registry`](
 
 The registry base URL can be overridden with the `CTX_LSP_REGISTRY_BASE_URL` environment variable (for mirrors or testing). It is deliberately an environment variable and not a config key: where manifests come from is a distribution concern, not a per-project setting.
 
+### Treat `.ctx/config.toml` as executable content
+
+The flip side of declarative registration: `ctx index` **spawns whatever `[lsp.<language>]` blocks the current repository's `.ctx/config.toml` declares** — the configured `command` with its `args` and `env`, run with the repository as working directory — as soon as a matching file is indexed. The `add` confirmation prompt protects entries *you* write; it does not apply to a config that arrives already committed in a checkout.
+
+Before running `ctx index` on a repository you don't trust, review its `.ctx/config.toml` like you would review a build script or git hook. Check the `command` **and** the `env` table — environment variables such as `LD_PRELOAD` or `DYLD_INSERT_LIBRARIES` can make even a familiar-looking binary load repository-local code.
+
 ## `add <LANGUAGE>`
 
 Fetches the registry entry for `LANGUAGE`, shows the curated server, and writes `[lsp.<LANGUAGE>]` to `.ctx/config.toml` after confirmation:

--- a/docs/website/docs/configuration.md
+++ b/docs/website/docs/configuration.md
@@ -471,12 +471,14 @@ ctx uses minimal environment variables:
 | `OLLAMA_HOST` | Ollama server URL (default `http://localhost:11434`) | Only for the Ollama provider |
 | `OLLAMA_EMBED_MODEL` | Ollama embedding model (default `nomic-embed-text`) | Only for the Ollama provider |
 | `OLLAMA_API_KEY` | Optional bearer token for a remote/authenticated Ollama host | No |
+| `CTX_LSP_REGISTRY_BASE_URL` | Alternate base URL for the `ctx lsp` community registry (mirrors/testing) | No |
 
 ### Project config (`.ctx/config.toml`)
 
 Per-project defaults live in an optional, **committed** `.ctx/config.toml` so a
-team shares one setup instead of passing flags/env vars every time. Today it
-configures the embedding backend:
+team shares one setup instead of passing flags/env vars every time. It
+configures the embedding backend and registers language servers for LSP-backed
+indexing:
 
 ```toml
 [embedding]
@@ -488,6 +490,54 @@ model = "qwen3-embedding:8b"   # Ollama/OpenAI model name
 Resolution is always **CLI flag > environment variable > `.ctx/config.toml` >
 built-in default**, so the file never overrides an explicit request. `.ctx/` is
 otherwise git-ignored; the repo's `.gitignore` keeps `config.toml` and `rules.toml` tracked.
+
+### Language servers (`[lsp.<language>]`)
+
+Each `[lsp.<language>]` table registers a stdio language server that `ctx index` uses to
+extract (or refine) code intelligence for the files it claims. The table key is the language
+name stored on indexed files and symbols:
+
+```toml
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]          # required: kotlin is not a built-in language
+backend = "lsp"                     # tree-sitter | lsp | hybrid (default hybrid)
+
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+# extensions default to the built-in set ("py", "pyi") for built-in language names
+```
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `command` | string | — (required) | Server executable; resolved via `PATH` unless it contains a path separator |
+| `args` | array of strings | `[]` | Arguments passed to the server |
+| `extensions` | array of strings | built-in set for built-in language names | File extensions (without dots) this server claims; required for non-built-in language names |
+| `root_markers` | array of strings | `[]` | Workspace-root marker files; informational, reported by `ctx lsp doctor` |
+| `capabilities` | array of strings | `[]` | Capabilities the server is expected to advertise; checked by `ctx lsp doctor` |
+| `backend` | string | `"hybrid"` | `"tree-sitter"`, `"lsp"`, or `"hybrid"` — see [Add a language via LSP](lsp-languages.md#backend-modes) |
+| `initialization_options` | any value | unset | Passed verbatim as LSP `initializationOptions` |
+| `env` | table of strings | `{}` | Extra environment variables for the server process |
+| `timeout_ms` | integer | `10000` | Per-request timeout in milliseconds |
+| `source` | string | unset | Provenance written by `ctx lsp add` (`"registry"` marks the entry as registry-managed); accepted and ignored by the indexer |
+| `source_server` | string | unset | Provenance written by `ctx lsp add`: the registry server name the entry was installed from |
+
+Entries installed with [`ctx lsp add`](commands/lsp.md) carry the `source` / `source_server`
+provenance keys so `ctx lsp update` can refresh them later; entries without
+`source = "registry"` are treated as hand-written and never touched by those commands.
+
+`[lsp.*]` configuration is **never fatal** to indexing:
+
+- An invalid block (empty `command`, or missing `extensions` for a non-built-in language name)
+  is skipped with a stderr warning; the remaining blocks and the built-in grammars keep working.
+- Unknown keys are tolerated, so configs written by newer ctx versions still load.
+- When two blocks claim the same extension, the first block in table-key order wins and a
+  warning names both blocks.
+- A configured server that is missing or crashes degrades gracefully at index time: warning on
+  stderr, tree-sitter fallback for built-in languages, exit code unaffected.
+
+Without any `[lsp.*]` block the LSP subsystem is completely inert — no server is ever spawned.
 
 ### Architecture policy (`.ctx/rules.toml`)
 

--- a/docs/website/docs/json-output.md
+++ b/docs/website/docs/json-output.md
@@ -501,6 +501,105 @@ One `files` entry per planned file. `action` is one of `created` (did not exist)
 
 `severity` is `error`, `warning`, or `info`; `hint` is omitted when there is none. `code` is a stable machine-readable identifier: `binary_version`, `harness_not_initialized`, `templates_stale`, `index_missing`, `index_schema`, `index_stale`, `rules_missing`, `rules_invalid`, `hooks_missing`, `hooks_modified`, `settings_not_wired`, `mcp_unavailable`, `mcp_not_wired`. Checks are independent (a missing index and an invalid rules file are both reported in one run). `healthy` is `true` when no check is an error or a warning; exit codes: 0 = healthy, 1 = problems, 2 = operational error.
 
+### `lsp.add`
+
+`ctx lsp add <LANGUAGE> [--server <NAME>] --yes --json`
+
+JSON mode never prompts, so `--yes` is required (exit 2 otherwise).
+
+```json
+{
+  "language": "python",
+  "server": "pyright",
+  "command": "pyright-langserver",
+  "args": ["--stdio"],
+  "backend": "hybrid",
+  "source": "registry",
+  "registry_url": "https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1/registry/python.toml",
+  "install_hint": "npm install -g pyright",
+  "homepage": "https://github.com/microsoft/pyright",
+  "binary_found": true,
+  "status": "added"
+}
+```
+
+`install_hint` and `homepage` are `null` when the registry entry does not provide them. `binary_found` reports whether the server command already resolves to an executable (a `false` is accompanied by a stderr install warning). When the entry is already configured and matches the registry, `data` is just `{"language", "server", "status": "already_configured"}`.
+
+### `lsp.list`
+
+`ctx lsp list [--available] --json`
+
+```json
+{
+  "available": false,
+  "servers": [
+    {
+      "language": "python",
+      "command": "pyright-langserver",
+      "args": ["--stdio"],
+      "backend": "hybrid",
+      "source": "registry",
+      "source_server": "pyright"
+    }
+  ]
+}
+```
+
+`source` is `"registry"` for entries installed by `ctx lsp add`, `"manual"` otherwise. With `--available` the payload is instead `{"available": true, "registry": "<base url>", "languages": [{"language", "recommended", "servers", "configured"}]}` — one row per registry language, with `configured` marking languages already present in `.ctx/config.toml`.
+
+### `lsp.update`
+
+`ctx lsp update [LANGUAGE] --yes --json`
+
+```json
+{
+  "registry": "https://raw.githubusercontent.com/agentis-tools/ctx-lsp-registry/v1",
+  "languages": [
+    { "language": "go", "server": "gopls", "status": "up_to_date" },
+    {
+      "language": "python",
+      "server": "pyright",
+      "status": "updated",
+      "changes": {
+        "args": { "from": "[\"--stdio\", \"--verbose\"]", "to": "[\"--stdio\"]" }
+      }
+    }
+  ]
+}
+```
+
+`changes` is present only for `"status": "updated"`, keyed by config key with display-string `from`/`to` values. When nothing in the config is registry-managed the payload is `{"languages": []}`.
+
+### `lsp.doctor`
+
+`ctx lsp doctor --json`
+
+```json
+{
+  "healthy": true,
+  "summary": { "pass": 1, "warn": 0, "fail": 0 },
+  "servers": [
+    {
+      "language": "python",
+      "command": "pyright-langserver",
+      "backend": "hybrid",
+      "binary_found": true,
+      "binary_path": "/usr/local/bin/pyright-langserver",
+      "root_markers_found": ["pyproject.toml"],
+      "handshake_ok": true,
+      "server_name": "pyright",
+      "server_version": "1.1.400",
+      "negotiated_capabilities": ["documentSymbolProvider", "definitionProvider"],
+      "missing_capabilities": [],
+      "stderr": [],
+      "status": "pass"
+    }
+  ]
+}
+```
+
+`status` per server is `fail` (binary missing or handshake failed), `warn` (requested capabilities not advertised), or `pass`. `binary_path`, `server_name`, `server_version`, and `error` are omitted when unknown. `healthy` is `true` when no server fails; exit codes: 0 = no failures (warnings allowed), 1 = at least one failure, 2 = operational error.
+
 ### `self_update`
 
 `ctx self-update [--version X.Y.Z] --json`

--- a/docs/website/docs/language-support.md
+++ b/docs/website/docs/language-support.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 # Language Support
 
-ctx uses tree-sitter for parsing, providing accurate symbol extraction across multiple programming languages. This page details what's extracted from each language and how relationships are tracked.
+ctx uses tree-sitter for parsing, providing accurate symbol extraction across multiple programming languages. This page details what's extracted from each language and how relationships are tracked. Languages without a built-in grammar can be added declaratively through any stdio language server — see [Languages beyond the built-in set (LSP)](#languages-beyond-the-built-in-set-lsp).
 
 ## Supported Languages Overview
 
@@ -21,6 +21,34 @@ ctx uses tree-sitter for parsing, providing accurate symbol extraction across mu
 | Go | `.go` | Full | Calls, Imports | Full |
 | Solidity | `.sol` | Full | Calls | Full |
 | YAML | `.yaml`, `.yml` | File tracking only | N/A | Partial |
+
+## Languages beyond the built-in set (LSP)
+
+Any language with a stdio language server can be indexed by registering the server under `[lsp.<language>]` in `.ctx/config.toml` — Kotlin, Scala, Ruby, Zig, and so on. ctx then extracts symbols via `textDocument/documentSymbol`, call edges via the call-hierarchy requests, and resolves cross-file references via `textDocument/definition`:
+
+```toml
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]
+backend = "lsp"
+```
+
+For languages covered by the community registry, `ctx lsp add <language>` writes this block for you after showing what it would install. Server failures never break indexing: a missing or crashed server produces a stderr warning and ctx falls back to tree-sitter (built-in languages) or file-only records (dynamic languages).
+
+See [Add a language via LSP](lsp-languages.md) for the full key reference, and [`ctx lsp`](commands/lsp.md) for the registry commands.
+
+### Hybrid mode for built-in languages
+
+The built-in languages above can also be paired with a language server using `backend = "hybrid"` (the default for configured blocks). Tree-sitter still does the extraction — fast and offline — and the server is consulted only afterwards, to resolve cross-file references that static name resolution left unresolved or ambiguous (see [Cross-File Resolution](#cross-file-resolution) below). This tightens the call graph without giving up tree-sitter's speed:
+
+```toml
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+# backend = "hybrid" is the default; extensions default to ["py", "pyi"]
+```
+
+Without any `[lsp.*]` block, nothing changes: no server is ever spawned and indexing behaves exactly as described on this page.
 
 ## Rust
 
@@ -468,6 +496,8 @@ Dependencies of 'myFunction':
   calls externalLib (line 15)         # Unresolved (external)
 ```
 
+Registering a language server with `backend = "hybrid"` narrows this limitation: after tree-sitter extraction, references that stayed unresolved are resolved via the server's `textDocument/definition` (see [Hybrid mode for built-in languages](#hybrid-mode-for-built-in-languages)).
+
 ### Dynamic Calls
 
 Dynamic or computed calls cannot be tracked:
@@ -536,7 +566,9 @@ callback(input);
 
 ## Adding Language Support
 
-To add support for a new language:
+The fastest way to add a language is to register its language server in `.ctx/config.toml` — no code involved; see [Add a language via LSP](lsp-languages.md).
+
+To add **built-in** tree-sitter support for a new language:
 
 1. Add the tree-sitter crate to `Cargo.toml`:
    ```toml
@@ -579,4 +611,4 @@ match extension {
 }
 ```
 
-Unknown extensions are skipped during indexing but included in context generation.
+Unknown extensions are skipped during indexing but included in context generation — unless an `[lsp.<language>]` block in `.ctx/config.toml` claims them, in which case they are indexed through the registered language server.

--- a/docs/website/docs/lsp-languages.md
+++ b/docs/website/docs/lsp-languages.md
@@ -1,0 +1,141 @@
+---
+id: lsp-languages
+title: Add a Language via LSP
+sidebar_position: 7
+---
+
+# Add a Language via LSP
+
+ctx ships tree-sitter grammars for a fixed set of languages ([Language Support](language-support.md)). For everything else — Kotlin, Scala, Ruby, Zig, anything with a stdio language server — you can register the server declaratively in `.ctx/config.toml` and `ctx index` extracts symbols, call edges, and cross-file references through it. No plugin, no rebuild.
+
+## Quick start
+
+For languages the community registry covers, one command sets everything up:
+
+```bash
+ctx lsp add python        # shows the curated entry, asks for confirmation
+ctx lsp doctor            # verify: binary found, handshake ok, capabilities ok
+ctx index                 # reindex through the server
+```
+
+`ctx lsp add` writes a `[lsp.<language>]` block to `.ctx/config.toml` and nothing more — it never installs or executes the server itself. If the server binary is missing it prints the install command for you to run. See [`ctx lsp`](commands/lsp.md) for the full command reference and trust model.
+
+## Manual registration
+
+For languages not in the registry, write the block yourself:
+
+```toml
+# .ctx/config.toml
+[lsp.kotlin]
+command = "kotlin-language-server"
+extensions = ["kt", "kts"]        # required: kotlin has no built-in grammar
+backend = "lsp"
+
+[lsp.python]
+command = "pyright-langserver"
+args = ["--stdio"]
+# extensions default to the built-in set ("py", "pyi") for built-in language names
+# backend defaults to "hybrid"
+```
+
+The table key (`kotlin`, `python`, …) is the language name stored on every indexed file and symbol; it flows through `ctx query`, `ctx sql`, and JSON output unchanged.
+
+### Key reference
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `command` | string | — (required) | Executable to spawn. Resolved via `PATH` unless it contains a path separator. |
+| `args` | array of strings | `[]` | Arguments passed to the server (e.g. `["--stdio"]`). |
+| `extensions` | array of strings | built-in set for built-in language names | File extensions (without the dot) this server claims. **Required** when the table key is not a built-in language name. Normalized to lowercase, leading dots stripped. |
+| `root_markers` | array of strings | `[]` | Marker files/dirs identifying a workspace root. Informational; `ctx lsp doctor` reports which ones exist under the project root. |
+| `capabilities` | array of strings | `[]` | Capabilities you expect the server to provide (e.g. `["documentSymbol", "definition"]`). `ctx lsp doctor` warns when the server does not advertise them. |
+| `backend` | `"tree-sitter"` \| `"lsp"` \| `"hybrid"` | `"hybrid"` | Extraction backend for files claimed by this block (see below). |
+| `initialization_options` | any TOML value | unset | Passed through verbatim as LSP `initializationOptions`. |
+| `env` | table of strings | `{}` | Extra environment variables for the server process. |
+| `timeout_ms` | integer | `10000` | Per-request timeout in milliseconds. |
+| `source`, `source_server` | string | unset | Provenance keys written by `ctx lsp add`; accepted and ignored by the indexer. Do not set them by hand — `source = "registry"` marks an entry as managed by `ctx lsp update`. |
+
+Built-in language names with default extension sets: `rust` (`rs`), `typescript` (`ts`), `tsx` (`tsx`), `javascript` (`js`, `mjs`, `cjs`), `jsx` (`jsx`), `python` (`py`, `pyi`), `go` (`go`), `solidity` (`sol`), `yaml` (`yaml`, `yml`).
+
+When two blocks claim the same extension, the first block (in table-key order) wins and a warning names both blocks.
+
+## Backend modes
+
+| `backend` | Symbols and edges from | Cross-file resolution | Use when |
+|-----------|------------------------|-----------------------|----------|
+| `tree-sitter` | Built-in grammar only | SQL name resolution only | You want to keep a registration around without using it. On a language with no built-in grammar this leaves the files unindexed. |
+| `lsp` | The language server (`textDocument/documentSymbol`, call hierarchy) | `textDocument/definition` | The language has no built-in grammar, or you want the server's semantic view (e.g. resolved call hierarchies) even for a built-in language. |
+| `hybrid` (default) | Built-in tree-sitter grammar | `textDocument/definition` for references tree-sitter left unresolved | The language has a built-in grammar. You keep tree-sitter's fast, offline extraction and add LSP precision only where static name resolution was ambiguous (e.g. the same function name defined in several files). |
+
+Two details worth knowing:
+
+- **`hybrid` on a dynamic language degrades to `lsp`.** With no built-in grammar there is nothing for tree-sitter to extract, so hybrid-configured blocks for non-built-in languages use full LSP extraction automatically. In practice: the default backend does the right thing for both kinds of language.
+- **Call edges via LSP need call hierarchy.** In `lsp` mode, `Calls` edges are collected through `callHierarchy/outgoingCalls` and are only gathered when the server advertises `callHierarchyProvider`. Symbols still come through without it.
+
+## Fallback and degradation
+
+LSP failures never fail an indexing run, and the exit code is unaffected:
+
+- **Server missing or crashing:** a warning is printed to stderr once per language per run, then ctx falls back — built-in languages are re-parsed with tree-sitter (full symbols), dynamic languages get a file record with zero symbols (so incremental indexing and deletion cleanup keep working).
+- **Invalid config blocks** (empty `command`, missing `extensions` for a non-built-in language) are skipped with a warning; the remaining blocks and built-in grammars keep working. Unknown keys are tolerated, so configs written by newer ctx versions still load.
+- **Slow servers:** each request gets `timeout_ms` (default 10 s); the first request after `initialize` gets a longer warmup grace period, because many servers index the workspace before answering. After 3 consecutive timeouts the server is declared failed for the rest of the run and the fallback above kicks in.
+
+## Performance
+
+- **Zero cost when unconfigured.** Without any `[lsp.*]` block, the subsystem is completely inert — nothing is spawned and indexing behaves exactly as before.
+- **Per-language opt-in.** Only files whose extension is claimed by a block go through a server; everything else stays on tree-sitter.
+- **Lazy spawn.** A server is started on the first file that needs it, not at startup. An incremental `ctx index` run that finds no changed files in that language never spawns the server at all.
+- **Warm reuse in watch mode.** `ctx index --watch` keeps servers running across file events; a one-shot `ctx index` shuts them down at the end of the run.
+- **First-request warmup.** Expect the first indexed file per server to be slower while the server warms up; subsequent files reuse the running process.
+
+`hybrid` is the cheaper mode for built-in languages: tree-sitter does the bulk extraction and the server is only consulted for edges that stayed unresolved.
+
+## Troubleshooting
+
+Start with the health probe:
+
+```bash
+ctx lsp doctor
+```
+
+It checks, per configured block: the binary resolves (explicit path or `PATH`), the server completes the `initialize` handshake, and every capability listed in `capabilities` was advertised — with the server's recent stderr attached to failed handshakes. Exit code 1 means at least one server failed. See [`ctx lsp doctor`](commands/lsp.md#doctor).
+
+Every `ctx index` run with LSP configured also writes a sidecar, `.ctx/lsp_status.json`, recording what actually happened:
+
+```json
+{
+  "generated_at": 1752580800,
+  "servers": [
+    {
+      "language": "kotlin",
+      "command": "kotlin-language-server",
+      "backend": "lsp",
+      "state": "healthy",
+      "server_name": "kotlin-language-server",
+      "server_version": "1.3.13",
+      "capabilities": ["documentSymbolProvider", "definitionProvider"]
+    }
+  ]
+}
+```
+
+`state` is `healthy`, `failed` (with a `reason`), or `idle` (configured, but no file needed the server this run). The sidecar lives in `.ctx/`, which is never indexed, so it never shows up in query results.
+
+Common cases:
+
+| Symptom | Explanation |
+|---------|-------------|
+| `Warning: LSP server '…' for … …; falling back to tree-sitter` during `ctx index` | The server failed to spawn, crashed, or timed out repeatedly. Indexing continued on the fallback path; run `ctx lsp doctor` for details. |
+| `Warning: ignoring [lsp.<lang>] …: 'extensions' is required for non-builtin languages` | The block's table key is not a built-in language name, so ctx cannot infer which files it claims. Add `extensions = [...]`. |
+| Doctor says `WARN … missing capabilities: …` | The server negotiated fewer capabilities than the config requests; extraction may be degraded (e.g. no call edges without `callHierarchy`). |
+| Dynamic-language files indexed but have no symbols | The server was unavailable, so only file records were stored. Fix the server (see doctor) and re-run `ctx index` after touching the files, or `ctx index --force`. |
+
+## Contributing a registry entry
+
+The curated entries behind `ctx lsp add` live in [`agentis-tools/ctx-lsp-registry`](https://github.com/agentis-tools/ctx-lsp-registry): one TOML file per language, each with one or more `[[servers]]` blocks (exactly one marked `recommended = true`) plus per-OS install hints. If you have a working manual `[lsp.<language>]` block for a language the registry does not cover yet, consider contributing it upstream — see that repository's `CONTRIBUTING.md`.
+
+## See Also
+
+- [`ctx lsp`](commands/lsp.md) — command reference (`add`, `list`, `update`, `doctor`)
+- [Language Support](language-support.md) — the built-in tree-sitter languages
+- [Configuration](configuration.md) — everything else in `.ctx/config.toml`

--- a/docs/website/docs/lsp-languages.md
+++ b/docs/website/docs/lsp-languages.md
@@ -130,6 +130,10 @@ Common cases:
 | Doctor says `WARN … missing capabilities: …` | The server negotiated fewer capabilities than the config requests; extraction may be degraded (e.g. no call edges without `callHierarchy`). |
 | Dynamic-language files indexed but have no symbols | The server was unavailable, so only file records were stored. Fix the server (see doctor) and re-run `ctx index` after touching the files, or `ctx index --force`. |
 
+## Security note
+
+`ctx index` spawns the servers the current repository's `.ctx/config.toml` declares — command, args, and `env` — with the repository as working directory. A checkout you didn't write can therefore name any executable. Before indexing an untrusted repository, review its `.ctx/config.toml` like a build script; see the [trust model](commands/lsp.md#trust-model) for details.
+
 ## Contributing a registry entry
 
 The curated entries behind `ctx lsp add` live in [`agentis-tools/ctx-lsp-registry`](https://github.com/agentis-tools/ctx-lsp-registry): one TOML file per language, each with one or more `[[servers]]` blocks (exactly one marked `recommended = true`) plus per-OS install hints. If you have a working manual `[lsp.<language>]` block for a language the registry does not cover yet, consider contributing it upstream — see that repository's `CONTRIBUTING.md`.

--- a/docs/website/sidebars.ts
+++ b/docs/website/sidebars.ts
@@ -63,6 +63,7 @@ const sidebars: SidebarsConfig = {
         'commands/diff',
         'commands/audit',
         'commands/harness',
+        'commands/lsp',
         'commands/self-update',
         'commands/shell',
         'commands/serve',
@@ -84,6 +85,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'configuration',
         'language-support',
+        'lsp-languages',
         'json-output',
         'reference/exit-codes',
         'sql-schema',


### PR DESCRIPTION
## Summary

Public documentation for AGE-10's pluggable LSP support (docs-only; no src/ changes):

- `docs/commands/lsp.md` — full `ctx lsp add/list/update/doctor` reference: flags, behavior, trust model, JSON envelopes, exit codes.
- `docs/lsp-languages.md` — "Add a Language via LSP" guide: quick start, manual `[lsp.<language>]` authoring with a complete key reference, backend modes (tree-sitter/lsp/hybrid), graceful degradation, performance notes, troubleshooting via `ctx lsp doctor` and `.ctx/lsp_status.json`, and how to contribute entries to [ctx-lsp-registry](https://github.com/agentis-tools/ctx-lsp-registry).
- Updates: `docs/language-support.md` (LSP path + hybrid sections), `docs/configuration.md` (`[lsp.<language>]` table incl. provenance keys, `CTX_LSP_REGISTRY_BASE_URL`), `docs/json-output.md` (`lsp.*` payloads), `docs/README.md` TOC.
- All pages mirrored into the Docusaurus site (`docs/website/docs/`) and registered in `sidebars.ts`.

Every documented behavior was verified against the implementation and its tests on this branch. Note: the Docusaurus build was not run locally (node_modules absent; would need a network install) — sidebars changes are two one-line insertions. Pre-existing drift spotted for a separate cleanup: root `docs/language-support.md` still lists Go as "Planned" while the website copy says Full.

**Stacked PR**: base is `johan/age-10-lsp-commands` (#77). Merge order: #74/#75/#76 → #77 → this; retarget to `main` as parents merge.

Part of [AGE-10](https://linear.app/itkonsult/issue/AGE-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)