### PR TITLE
ci: fail and surface perf regressions instead of hiding them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,11 +244,21 @@ jobs:
           CTX_PERF_BIN: ${{ github.workspace }}/target/perf/ctx
         run: cargo run --locked --release --manifest-path perf/Cargo.toml -- --smoke
 
-      # Advisory period: continue-on-error until the ubuntu-latest baseline
-      # lands in perf/baselines/ and run-to-run spread is confirmed <20%.
-      # Flip this to required (remove continue-on-error) at that point.
+      # The original advisory condition ("until the ubuntu-latest baseline
+      # lands in perf/baselines/ and run-to-run spread is confirmed <20%") has
+      # been met since 2026-07-10: the baseline is committed and spread is a
+      # few percent. It is no longer why this is advisory.
+      #
+      # Pull requests stay advisory so the pre-existing indexing regression
+      # (#96) does not block unrelated work. Scheduled, dispatched, and
+      # push-to-main runs fail hard, so a regression turns main red and
+      # notifies instead of hiding as a failed step inside a green job --
+      # which is exactly how #96 went unnoticed from 2026-07-11 to 07-31.
+      #
+      # Remove this expression entirely (making perf required everywhere)
+      # once #96 is fixed and the suite is green.
       - name: Run perf harness
-        continue-on-error: true
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
           CTX_PERF_BIN: ${{ github.workspace }}/target/perf/ctx
           CTX_PERF_BUDGET_SCALE: "1.5"
@@ -263,6 +273,39 @@ jobs:
             --suite "$SUITE" \
             --baseline perf/baselines/ubuntu-latest.json \
             --json-out perf-results.json
+
+      # Without this, a perf failure is only legible by downloading the
+      # artifact and reading JSON, so nobody reads it.
+      - name: Summarize perf results
+        if: always()
+        run: |
+          test -f perf-results.json || exit 0
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+
+          data = json.load(open("perf-results.json"))
+          scenarios = data.get("scenarios", {})
+          meta = data.get("meta", {})
+          suite = meta.get("suite", "?")
+          bad = {k: v for k, v in scenarios.items() if v.get("status") != "pass"}
+          print("### Perf (%s suite)\n" % suite)
+          if not bad:
+              print(f"All {len(scenarios)} scenarios within budget and baseline.")
+          else:
+              print(f"**{len(bad)} of {len(scenarios)} scenarios failed.**\n")
+              print("| scenario | median | budget | baseline | vs budget | vs baseline |")
+              print("| --- | ---: | ---: | ---: | ---: | ---: |")
+              for name, s in sorted(bad.items()):
+                  median = s.get("median_ms") or 0
+                  budget = s.get("budget_ms")
+                  base = s.get("baseline_median_ms")
+                  vs_budget = f"{median / budget:.1f}x" if budget else "-"
+                  vs_base = f"{median / base:.1f}x" if base else "-"
+                  print(
+                      f"| `{name}` | {median:.0f} ms | {budget or '-'} | {base or '-'} "
+                      f"| {vs_budget} | {vs_base} |"
+                  )
+          PY
 
       - name: Upload perf results
         if: always()


### PR DESCRIPTION
The perf harness has reported a failing suite on **every nightly run since 2026-07-11**, and nothing surfaced it. The step is `continue-on-error: true`, so a red step sat inside a green job for three weeks while a 255x indexing regression (#96) shipped in v0.3.3, v0.3.4, v0.3.5, and v0.4.0.

Two separate causes, two fixes.

## 1. The advisory condition was stale, and the comment said so incorrectly

The comment read:

> Advisory period: continue-on-error until the ubuntu-latest baseline lands in `perf/baselines/` and run-to-run spread is confirmed <20%.

`perf/baselines/ubuntu-latest.json` landed on **2026-07-10**, and run-to-run spread is a few percent (`index_incremental_1`: 53.2 / 53.2 / 53.4 / 54.2 / 54.3 s). Both stated conditions have been met for three weeks, so the comment no longer explained why the step was advisory — it just looked like a decision someone would get to later.

Now: pull requests stay advisory, so the pre-existing regression in `main` does not block unrelated work. Scheduled, dispatched, and push-to-`main` runs **fail hard**.

```yaml
continue-on-error: ${{ github.event_name == 'pull_request' }}
```

That turns `main` red and triggers GitHub's built-in failed-run notifications — which is the actual "how do we get told about this" mechanism, with no new infrastructure.

**This makes `main` red until #96 is fixed.** That is the honest state: the suite genuinely fails. The alternative — re-baselining to the current numbers — would bless a 255x regression as normal, so it is deliberately not done here. The comment says to remove the expression entirely once #96 lands.

## 2. A failure was illegible

Reading a failure meant downloading the `perf-results` artifact and parsing JSON by hand, so nobody did. Failing scenarios now render into the job summary. Rendered against the real `perf-results.json` from run [30517821324](https://github.com/agentis-tools/ctx/actions/runs/30517821324):

### Perf (full suite)

**4 of 7 scenarios failed.**

| scenario | median | budget | baseline | vs budget | vs baseline |
| --- | ---: | ---: | ---: | ---: | ---: |
| `index_cold_150k` | 232927 ms | 60000.0 | 13641.7 | 3.9x | 17.1x |
| `index_cold_2k` | 106008 ms | - | 8043.8 | - | 13.2x |
| `index_incremental_1` | 53401 ms | 300.0 | 209.7 | 178.0x | 254.7x |
| `score_3_changed` | 61327 ms | 2000.0 | 5965.1 | 30.7x | 10.3x |

## Verification

The workflow parses as valid YAML, and the summary step was extracted and executed against that real artifact to produce the table above — it is generated output, not hand-written.

Refs #96, #23