### PR TITLE
Commit real architecture layering rules for the ctx repository itself

### DIFF
--- a/.ctx/rules.toml
+++ b/.ctx/rules.toml
@@ -6,7 +6,18 @@
 # parser and the index/lsp pipeline sit above it; analytics above that;
 # mcp/harness are integration leaves; the bin crate (main/cli/shell/commands)
 # is the outermost shell. Files matching no layer (config.rs, walker.rs,
-# score.rs, error.rs, ...) are deliberately unconstrained.
+# score.rs, error.rs, lsp_registry.rs, embeddings/, tests/, perf/, ...) are
+# deliberately unconstrained — including as dependents of allowed_dependents
+# layers, so every invariant below binds layered files only.
+#
+# Known engine hazard (adversarially tested 2026-07-16): call-graph edges
+# resolve by unique bare name, so std method calls can mis-resolve into a
+# target layer when the name is crate-unique there — e.g. std::io::Read's
+# `read` (lsp/transport.rs), `thread::spawn` (lsp/client.rs), a `connection`
+# accessor (analytics/duckdb_impl.rs). If a shipped rule ever fires on such
+# a call, treat it as the resolver bug (see issue #61 follow-up), not as a
+# rule to loosen. The engine also misses fully-qualified calls to non-unique
+# names, so green here is necessary, not sufficient.
 
 version = 1
 
@@ -25,7 +36,7 @@ periphery  = ["src/mcp/**", "src/harness/**"]
 [[rules.allowed_dependents]]
 layer  = "cli"
 only   = []
-reason = "commands/cli/main/shell are the outermost shell; no library code may reach them"
+reason = "commands/cli/main/shell are the outermost shell; no layered library code may reach them"
 
 # ── Invariant 2: mcp and harness are leaves only the CLI touches ────────
 # HELD OUT pending the same-language successor to issue #61 (call-graph name
@@ -33,8 +44,9 @@ reason = "commands/cli/main/shell are the outermost shell; no library code may r
 # analytics/db mis-resolve to the test helper `fn find` in
 # src/harness/doctor.rs (81 edges), and sha2 `Digest::finalize` mis-resolves
 # to src/harness/checksum.rs::finalize (1 edge) — all false positives, zero
-# real edges (verified against source 2026-07-16; no file outside
-# src/commands imports crate::harness or crate::mcp). Enable once the
+# real edges (verified against source 2026-07-16; no layered file imports
+# crate::harness or crate::mcp — tests/harness_cli.rs:492 does, but tests
+# are unlayered by design). Enable once the
 # resolver bug is fixed. Do not loosen this into a weaker rule to silence
 # the resolver.
 #

--- a/.ctx/rules.toml
+++ b/.ctx/rules.toml
@@ -1,0 +1,94 @@
+# Architecture rules for the ctx repository itself, enforced by `ctx check`
+# (and surfaced as `check_violations` in `ctx score` and the PR analysis
+# comment). Hand-authored policy; ctx never regenerates this file.
+#
+# Layering model (low → high): db is the shared domain/storage foundation;
+# parser and the index/lsp pipeline sit above it; analytics above that;
+# mcp/harness are integration leaves; the bin crate (main/cli/shell/commands)
+# is the outermost shell. Files matching no layer (config.rs, walker.rs,
+# score.rs, error.rs, ...) are deliberately unconstrained.
+
+version = 1
+
+[layers]
+cli        = ["src/main.rs", "src/cli.rs", "src/shell.rs", "src/commands/**"]
+domain     = ["src/db/**"]
+extraction = ["src/parser/**"]
+indexing   = ["src/index/**", "src/lsp/**"]
+analytics  = ["src/analytics/**"]
+periphery  = ["src/mcp/**", "src/harness/**"]
+
+# ── Invariant 1: nothing depends on the CLI surface ─────────────────────
+# Compiler-redundant today (commands/cli/main/shell form the binary crate,
+# outside lib.rs) — this rule fires the day that boundary is dissolved.
+
+[[rules.allowed_dependents]]
+layer  = "cli"
+only   = []
+reason = "commands/cli/main/shell are the outermost shell; no library code may reach them"
+
+# ── Invariant 2: mcp and harness are leaves only the CLI touches ────────
+# HELD OUT pending the same-language successor to issue #61 (call-graph name
+# mis-resolution): plain `Iterator::find(...)` calls across parser/lsp/
+# analytics/db mis-resolve to the test helper `fn find` in
+# src/harness/doctor.rs (81 edges), and sha2 `Digest::finalize` mis-resolves
+# to src/harness/checksum.rs::finalize (1 edge) — all false positives, zero
+# real edges (verified against source 2026-07-16; no file outside
+# src/commands imports crate::harness or crate::mcp). Enable once the
+# resolver bug is fixed. Do not loosen this into a weaker rule to silence
+# the resolver.
+#
+# [[rules.allowed_dependents]]
+# layer  = "periphery"
+# only   = ["cli"]
+# reason = "mcp and harness are integration leaves; core modules must not import them"
+
+# ── Invariant 3: db depends on nothing above it ─────────────────────────
+# db doubles as the shared domain model (Symbol/Edge/ParseResult); its only
+# internal dependency is error.
+
+[[rules.forbidden]]
+from   = "domain"
+to     = "extraction"
+reason = "db is the foundation; it must not depend on parsers"
+
+[[rules.forbidden]]
+from   = "domain"
+to     = "indexing"
+reason = "db is the foundation; it must not depend on the indexing/LSP pipeline"
+
+[[rules.forbidden]]
+from   = "domain"
+to     = "analytics"
+reason = "db is the foundation; it must not depend on analytics"
+
+# ── Invariant 4: parsers stay pure ──────────────────────────────────────
+# Extraction consumes source text and produces domain types; it must not
+# call back into the pipeline that drives it.
+
+[[rules.forbidden]]
+from   = "extraction"
+to     = "indexing"
+reason = "parsers must not depend on the indexing/LSP pipeline that drives them"
+
+[[rules.forbidden]]
+from   = "extraction"
+to     = "analytics"
+reason = "parsers must not depend on analytics"
+
+# ── Invariant 5 (partial): analytics touches the domain layer only ──────
+# analytics -> indexing is DELIBERATELY NOT ENFORCED yet: the CTX_DIR and
+# DB_FILE path constants live in src/index/, so analytics/duckdb_impl.rs
+# legitimately imports them. Enable this rule once those constants move to
+# a neutral low module (tracked in Linear AGE-22). Same story for splitting
+# lsp/ and index/ into separate layers.
+
+[[rules.forbidden]]
+from   = "analytics"
+to     = "extraction"
+reason = "analytics reads the index database; it must not depend on parsers"
+
+# ── Limits ───────────────────────────────────────────────────────────────
+# [[rules.limit]] entries are deliberately omitted: a threshold calibrated
+# above today's worst offender is a gate that cannot fire. Limits will be
+# added once we have calibration data worth enforcing.


