### PR TITLE
fix: use one merge base for score baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ctx score` now resolves its merge base once and uses that commit for every
+  baseline input, avoiding inconsistent results when the target branch moved
+  after a feature branch diverged (#99).
+
 ## [0.4.0] - 2026-07-24
 
 ### Added

--- a/docs/commands/score.md
+++ b/docs/commands/score.md
@@ -10,7 +10,7 @@ ctx score [--against <REF>] [--fail-on <EXPR>] [--json]
 
 ## Description
 
-The `score` command compares the working tree (plus commits since the merge base with REF) against REF and prints a compact scorecard. It answers "did this change make the code better or worse?" with numbers:
+The `score` command compares the working tree (plus commits since the merge base with REF) against REF and prints a compact scorecard. It answers "did this change make the code better or worse?" with numbers. Score resolves the merge base once and uses that commit consistently for changed paths, baseline file contents, duplication, and architecture checks. The resolved commit is shown in human output and emitted as `data.baseline` in JSON.
 
 - **Complexity and fan-out deltas** - per changed file, baseline vs. current
 - **New duplication** - near-duplicate function pairs that did not exist at REF
@@ -59,7 +59,7 @@ ctx score
 
 Output:
 ```
-Score vs HEAD (1 file changed)
+Score vs HEAD (baseline 0123456) (1 file changed)
 
   complexity_delta        3 → 6      ▲ +3
   fan_out_delta           1 → 2      ▲ +1
