### PR TITLE
fix: resolve calls and crate:: paths within their own crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ctx check` no longer reports `forbidden` dependency violations between crates
+  that have no dependency relationship, which made `[[rules.forbidden]]`
+  unusable in a Cargo workspace (#92). Three independent resolution defects
+  produced the false edges:
+  - `use crate::…` in a workspace member resolved against the repository root's
+    `src/`, so every member importing from its own crate root was recorded as
+    importing from the root package's `src/lib.rs`. `crate::` now resolves
+    against the importing file's own crate root.
+  - A candidate's `qualified_name` was matched as a bare substring of the call
+    context, so `BTreeMap::new()` and `serde_json::Map::new()` both bound to a
+    local `Map::new`. The match is now anchored at an identifier boundary.
+  - Global name uniqueness was accepted as evidence for calls that carry a
+    receiver or path qualifier (`out.push(v)`, `Type::from(x)`), and for bare
+    calls whose only candidate is an `impl` method. Uniqueness now applies only
+    to bare calls resolving to a free function, matching the guard the
+    same-file resolution step already used.
+
+  A bare call shadowed by a local closure binding can still resolve to an
+  unrelated same-named free function; that case needs the Cargo dependency
+  graph or closure-scope awareness and is not addressed here.
+
+  Re-running `ctx index` on an existing index is not sufficient to clear
+  previously stored false edges, because resolution only fills targets that are
+  still unset. Delete `.ctx/codebase.sqlite` and reindex to pick up the fix.
+
 ## [0.4.0] - 2026-07-24
 
 ### Added

--- a/src/check.rs
+++ b/src/check.rs
@@ -299,14 +299,16 @@ fn resolve_c_include(
     matches.next().is_none().then_some(only)
 }
 
-/// Rust `use` path resolution: `crate::` from `src/`, `self::`/`super::`
-/// relative to the importing file's module, bare paths are external crates.
+/// Rust `use` path resolution: `crate::` from the importing file's own crate
+/// root, `self::`/`super::` relative to the importing file's module, bare paths
+/// are external crates.
 fn resolve_rust(indexed: &HashSet<String>, importing_file: &str, from: &str) -> Option<String> {
     let segs: Vec<&str> = from.split("::").filter(|s| !s.is_empty()).collect();
     let first = *segs.first()?;
 
+    let crate_src = rust_crate_src_root(importing_file);
     let (base, rest): (String, &[&str]) = match first {
-        "crate" => ("src".to_string(), &segs[1..]),
+        "crate" => (crate_src.clone(), &segs[1..]),
         "self" => (rust_self_dir(importing_file), &segs[1..]),
         "super" => {
             let mut dir = rust_self_dir(importing_file);
@@ -342,8 +344,11 @@ fn resolve_rust(indexed: &HashSet<String>, importing_file: &str, from: &str) -> 
                 return Some(candidate);
             }
         }
-        if base == "src" {
-            for candidate in ["src/lib.rs".to_string(), "src/main.rs".to_string()] {
+        if base == crate_src {
+            for candidate in [
+                format!("{}/lib.rs", crate_src),
+                format!("{}/main.rs", crate_src),
+            ] {
                 if indexed.contains(&candidate) {
                     return Some(candidate);
                 }
@@ -351,6 +356,26 @@ fn resolve_rust(indexed: &HashSet<String>, importing_file: &str, from: &str) -> 
         }
     }
     None
+}
+
+/// The `src` directory of the crate that owns `importing_file`.
+///
+/// `crate::` resolves against the enclosing crate root, not the repository
+/// root. In a Cargo workspace `child/src/lib.rs` belongs to the `child` member,
+/// so `use crate::inner::Thing` there must resolve under `child/src`, never
+/// under the workspace root's `src`. Resolving it to the root package's
+/// `src/lib.rs` invents a dependency between crates that may not even be
+/// allowed to depend on each other.
+///
+/// The nearest enclosing `src/` directory is the crate root under the standard
+/// Cargo layout. Files outside any `src/` directory keep the previous
+/// repository-root behaviour.
+fn rust_crate_src_root(importing_file: &str) -> String {
+    match importing_file.rfind("/src/") {
+        // Keep the `/src` itself, drop the trailing slash and remainder.
+        Some(i) => importing_file[..i + "/src".len()].to_string(),
+        None => "src".to_string(),
+    }
 }
 
 /// The directory that holds child modules of the importing Rust file:
@@ -550,6 +575,75 @@ mod tests {
             // external crates
             ("src/main.rs", "std::collections::HashMap", None),
             ("src/main.rs", "serde::Serialize", None),
+        ];
+        for (file, from, expected) in cases {
+            assert_eq!(
+                resolve_import(&idx, file, from).as_deref(),
+                expected,
+                "{} imports {:?}",
+                file,
+                from
+            );
+        }
+    }
+
+    /// `crate::` is relative to the importing file's own crate root, not the
+    /// workspace root. A member crate resolving `crate::` into the root
+    /// package's `src/lib.rs` fabricates a dependency between crates that may
+    /// have no dependency relationship at all (and could not have one, when the
+    /// root package already depends on the member).
+    #[test]
+    fn test_resolve_import_rust_crate_is_relative_to_workspace_member() {
+        let idx = indexed(&[
+            "src/lib.rs",
+            "src/engine_thing.rs",
+            "child/src/lib.rs",
+            "child/src/inner.rs",
+            "child/src/deep/mod.rs",
+            "nested/member/src/lib.rs",
+            "nested/member/src/thing.rs",
+        ]);
+        let cases = [
+            // `crate::` inside a member stays inside that member.
+            (
+                "child/src/lib.rs",
+                "crate::inner::ChildConfig",
+                Some("child/src/inner.rs"),
+            ),
+            (
+                "child/src/inner.rs",
+                "crate::deep",
+                Some("child/src/deep/mod.rs"),
+            ),
+            // Bare `crate` item resolves to the member's own lib.rs.
+            ("child/src/inner.rs", "crate", Some("child/src/lib.rs")),
+            (
+                "child/src/inner.rs",
+                "crate::ChildEntry",
+                Some("child/src/lib.rs"),
+            ),
+            // Deeply nested members resolve against their own root.
+            (
+                "nested/member/src/lib.rs",
+                "crate::thing",
+                Some("nested/member/src/thing.rs"),
+            ),
+            // The root package is unaffected: it must not reach into a member.
+            (
+                "src/lib.rs",
+                "crate::engine_thing",
+                Some("src/engine_thing.rs"),
+            ),
+            // A module name that exists only in the root package must never
+            // resolve across the crate boundary. `engine_thing` is not a module
+            // of `child`, so this falls back to the member's own crate root as
+            // a possibly re-exported item -- the point is that it stays inside
+            // `child/` and never reaches `src/engine_thing.rs`.
+            (
+                "child/src/lib.rs",
+                "crate::engine_thing",
+                Some("child/src/lib.rs"),
+            ),
         ];
         for (file, from, expected) in cases {
             assert_eq!(

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1768,7 +1768,19 @@ impl Database {
                 WHERE t.name = edges.target_name
                   AND t.kind IN ('function', 'method')
                   AND t.qualified_name IS NOT NULL
-                  AND edges.context LIKE '%' || t.qualified_name || '%'
+                  -- The qualified name must appear at an identifier boundary,
+                  -- not as a bare substring: `BTreeMap::new()` contains the
+                  -- text `Map::new`, and matching that binds a std call to an
+                  -- unrelated local `Map::new` in another file (or crate).
+                  AND INSTR(edges.context, t.qualified_name) > 0
+                  AND (
+                    INSTR(edges.context, t.qualified_name) = 1
+                    OR SUBSTR(
+                         edges.context,
+                         INSTR(edges.context, t.qualified_name) - 1,
+                         1
+                       ) NOT GLOB '[A-Za-z0-9_:]'
+                  )
             )
             WHERE target_id IS NULL
               AND (
@@ -1783,13 +1795,38 @@ impl Database {
                 WHERE t.name = edges.target_name
                   AND t.kind IN ('function', 'method')
                   AND t.qualified_name IS NOT NULL
-                  AND edges.context LIKE '%' || t.qualified_name || '%'
+                  -- The qualified name must appear at an identifier boundary,
+                  -- not as a bare substring: `BTreeMap::new()` contains the
+                  -- text `Map::new`, and matching that binds a std call to an
+                  -- unrelated local `Map::new` in another file (or crate).
+                  AND INSTR(edges.context, t.qualified_name) > 0
+                  AND (
+                    INSTR(edges.context, t.qualified_name) = 1
+                    OR SUBSTR(
+                         edges.context,
+                         INSTR(edges.context, t.qualified_name) - 1,
+                         1
+                       ) NOT GLOB '[A-Za-z0-9_:]'
+                  )
               ) = 1
             "#,
             [],
         )?;
 
-        // Step 2: Resolve edges where target name is unique across the codebase
+        // Step 2: Resolve edges where target name is unique across the codebase.
+        //
+        // Global name uniqueness is only evidence for a *bare* call like
+        // `helper()`. A receiver or path qualifier means the target is selected
+        // by a type we have not resolved -- `out.push(v)` on a `Vec`, or
+        // `Type::from(x)` -- and the sole indexed symbol with that bare name is
+        // very often an unrelated one. Binding those produces edges between
+        // files (and, in a Cargo workspace, between crates) that have no
+        // dependency relationship at all, which `ctx check` then reports as
+        // architecture violations.
+        //
+        // This is the same guard Step 3 applies for the same-file case; the
+        // trailing clause still admits a qualified call whose qualifier matches
+        // the candidate's own qualified name.
         let unique_resolved = self.conn.execute(
             r#"
             UPDATE edges
@@ -1809,6 +1846,59 @@ impl Database {
                 WHERE name = edges.target_name
                   AND kind IN ('function', 'method')
               ) = 1
+              AND (
+                context IS NULL
+                OR (
+                    context NOT LIKE '%::' || target_name || '(%'
+                    AND context NOT LIKE '%.' || target_name || '(%'
+                    AND context NOT LIKE '%->' || target_name || '(%'
+                )
+                -- Anchored, for the same reason as Step 1: `BTreeMap::new(`
+                -- must not be rescued by a candidate qualified `Map::new`.
+                OR (
+                    INSTR(context, (
+                        SELECT t.qualified_name
+                        FROM symbols t
+                        WHERE t.name = edges.target_name
+                          AND t.kind IN ('function', 'method')
+                        LIMIT 1
+                    ) || '(') > 0
+                    AND (
+                      INSTR(context, (
+                          SELECT t.qualified_name
+                          FROM symbols t
+                          WHERE t.name = edges.target_name
+                            AND t.kind IN ('function', 'method')
+                          LIMIT 1
+                      ) || '(') = 1
+                      OR SUBSTR(context, INSTR(context, (
+                          SELECT t.qualified_name
+                          FROM symbols t
+                          WHERE t.name = edges.target_name
+                            AND t.kind IN ('function', 'method')
+                          LIMIT 1
+                      ) || '(') - 1, 1) NOT GLOB '[A-Za-z0-9_:]'
+                    )
+                )
+              )
+              -- A call that reads as bare (`helper()`) cannot reach an `impl`
+              -- method: methods need a receiver or a path. When the context
+              -- shows no qualifier the sole candidate must be a free function.
+              -- This also covers a long call chain whose context was truncated
+              -- before its `.method(` ever became visible.
+              AND (
+                context IS NULL
+                OR context LIKE '%::' || target_name || '(%'
+                OR context LIKE '%.' || target_name || '(%'
+                OR context LIKE '%->' || target_name || '(%'
+                OR (
+                    SELECT t.kind
+                    FROM symbols t
+                    WHERE t.name = edges.target_name
+                      AND t.kind IN ('function', 'method')
+                    LIMIT 1
+                  ) = 'function'
+              )
             "#,
             [],
         )?;
@@ -2506,6 +2596,219 @@ mod tests {
             .pop()
             .expect("uses edge");
         assert_eq!(edge.target_id.as_deref(), Some("src/example.sol::target"));
+    }
+
+    /// Symbol with an explicit qualified name and kind, for resolution tests.
+    fn make_qualified_symbol(
+        id: &str,
+        name: &str,
+        qualified: &str,
+        file: &str,
+        kind: SymbolKind,
+    ) -> Symbol {
+        let mut s = make_fn_symbol(id, name, file, 1);
+        s.qualified_name = Some(qualified.to_string());
+        s.kind = kind;
+        s
+    }
+
+    fn rust_file(db: &Database, path: &str) {
+        db.upsert_file(
+            &FileRecord {
+                path: path.to_string(),
+                content_hash: path.to_string(),
+                size_bytes: 100,
+                language: Some("rust".to_string()),
+                last_indexed: 0,
+            },
+            None,
+        )
+        .unwrap();
+    }
+
+    fn call_edge_with_context(source_id: &str, target_name: &str, context: &str) -> Edge {
+        Edge {
+            source_id: source_id.to_string(),
+            target_id: None,
+            target_name: target_name.to_string(),
+            kind: EdgeKind::Calls,
+            line: Some(2),
+            col: None,
+            context: Some(context.to_string()),
+        }
+    }
+
+    /// A qualified name must match at an identifier boundary, not as a bare
+    /// substring. `BTreeMap::new()` and `serde_json::Map::new()` both contain
+    /// the text `Map::new`; binding either to a local `Map::new` invents a
+    /// dependency on whatever file (or crate) happens to define it.
+    #[test]
+    fn qualified_name_match_requires_an_identifier_boundary() {
+        let db = Database::open_in_memory().unwrap();
+        rust_file(&db, "src/caller.rs");
+        rust_file(&db, "src/map.rs");
+        db.insert_symbol(&make_fn_symbol("src/caller.rs::c", "c", "src/caller.rs", 1))
+            .unwrap();
+        db.insert_symbol(&make_qualified_symbol(
+            "src/map.rs::new",
+            "new",
+            "Map::new",
+            "src/map.rs",
+            SymbolKind::Method,
+        ))
+        .unwrap();
+
+        for context in ["BTreeMap::new()", "serde_json::Map::new()"] {
+            db.insert_edge(&call_edge_with_context("src/caller.rs::c", "new", context))
+                .unwrap();
+        }
+        db.resolve_edge_targets().unwrap();
+
+        for edge in db.get_outgoing_edges("src/caller.rs::c").unwrap() {
+            assert_eq!(
+                edge.target_id, None,
+                "{:?} must not bind to Map::new",
+                edge.context
+            );
+        }
+    }
+
+    /// A genuine `Map::new()` call still resolves: anchoring rejects only the
+    /// cases where the qualified name is a suffix of a longer path.
+    #[test]
+    fn qualified_name_match_still_resolves_a_real_call() {
+        let db = Database::open_in_memory().unwrap();
+        rust_file(&db, "src/caller.rs");
+        rust_file(&db, "src/map.rs");
+        db.insert_symbol(&make_fn_symbol("src/caller.rs::c", "c", "src/caller.rs", 1))
+            .unwrap();
+        db.insert_symbol(&make_qualified_symbol(
+            "src/map.rs::new",
+            "new",
+            "Map::new",
+            "src/map.rs",
+            SymbolKind::Method,
+        ))
+        .unwrap();
+        db.insert_edge(&call_edge_with_context(
+            "src/caller.rs::c",
+            "new",
+            "let m = Map::new();",
+        ))
+        .unwrap();
+
+        db.resolve_edge_targets().unwrap();
+        let edge = db
+            .get_outgoing_edges("src/caller.rs::c")
+            .unwrap()
+            .pop()
+            .expect("call edge");
+        assert_eq!(edge.target_id.as_deref(), Some("src/map.rs::new"));
+    }
+
+    /// Global name uniqueness is only evidence for a bare call. A receiver
+    /// means the target is chosen by an unresolved type, so the sole indexed
+    /// symbol with that name must not be bound.
+    #[test]
+    fn receiver_calls_do_not_bind_to_a_globally_unique_name() {
+        let db = Database::open_in_memory().unwrap();
+        rust_file(&db, "src/caller.rs");
+        rust_file(&db, "src/widget.rs");
+        db.insert_symbol(&make_fn_symbol("src/caller.rs::c", "c", "src/caller.rs", 1))
+            .unwrap();
+        db.insert_symbol(&make_qualified_symbol(
+            "src/widget.rs::push",
+            "push",
+            "Widget::push",
+            "src/widget.rs",
+            SymbolKind::Method,
+        ))
+        .unwrap();
+        db.insert_edge(&call_edge_with_context(
+            "src/caller.rs::c",
+            "push",
+            "out.push(value)",
+        ))
+        .unwrap();
+
+        db.resolve_edge_targets().unwrap();
+        let edge = db
+            .get_outgoing_edges("src/caller.rs::c")
+            .unwrap()
+            .pop()
+            .expect("call edge");
+        assert_eq!(edge.target_id, None, "Vec::push must not bind Widget::push");
+    }
+
+    /// A bare call cannot reach an `impl` method: methods need a receiver or a
+    /// path. This also covers a chain whose context was truncated before its
+    /// `.method(` became visible.
+    #[test]
+    fn bare_calls_do_not_bind_to_a_method() {
+        let db = Database::open_in_memory().unwrap();
+        rust_file(&db, "src/caller.rs");
+        rust_file(&db, "src/report.rs");
+        db.insert_symbol(&make_fn_symbol("src/caller.rs::c", "c", "src/caller.rs", 1))
+            .unwrap();
+        db.insert_symbol(&make_qualified_symbol(
+            "src/report.rs::push",
+            "push",
+            "Report::push",
+            "src/report.rs",
+            SymbolKind::Method,
+        ))
+        .unwrap();
+        // Truncated chain: the `.push(` never appears in the stored context.
+        db.insert_edge(&call_edge_with_context(
+            "src/caller.rs::c",
+            "push",
+            "self.information.entry(object.information_id).or_default()",
+        ))
+        .unwrap();
+
+        db.resolve_edge_targets().unwrap();
+        let edge = db
+            .get_outgoing_edges("src/caller.rs::c")
+            .unwrap()
+            .pop()
+            .expect("call edge");
+        assert_eq!(edge.target_id, None, "bare call must not bind a method");
+    }
+
+    /// The complement: a bare call to a globally unique free *function* still
+    /// resolves, which is what Step 2 exists to do.
+    #[test]
+    fn bare_calls_still_bind_a_unique_free_function() {
+        let db = Database::open_in_memory().unwrap();
+        rust_file(&db, "src/caller.rs");
+        rust_file(&db, "src/helpers.rs");
+        db.insert_symbol(&make_fn_symbol("src/caller.rs::c", "c", "src/caller.rs", 1))
+            .unwrap();
+        db.insert_symbol(&make_qualified_symbol(
+            "src/helpers.rs::generate_province",
+            "generate_province",
+            "generate_province",
+            "src/helpers.rs",
+            SymbolKind::Function,
+        ))
+        .unwrap();
+        db.insert_edge(&call_edge_with_context(
+            "src/caller.rs::c",
+            "generate_province",
+            "generate_province(budget)",
+        ))
+        .unwrap();
+
+        db.resolve_edge_targets().unwrap();
+        let edge = db
+            .get_outgoing_edges("src/caller.rs::c")
+            .unwrap()
+            .pop()
+            .expect("call edge");
+        assert_eq!(
+            edge.target_id.as_deref(),
+            Some("src/helpers.rs::generate_province")
+        );
     }
 
     /// Build a 'calls' edge for metrics tests.


### PR DESCRIPTION
Fixes #92.

`ctx check` reported `forbidden` violations between crates with no dependency relationship, which made `[[rules.forbidden]]` unusable in a Cargo workspace. On the 70-file workspace in #92 it produced **92 violations, none of them real**.

Three independent resolution defects turned out to be responsible.

## 1. `crate::` resolved against the repository root

`resolve_rust` hardcoded `"crate" => "src"`. In a workspace, `child/src/lib.rs` doing `use crate::inner::Thing` was recorded as importing the *root package's* `src/lib.rs` — an edge that cannot exist, since the root package already depends on the member.

`crate::` now resolves against the importing file's own crate root (the nearest enclosing `src/`, which is the crate root under the standard Cargo layout). Files outside any `src/` keep the previous behaviour.

## 2. `qualified_name` matched as a bare substring

Step 1 used `context LIKE '%' || t.qualified_name || '%'`. The text `BTreeMap::new()` contains `Map::new`, so a std call bound to a local `Map::new` in an unrelated file. `serde_json::Map::new()` did the same.

The match is now anchored at an identifier boundary: the qualified name must start the context or be preceded by a character outside `[A-Za-z0-9_:]`. Excluding `:` is what separates a real `Map::new()` from the suffix of `serde_json::Map::new()`.

## 3. Global name uniqueness applied to calls that were not bare

Step 2 resolved any call whose target name was unique across the index, with no guard at all — while Step 3 (same-file) already excluded receiver and path-qualified calls. So `out.push(v)` on a `Vec` bound to the single indexed `Widget::push`, and `Type::from(x)` bound to whatever unique `from` existed.

Step 2 now applies the same guard Step 3 uses, plus one addition: a call that reads as bare cannot reach an `impl` method, since methods need a receiver or a path. That also covers a long call chain whose stored context was truncated before its `.method(` became visible.

Bare calls to globally unique *free functions* still resolve — that is what the step exists for, and there is a test pinning it.

## Result

On the reporter's workspace, fabricated `forbidden` edges go from **92 to 12**, and 4 of the 5 rules that had to be commented out now pass clean. The frozen-path (`no_new_dependents`) baseline on the same repo drops from 48 to 6, since most of those were the same false edges.

## Known remaining case

A bare call shadowed by a **local closure binding** can still resolve to an unrelated same-named free function:

```rust
let rejected = |rejection, revision| { /* ... */ };
return rejected(SurfaceRejection::AttributionMismatch, self.revision);
```

`rejected` is not indexed as a symbol, so the sole indexed `fn rejected` elsewhere wins. The Rust parser already has an `is_locally_bound` helper for exactly this, but it is applied only to function-item references, not to call edges. Fixing it properly wants either that check extended to calls or the Cargo dependency graph. Left for follow-up rather than bundled here.

## Reindexing note

Re-running `ctx index` over an existing index does **not** clear previously stored false edges: resolution only fills targets that are still `NULL`, so edges already bound keep their wrong target. `.ctx/codebase.sqlite` has to be deleted and rebuilt to pick this up. Called out in the changelog.

## Validation

```
cargo fmt --all -- --check          # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test --lib                    # 420 passed, 0 failed (5 new)
python3 scripts/check-governance.py check   # OK
python3 -m unittest discover -s tests/versioning -p 'test_*.py'  # OK
```

No version bump, per the ordinary-PR rule in AGENTS.md.

New tests: one in `check.rs` covering `crate::` inside workspace members (including nested members and the root package), and four in `db/schema.rs` covering boundary-anchored qualified matching, a real `Map::new()` still resolving, receiver calls not binding a globally unique name, bare calls not binding a method, and bare calls still binding a unique free function.
