### PR TITLE
ci: report checks on every pull request so protection can require them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
+  # No paths-ignore here: a workflow skipped by a path filter never reports its
+  # checks, so any of them that branch protection requires would stay pending
+  # forever and block the pull request. Docs-only runs are skipped per job via
+  # `needs.changes.outputs.code` instead -- a job skipped by `if:` does report,
+  # and counts as success.
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
   # Nightly perf run (full suite) and manual triggers (e.g. baseline capture
   # runs). Schedule/dispatch events are unaffected by the paths-ignore above.
   schedule:
@@ -24,7 +26,36 @@ permissions:
   contents: read
 
 jobs:
+  # Replaces the workflow-level paths-ignore: report whether the pull request
+  # touches anything but docs, so the expensive jobs can skip a docs-only change
+  # while still reporting a status that branch protection accepts.
+  changes:
+    name: detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE_SHA...HEAD" | grep -qvE '^docs/|\.md$'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -69,6 +100,8 @@ jobs:
         run: cargo test --locked --verbose ${{ matrix.features }}
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -91,6 +124,8 @@ jobs:
         run: node --test .github/scripts/render-ctx-pr-comment.test.cjs
 
   plugins:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -123,6 +158,8 @@ jobs:
           codex plugin add ctx@ctx-local --json
 
   publish-dry-run:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -141,6 +178,8 @@ jobs:
         run: cargo publish --locked --dry-run --no-default-features
 
   packaging-metadata:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -163,6 +202,8 @@ jobs:
           python3 -m json.tool packaging/scoop/ctx.json >/dev/null
 
   perf:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Completed the first cookbook set with a release-health reporting workflow that combines immutable comparisons, provenance, normalized metrics, focused investigations, uncertainty, and owned actions.
 
 ### Internal
+- Made CI report its checks on every pull request so branch protection can require them. The
+  workflow-level `paths-ignore` meant a docs-only pull request never ran CI, and a check that never
+  runs never reports -- so any required check would have stayed pending forever and blocked the
+  merge. Docs-only runs now skip the expensive jobs individually via a `changes` filter, which
+  reports a skipped status that branch protection accepts.
 - Added an internal LSP registry client (`lsp_registry`) and a format-preserving
   `.ctx/config.toml` writer (`config_edit`) as groundwork for the future `ctx lsp`
   commands. Internal only: no CLI surface, config contract, or documented behavior


### PR DESCRIPTION
## Summary

`ci.yml` skipped itself on docs-only pull requests via `paths-ignore`. A workflow skipped by a path filter **never reports its checks**, so any check branch protection requires would sit pending forever and block the merge — permanently, on a repository whose cookbook work is largely docs.

This drops `paths-ignore` from the `pull_request` trigger and moves the skip into the jobs, keyed on a `changes` filter. A job skipped by `if:` still reports a status, and branch protection counts a skipped job as success — so docs-only runs stay cheap without stranding the pull request.

`push` is unchanged: nothing requires checks on main.

## Why

Main had no branch protection until today. Enabling it exposed this: `repository policy`, `Rust 1.91 MSRV`, and `dependency, license, and source policy` come from `policy.yml`, which has no `paths-ignore` and so was safe to require. The `ci.yml` checks — `test`, `lint`, `perf` — could not be required until this lands.

That matters because the gap is not hypothetical. Two Dependabot PRs merged 31 seconds apart on 2026-07-15 left main red for ~10 hours (AGE-17); the break was caught by a `ci.yml` job that nothing required.

## Follow-up

Once this merges, add to the required set: `test (ubuntu-latest, --all-features)`, `test (macos-latest)`, `test (windows-latest, --no-default-features)`, `lint`, `plugins`, `packaging-metadata`. Leaving `perf` and `publish-dry-run` advisory is reasonable — both are slow and would add ~30 minutes to every merge.

Closes part of AGE-17.

## Validation

- `ci.yml` parses; jobs: `changes`, `test`, `lint`, `plugins`, `publish-dry-run`, `packaging-metadata`, `perf`
- `pull_request` trigger carries no path filter
- checkout action pinned to the same SHA as the other jobs