@@ -98,6 +98,7 @@ ctx score --against main --json
   "generated_at": "2026-07-09T12:00:00Z",
   "data": {
     "against": "main",
+    "baseline": "0123456789abcdef0123456789abcdef01234567",
     "files_changed": 1,
     "metrics": {
       "complexity_delta": 3,

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -508,6 +508,7 @@ Exit codes follow the suite convention: 0 = no violations, 1 = at least one viol
 ```json
 {
   "against": "main",
+  "baseline": "0123456789abcdef0123456789abcdef01234567",
   "files_changed": 1,
   "metrics": {
     "complexity_delta": 3,

--- a/docs/website/docs/commands/score.md
+++ b/docs/website/docs/commands/score.md
@@ -104,6 +104,7 @@ ctx score --against main --json
   "generated_at": "2026-07-09T12:00:00Z",
   "data": {
     "against": "main",
+    "baseline": "0123456789abcdef0123456789abcdef01234567",
     "files_changed": 1,
     "metrics": {
       "complexity_delta": 3,

--- a/docs/website/docs/json-output.md
+++ b/docs/website/docs/json-output.md
@@ -392,6 +392,7 @@ Exit codes follow the suite convention: 0 = no violations, 1 = at least one viol
 ```json
 {
   "against": "main",
+  "baseline": "0123456789abcdef0123456789abcdef01234567",
   "files_changed": 1,
   "metrics": {
     "complexity_delta": 3,

--- a/src/commands/score.rs
+++ b/src/commands/score.rs
@@ -125,6 +125,7 @@ fn score_data(report: &ScoreReport, failed: &[FailCondition]) -> serde_json::Val
 
     serde_json::json!({
         "against": report.against,
+        "baseline": report.baseline,
         "files_changed": m.files_changed,
         "metrics": metrics_value(m),
         "check_violations_note": report.check_violations_note,
@@ -147,8 +148,9 @@ fn print_human(report: &ScoreReport, failed: &[FailCondition]) {
     let m = &report.metrics;
 
     println!(
-        "Score vs {} ({} file{} changed)",
+        "Score vs {} (baseline {}) ({} file{} changed)",
         report.against,
+        report.baseline,
         m.files_changed,
         if m.files_changed == 1 { "" } else { "s" }
     );

--- a/src/commands/score.rs
+++ b/src/commands/score.rs
@@ -31,7 +31,7 @@ fn run_score_in(
         None => Vec::new(),
     };
 
-    let report = score::compute_score(root, against)?;
+    let (report, baseline) = score::compute_score_with_baseline(root, against)?;
     eprintln!(
         "note: index refreshed ({} files reindexed)",
         report.files_reindexed
@@ -66,9 +66,9 @@ fn run_score_in(
     }
 
     if json_mode {
-        ctx::json::emit("score", score_data(&report, &failed))?;
+        ctx::json::emit("score", score_data(&report, &baseline, &failed))?;
     } else {
-        print_human(&report, &failed);
+        print_human(&report, &baseline, &failed);
     }
 
     if failed.is_empty() {
@@ -105,7 +105,7 @@ fn metrics_value(m: &Metrics) -> serde_json::Value {
 }
 
 /// The `data` payload for `--json` mode (see docs/json-output.md, `score`).
-fn score_data(report: &ScoreReport, failed: &[FailCondition]) -> serde_json::Value {
+fn score_data(report: &ScoreReport, baseline: &str, failed: &[FailCondition]) -> serde_json::Value {
     let m = &report.metrics;
     let per_file: Vec<serde_json::Value> = report
         .per_file
@@ -125,7 +125,7 @@ fn score_data(report: &ScoreReport, failed: &[FailCondition]) -> serde_json::Val
 
     serde_json::json!({
         "against": report.against,
-        "baseline": report.baseline,
+        "baseline": baseline,
         "files_changed": m.files_changed,
         "metrics": metrics_value(m),
         "check_violations_note": report.check_violations_note,
@@ -144,13 +144,13 @@ fn marker(delta: i64) -> &'static str {
     }
 }
 
-fn print_human(report: &ScoreReport, failed: &[FailCondition]) {
+fn print_human(report: &ScoreReport, baseline: &str, failed: &[FailCondition]) {
     let m = &report.metrics;
 
     println!(
         "Score vs {} (baseline {}) ({} file{} changed)",
         report.against,
-        report.baseline,
+        baseline,
         m.files_changed,
         if m.files_changed == 1 { "" } else { "s" }
     );
@@ -314,12 +314,14 @@ pub fn sum_invoices(entries: &[i64]) -> i64 {
             "src/a.rs",
             "pub fn a() -> i64 { b() }\npub fn b() -> i64 { 2 }\n",
         );
-        let report = ctx::score::compute_score(&repo.root, "HEAD").unwrap();
+        let (report, baseline) =
+            ctx::score::compute_score_with_baseline(&repo.root, "HEAD").unwrap();
         let conditions = ctx::score::parse_fail_on("symbols_added>0").unwrap();
         let failed = ctx::score::failed_conditions(&conditions, &report.metrics);
-        let data = score_data(&report, &failed);
+        let data = score_data(&report, &baseline, &failed);
 
         assert_eq!(data["against"], "HEAD");
+        assert_eq!(data["baseline"], baseline);
         assert_eq!(data["files_changed"], 1);
 
         // Flat metrics object with exactly the seven documented keys.

--- a/src/gitutil.rs
+++ b/src/gitutil.rs
@@ -52,6 +52,11 @@ pub fn show_file(reference: &str, path: &str) -> Result<Option<String>> {
     show_file_in(Path::new("."), reference, path)
 }
 
+/// Resolve `reference` to the commit where it diverges from `HEAD`.
+pub fn merge_base(reference: &str) -> Result<String> {
+    merge_base_in(Path::new("."), reference)
+}
+
 // ============================================================================
 // Directory-explicit implementations (used directly by tests)
 // ============================================================================
@@ -65,6 +70,24 @@ pub fn is_git_repo_in(dir: &Path) -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// Dir-explicit variant of [`merge_base`].
+pub fn merge_base_in(dir: &Path, reference: &str) -> Result<String> {
+    if !is_git_repo_in(dir) {
+        return Err(CtxError::NotGitRepo);
+    }
+
+    let output = run_git(dir, &["merge-base", reference, "HEAD"])?;
+    let base = stdout_or_err(output, Some(reference))?;
+    let base = base.trim();
+    if base.is_empty() {
+        return Err(CtxError::git(format!(
+            "git merge-base returned no commit for {}",
+            reference
+        )));
+    }
+    Ok(base.to_string())
 }
 
 fn repo_prefix_in(dir: &Path) -> Result<String> {
@@ -266,6 +289,8 @@ fn stdout_or_err(output: Output, revision: Option<&str>) -> Result<String> {
             || stderr.contains("bad revision")
             || stderr.contains("invalid object name")
             || stderr.contains("bad object")
+            || stderr.contains("Not a valid object name")
+            || stderr.contains("ambiguous argument")
         {
             return Err(CtxError::InvalidRevision(rev.to_string()));
         }
@@ -409,6 +434,20 @@ mod tests {
             "expected InvalidRevision, got: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_merge_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = GitRepo::init(dir.path());
+        repo.commit_file("a.rs", "fn a() {}", "initial");
+        let base = crate::testutil::git_stdout(&repo.root, &["rev-parse", "HEAD"]);
+        repo.branch("feature");
+        repo.commit_file("a.rs", "fn a() { 1; }", "feature");
+
+        assert_eq!(merge_base_in(&repo.root, "main").unwrap(), base);
+        let err = merge_base_in(&repo.root, "no-such-ref").unwrap_err();
+        assert!(matches!(err, CtxError::InvalidRevision(ref r) if r == "no-such-ref"));
     }
 
     #[test]

--- a/src/gitutil.rs
+++ b/src/gitutil.rs
@@ -108,19 +108,25 @@ pub fn changed_files_against_in(dir: &Path, reference: &str) -> Result<HashSet<S
 
     // Committed changes since the merge base with the reference.
     let range = format!("{}...HEAD", reference);
-    let output = run_git(dir, &["diff", "--name-only", &range])?;
+    let output = run_git(dir, &["diff", "--name-only", "-z", &range])?;
     let committed = stdout_or_err(output, Some(reference))?;
     collect_paths(&committed, &prefix, &mut files);
 
     // Uncommitted (staged + unstaged) changes.
-    let output = run_git(dir, &["diff", "--name-only", "HEAD"])?;
+    let output = run_git(dir, &["diff", "--name-only", "-z", "HEAD"])?;
     let uncommitted = stdout_or_err(output, None)?;
     collect_paths(&uncommitted, &prefix, &mut files);
 
     // Untracked files (--full-name makes paths repo-root-relative like diff).
     let output = run_git(
         dir,
-        &["ls-files", "--others", "--exclude-standard", "--full-name"],
+        &[
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "--full-name",
+            "-z",
+        ],
     )?;
     let untracked = stdout_or_err(output, None)?;
     collect_paths(&untracked, &prefix, &mut files);
@@ -328,12 +334,11 @@ fn strip_repo_prefix(path: &str, prefix: &str) -> Option<String> {
 
 /// Add each non-blank, prefix-local path in `raw` to `files`.
 fn collect_paths(raw: &str, prefix: &str, files: &mut HashSet<String>) {
-    for line in raw.lines() {
-        let line = line.trim_end_matches('\r');
-        if line.trim().is_empty() {
+    for path in raw.split('\0') {
+        if path.is_empty() {
             continue;
         }
-        if let Some(local) = strip_repo_prefix(line, prefix) {
+        if let Some(local) = strip_repo_prefix(path, prefix) {
             files.insert(local);
         }
     }
@@ -371,6 +376,14 @@ mod tests {
             Some("src/a.rs".to_string())
         );
         assert_eq!(strip_repo_prefix("other/a.rs", "sub/"), None);
+    }
+
+    #[test]
+    fn test_collect_paths_preserves_special_filenames() {
+        let mut files = HashSet::new();
+        collect_paths("src/plain.rs\0src/line\nbreak.rs\0", "", &mut files);
+        assert!(files.contains("src/plain.rs"));
+        assert!(files.contains("src/line\nbreak.rs"));
     }
 
     #[test]

--- a/src/score.rs
+++ b/src/score.rs
@@ -108,6 +108,8 @@ pub struct FileScore {
 pub struct ScoreReport {
     /// The git reference the working tree was compared against.
     pub against: String,
+    /// The commit used as the baseline for every score dimension.
+    pub baseline: String,
     /// How many files the internal incremental index refresh reindexed.
     pub files_reindexed: usize,
     /// Summed baseline complexity over changed files.
@@ -139,6 +141,12 @@ pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
         return Err(CtxError::NotGitRepo);
     }
 
+    // Resolve the merge base once. Every score input must use this same
+    // commit; using the reference tip for file contents while changed paths
+    // are merge-base-scoped makes branch scores depend on unrelated target
+    // branch changes.
+    let baseline = gitutil::merge_base_in(root, reference)?;
+
     // Incremental index refresh: only changed files are re-parsed; the
     // existing database is never cleared.
     let mut indexer = Indexer::with_config(root, false, WalkerConfig::default())?;
@@ -166,20 +174,20 @@ pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
             root,
             &db,
             &mut parser,
-            reference,
+            &baseline,
             path,
             &indexed,
         )?);
     }
 
     // Newly introduced near-duplicate pairs.
-    let new_duplication = new_duplication(root, &db, &mut parser, reference, &changed_set)?;
+    let new_duplication = new_duplication(root, &db, &mut parser, &baseline, &changed_set)?;
 
     // Architecture rules, scoped to the same reference.
     let rules_path = root.join(rules::DEFAULT_RULES_PATH);
     let (check_violations, check_violations_note) = if rules_path.exists() {
         let context = check::load_context(root, None)?;
-        let violations = check::collect_violations(root, &context, Some(reference))?;
+        let violations = check::collect_violations(root, &context, Some(&baseline))?;
         (violations.len() as i64, None)
     } else {
         (0, Some(NO_RULES_NOTE.to_string()))
@@ -213,6 +221,7 @@ pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
 
     Ok(ScoreReport {
         against: reference.to_string(),
+        baseline,
         files_reindexed: index_result.files_indexed,
         complexity_baseline,
         complexity_current,

--- a/src/score.rs
+++ b/src/score.rs
@@ -108,8 +108,6 @@ pub struct FileScore {
 pub struct ScoreReport {
     /// The git reference the working tree was compared against.
     pub against: String,
-    /// The commit used as the baseline for every score dimension.
-    pub baseline: String,
     /// How many files the internal incremental index refresh reindexed.
     pub files_reindexed: usize,
     /// Summed baseline complexity over changed files.
@@ -137,6 +135,13 @@ pub struct ScoreReport {
 ///
 /// `root` is the project root (also the directory git commands run in).
 pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
+    compute_score_with_baseline(root, reference).map(|(report, _)| report)
+}
+
+/// Compute a score and return the immutable merge-base commit used for every
+/// score dimension. This keeps the resolved baseline available to CLI output
+/// without adding a field to the public ScoreReport struct.
+pub fn compute_score_with_baseline(root: &Path, reference: &str) -> Result<(ScoreReport, String)> {
     if !gitutil::is_git_repo_in(root) {
         return Err(CtxError::NotGitRepo);
     }
@@ -146,6 +151,14 @@ pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
     // are merge-base-scoped makes branch scores depend on unrelated target
     // branch changes.
     let baseline = gitutil::merge_base_in(root, reference)?;
+    let report = compute_score_at_baseline(root, reference, &baseline)?;
+    Ok((report, baseline))
+}
+
+fn compute_score_at_baseline(root: &Path, against: &str, baseline: &str) -> Result<ScoreReport> {
+    if !gitutil::is_git_repo_in(root) {
+        return Err(CtxError::NotGitRepo);
+    }
 
     // Incremental index refresh: only changed files are re-parsed; the
     // existing database is never cleared.
@@ -158,7 +171,7 @@ pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
     // Changed files, filtered to supported source files that are either
     // indexed (exist) or gone from disk (deleted). Supported files that
     // exist but are excluded from the index (ignore patterns) are skipped.
-    let mut changed: Vec<String> = gitutil::changed_files_against_in(root, reference)?
+    let mut changed: Vec<String> = gitutil::changed_files_against_in(root, baseline)?
         .into_iter()
         .filter(|f| CodeParser::is_supported_static(Path::new(f)))
         .filter(|f| indexed.contains(f) || !root.join(f).exists())
@@ -174,20 +187,20 @@ pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
             root,
             &db,
             &mut parser,
-            &baseline,
+            baseline,
             path,
             &indexed,
         )?);
     }
 
     // Newly introduced near-duplicate pairs.
-    let new_duplication = new_duplication(root, &db, &mut parser, &baseline, &changed_set)?;
+    let new_duplication = new_duplication(root, &db, &mut parser, baseline, &changed_set)?;
 
     // Architecture rules, scoped to the same reference.
     let rules_path = root.join(rules::DEFAULT_RULES_PATH);
     let (check_violations, check_violations_note) = if rules_path.exists() {
         let context = check::load_context(root, None)?;
-        let violations = check::collect_violations(root, &context, Some(&baseline))?;
+        let violations = check::collect_violations(root, &context, Some(baseline))?;
         (violations.len() as i64, None)
     } else {
         (0, Some(NO_RULES_NOTE.to_string()))
@@ -220,8 +233,7 @@ pub fn compute_score(root: &Path, reference: &str) -> Result<ScoreReport> {
     }
 
     Ok(ScoreReport {
-        against: reference.to_string(),
-        baseline,
+        against: against.to_string(),
         files_reindexed: index_result.files_indexed,
         complexity_baseline,
         complexity_current,


### PR DESCRIPTION
Fixes #99

- Resolve the merge base once per score run.
- Use it consistently for changed paths, baseline contents, duplication, and architecture checks.
- Expose the resolved baseline in human and JSON output.