### PR TITLE
fix(perf): add zig/c/cpp grammar crates to perf/Cargo.lock

### DIFF
--- a/perf/Cargo.lock
+++ b/perf/Cargo.lock
@@ -39,11 +39,14 @@ dependencies = [
  "toml",
  "toml_edit",
  "tree-sitter",
+ "tree-sitter-c",
+ "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "tree-sitter-zig",
  "zerocopy",
  "zip",
 ]
@@ -4098,6 +4101,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,6 +4171,16 @@ name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
 dependencies = [
  "cc",
  "tree-sitter-language",


### PR DESCRIPTION
## Why

Main's CI `perf` job is red after #72: it added `tree-sitter-zig/c/cpp` to the root crate, but `perf/Cargo.lock` (path-depends on `agentis-ctx`) was never refreshed, so `cargo test --locked --manifest-path perf/Cargo.toml` fails with `lock file needs to be updated but --locked was passed`. `perf` is advisory (not a required check), so #72 merged green on the 9 required checks while perf went red.

## What

Additive `perf/Cargo.lock` update — only the three grammar crates are added; no existing pins change. Verified `cargo test --locked --manifest-path perf/Cargo.toml` passes locally (20 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)