### PR DESCRIPTION
## Why

Every PR's ctx analysis comment has been publicly reporting `check_violations: no rules file (.ctx/rules.toml)` — the governance product wasn't running its own flagship gate, and `check_violations` was the only Holm-significant endpoint in the Phase 3 benchmark. `.ctx/rules.toml` had never been committed on any ref, despite `.gitignore` deliberately un-ignoring the path.

Committing the shipped inert starter would have flipped the output to `Architecture-rule findings (0)` — a zero masquerading as a pass. This PR instead commits real, source-validated layering policy.

## What

`.ctx/rules.toml` with six layers (`cli`, `domain`, `extraction`, `indexing`, `analytics`, `periphery`) and seven rules encoding five invariants, derived from the actual `use crate::` graph:

1. **Nothing depends on the CLI surface** (`allowed_dependents: cli only []`) — compiler-redundant today via the bin/lib crate split; fires the day that boundary is dissolved.
2. **db depends on nothing above it** — it's the shared domain model; its only internal dep is `error`.
3. **Parsers stay pure** — extraction must not depend on indexing/LSP or analytics.
4. **Analytics touches the domain layer only** (partial — see deferrals).

Layering only, no `[[rules.limit]]` thresholds: a layering rule that never fires is doing its job (prevention); a metric limit calibrated above today's worst offender is a gate that cannot fire.

## Deliberately deferred (documented in-file)

- **`analytics -> indexing` + splitting `lsp`/`index` into separate layers**: blocked by the `CTX_DIR`/`DB_FILE` constants living in `src/index/` (spurious upward edges from lsp/analytics/config). Tracked in Linear **AGE-22**; enable in a second rules PR after the relocation.
- **The periphery (`mcp`/`harness`) `allowed_dependents` rule**: held out (commented, not loosened) pending a resolver fix. Enabling it fires **82 violations, every one a false positive** — a same-language variant of #61: plain `Iterator::find(...)` calls across parser/lsp/analytics/db mis-resolve to the test helper `fn find` in `src/harness/doctor.rs:433`, and sha2 `Digest::finalize()` mis-resolves to `harness/checksum.rs::finalize`. Verified against source: no file outside `src/commands/` imports `crate::harness` or `crate::mcp`. Persists on current main after `ctx index --force` (the unreleased caller-resolution fixes don't cover the same-language case).

## Validation

- `ctx check --list`: parses, six layers with sane counts (cli 26, domain 3, extraction 6, indexing 9, analytics 3, periphery 11), no layer overlap.
- `ctx check` and `ctx check --against main`: exit 0 on both the released 0.3.5 binary and a main-built binary after full re-index.
- `ctx score --against main`: `check_violations 0` as a real metric (no `no rules file` note).
- Every violation candidate read against source before dispositioning (fix vs. defer); zero real boundary leaks found.

Not run / notes: no Rust source changed, so fmt/clippy/tests are unaffected; `ctx harness doctor` shows a pre-existing local-only `templates_stale` warning from the untracked `.ctx/harness.lock` (v0.2.1 residue), unrelated to CI. `skip-changelog`: repository policy config, not product behavior — maintainer to confirm the label.

## Advisory first

No blocking gate is added: the PR analysis comment already surfaces violations advisorily. Promote to a blocking `--fail-on "check_violations>0"` gate after a few weeks of clean signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)