### PR TITLE
fix: make the breaking-change gate reachable and enforce it by label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Completed the first cookbook set with a release-health reporting workflow that combines immutable comparisons, provenance, normalized metrics, focused investigations, uncertainty, and owned actions.
 
 ### Internal
+- Made the `breaking-change` policy gate reachable and enforced it by label.
+  `check-contracts.py pr-policy` required a `breaking-change` label for removed CLI
+  contracts, but no such label existed in the repository, so the requirement could
+  never be satisfied. The `BREAKING:` changelog requirement now fires on the label
+  itself rather than only on contract removal, since an exit-code or JSON-meaning
+  change removes nothing yet still breaks. The matching version increase moved from
+  the pull request to the release cut, where `governance/releasing.md` places it:
+  acknowledged breaks accumulate under Unreleased, and `version.py` refuses to
+  release them under an insufficient bump.
 - Added an internal LSP registry client (`lsp_registry`) and a format-preserving
   `.ctx/config.toml` writer (`config_edit`) as groundwork for the future `ctx lsp`
   commands. Internal only: no CLI surface, config contract, or documented behavior

--- a/scripts/check-contracts.py
+++ b/scripts/check-contracts.py
@@ -215,21 +215,19 @@ def pr_policy(base_ref: str, labels: set[str]) -> None:
             "compatibility-sensitive changes require maintainer label contract-review: "
             + details
         )
-    if removed:
-        if "breaking-change" not in labels:
-            raise ContractError(
-                "removed CLI contracts require maintainer label breaking-change: "
-                + ", ".join(removed)
-            )
+    if removed and "breaking-change" not in labels:
+        raise ContractError(
+            "removed CLI contracts require maintainer label breaking-change: "
+            + ", ".join(removed)
+        )
+    # An acknowledged break must read as one in the changelog. The matching
+    # version increase is enforced when the release is cut (version.py), not
+    # here: breaks land under Unreleased and the release PR carries the bump.
+    if "breaking-change" in labels:
         old, new = version_from_ref(base_ref), current_version()
-        compatible_bump = new[0] > old[0] if old[0] > 0 else (new[0] > old[0] or new[1] > old[1])
-        if not compatible_bump:
-            raise ContractError(
-                f"breaking CLI change requires a major bump (or pre-1.0 minor bump): {old} -> {new}"
-            )
         if "BREAKING:" not in breaking_notes_section(old, new):
             raise ContractError(
-                "breaking change needs a prominent BREAKING: entry in Unreleased "
+                "breaking-change requires a prominent BREAKING: entry in Unreleased "
                 "or the release-preparation version section"
             )
     print("OK: compatibility-sensitive changes have the required review acknowledgement")

--- a/scripts/check-contracts.py
+++ b/scripts/check-contracts.py
@@ -220,15 +220,28 @@ def pr_policy(base_ref: str, labels: set[str]) -> None:
             "removed CLI contracts require maintainer label breaking-change: "
             + ", ".join(removed)
         )
-    # An acknowledged break must read as one in the changelog. The matching
-    # version increase is enforced when the release is cut (version.py), not
-    # here: breaks land under Unreleased and the release PR carries the bump.
+    # An acknowledged break must read as one in the changelog. Check the lines
+    # this PR adds, not the section as a whole: Unreleased accumulates entries
+    # from every merged break, so "the section mentions BREAKING:" would pass on
+    # somebody else's entry and wave this one through.
+    #
+    # The matching version increase is enforced when the release is cut
+    # (version.py), not here: breaks land under Unreleased and the release PR
+    # carries the bump, per governance/releasing.md.
     if "breaking-change" in labels:
-        old, new = version_from_ref(base_ref), current_version()
-        if "BREAKING:" not in breaking_notes_section(old, new):
+        added = [
+            line
+            for line in git_output(
+                "diff", f"{base_ref}...HEAD", "--", "CHANGELOG.md"
+            ).splitlines()
+            if line.startswith("+") and not line.startswith("+++")
+        ]
+        # Match the entry convention ("- BREAKING: ..."), not a bare mention:
+        # prose that merely discusses the marker is not a declaration of a break.
+        if not any(re.match(r"\+\s*-\s*BREAKING:", line) for line in added):
             raise ContractError(
-                "breaking-change requires a prominent BREAKING: entry in Unreleased "
-                "or the release-preparation version section"
+                "breaking-change requires this pull request to add a prominent "
+                "'- BREAKING:' changelog entry under Unreleased"
             )
     print("OK: compatibility-sensitive changes have the required review acknowledgement")
 

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -361,6 +361,25 @@ def finalize_changelog(text: str, old: str, new: str, date: str, allow_empty: bo
     return text.replace(old_unreleased, new_links, 1)
 
 
+def require_breaking_bump(text: str, old: SemVer, new: SemVer) -> None:
+    """Refuse to release accumulated breaks under an insufficient bump.
+
+    PR review records a break with the `breaking-change` label and a BREAKING:
+    entry under Unreleased; the version increase those breaks require is owed
+    at release time, which is here. Pre-1.0 the vehicle is 0.MINOR.0, so a
+    minor bump suffices; from 1.0 a break needs a major.
+    """
+    if "BREAKING:" not in changelog_section(text, "Unreleased"):
+        return
+    sufficient = new.major > old.major if old.major > 0 else new.minor > old.minor
+    if not sufficient:
+        level = "major" if old.major > 0 else "minor"
+        raise PolicyError(
+            f"Unreleased contains a BREAKING: entry; {old} -> {new} is not a "
+            f"{level} bump. Breaking changes require a {level} increase."
+        )
+
+
 def ensure_clean(allow_dirty: bool) -> None:
     result = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=normal"],
@@ -398,6 +417,7 @@ def set_version(args: argparse.Namespace) -> int:
     changed: list[Path] = []
     manifest_text = MANIFEST.read_text(encoding="utf-8")
     changelog_text = CHANGELOG.read_text(encoding="utf-8")
+    require_breaking_bump(changelog_text, old, new)
     updates: dict[Path, str] = {
         MANIFEST: replace_manifest_version(manifest_text, str(old), str(new)),
         CHANGELOG: finalize_changelog(

--- a/tests/versioning/test_version.py
+++ b/tests/versioning/test_version.py
@@ -97,5 +97,49 @@ class GitHubEnvironmentTests(unittest.TestCase):
         self.assertEqual(version.tag_from_environment(environment), "v0.3.4")
 
 
+class BreakingBumpTests(unittest.TestCase):
+    """Breaks land under Unreleased; the version they owe is due at release."""
+
+    BREAKING = (
+        "# Changelog\n\n## [Unreleased]\n\n### Fixed\n"
+        "- BREAKING: `ctx index` now exits 2 when a scope matches nothing.\n\n"
+        "## [0.3.5] - 2026-07-01\n"
+    )
+    COMPATIBLE = (
+        "# Changelog\n\n## [Unreleased]\n\n### Fixed\n"
+        "- Diff selection is now deterministic.\n\n"
+        "## [0.3.5] - 2026-07-01\n"
+    )
+
+    def check(self, text, old, new):
+        version.require_breaking_bump(
+            text, version.SemVer.parse(old), version.SemVer.parse(new)
+        )
+
+    def test_pre_1_0_break_requires_a_minor_bump(self):
+        with self.assertRaises(version.PolicyError) as caught:
+            self.check(self.BREAKING, "0.3.5", "0.3.6")
+        self.assertIn("BREAKING:", str(caught.exception))
+        self.assertIn("minor", str(caught.exception))
+
+    def test_pre_1_0_break_accepts_a_minor_bump(self):
+        self.check(self.BREAKING, "0.3.5", "0.4.0")
+
+    def test_post_1_0_break_requires_a_major_bump(self):
+        with self.assertRaises(version.PolicyError):
+            self.check(self.BREAKING, "1.2.3", "1.3.0")
+        self.check(self.BREAKING, "1.2.3", "2.0.0")
+
+    def test_compatible_release_is_unaffected_by_the_gate(self):
+        self.check(self.COMPATIBLE, "0.3.5", "0.3.6")
+
+    def test_only_the_unreleased_section_is_considered(self):
+        already_released = (
+            "# Changelog\n\n## [Unreleased]\n\n### Fixed\n- A compatible fix.\n\n"
+            "## [0.4.0] - 2026-07-01\n\n### Changed\n- BREAKING: an old break.\n"
+        )
+        self.check(already_released, "0.4.0", "0.4.1")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Three fixes to the compatibility gate in `check-contracts.py`, found while labelling the 0.4.0 stack.

**The gate was unreachable.** `pr-policy` required a `breaking-change` label for removed CLI contracts, but no such label existed in the repository. Any PR removing a CLI contract would have been told to apply an unappliable label. The label now exists.

**The `BREAKING:` requirement now fires on the label**, not only on contract removal. An exit-code change or a JSON field changing meaning removes nothing yet still breaks — PR #73 (exit 0 → 2) and #66 (`callers` narrowing) are both live examples that sailed through green.

**The version increase moved to the release cut.** `pr-policy` demanded the bump *in the breaking PR*, which contradicts `governance/releasing.md` placing it in the release PR. It was latent only because the block was gated on `removed`, which nothing triggers today. Now breaks accumulate under Unreleased and `version.py` refuses to release them under an insufficient bump — pre-1.0 needs minor, from 1.0 a major.

## The entry check is diff-based

Asking whether Unreleased *contains* `BREAKING:` passes as soon as any break has landed there — the next labelled PR rides in on someone else's entry. It checks the lines this PR adds, and matches the entry convention (`- BREAKING: ...`) rather than a bare mention, so prose discussing the marker doesn't count as declaring a break.

## What this cannot do

It enforces that a **declared** break is documented and versioned. It cannot **detect** an undeclared one — that needs behavioural snapshots (AGE-16). Whether a change *is* breaking stays a human judgment, which is what `contract-review` records.

## Validation

- 5 new `require_breaking_bump` tests: pre-1.0 minor, post-1.0 major, both negatives, and that only the Unreleased section counts
- Gate exercised both ways: exit 1 when it trips, 0 when clean
- Verified against real PRs: #66 without its entry → blocked; with it → passes
- Full versioning suite green