### PR TITLE
fix: exclude SHA256SUMS from its own manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,7 @@ jobs:
           cp downloaded/ctx-agent-plugins/plugin-SHA256SUMS dist/
           (
             cd dist
-            find . -maxdepth 1 -type f -printf '%f\n' \
+            find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%f\n' \
               | LC_ALL=C sort \
               | xargs sha256sum > SHA256SUMS
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,12 +267,18 @@ jobs:
             "ctx-${version}-1.x86_64.rpm"
           )
           while IFS= read -r checksum; do
-            (cd "$(dirname "$checksum")" && sha256sum -c "$(basename "$checksum")")
+            (cd "$(dirname "$checksum")" && sha256sum --strict --check "$(basename "$checksum")")
           done < <(find downloaded -type f -name '*.sha256' | LC_ALL=C sort)
-          (cd downloaded/ctx-agent-plugins && sha256sum -c plugin-SHA256SUMS)
+          test -f downloaded/ctx-agent-plugins/plugin-SHA256SUMS
+          (cd downloaded/ctx-agent-plugins && sha256sum --strict --check plugin-SHA256SUMS)
           for artifact in "${expected[@]}"; do
             mapfile -t matches < <(find downloaded -type f -name "$artifact")
             test "${#matches[@]}" -eq 1
+            if [[ "$artifact" != ctx-claude-plugin-*.zip && "$artifact" != ctx-codex-plugin-*.zip ]]; then
+              sidecar="${matches[0]}.sha256"
+              test -f "$sidecar"
+              (cd "$(dirname "$sidecar")" && sha256sum --strict --check "$(basename "$sidecar")")
+            fi
             cp "${matches[0]}" "dist/$artifact"
           done
           find downloaded -type f -name '*.sha256' -exec cp {} dist/ \;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Release checksum generation no longer includes `SHA256SUMS` in its own
+  manifest, and release validation rejects self-referential entries (#103).
+
 ## [0.4.0] - 2026-07-24
 
 ### Added

--- a/scripts/validate-release-assets.py
+++ b/scripts/validate-release-assets.py
@@ -4,6 +4,8 @@
 import argparse
 import hashlib
 from pathlib import Path
+import posixpath
+import re
 import tarfile
 import zipfile
 
@@ -13,6 +15,53 @@ TARGETS = {
     "aarch64-apple-darwin": ".tar.gz",
     "x86_64-pc-windows-msvc": ".zip",
 }
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def normalized_manifest_name(name: str) -> str:
+    return posixpath.normpath(name.lstrip("* ").strip())
+
+
+def read_checksums(path: Path) -> dict[str, str]:
+    listed: dict[str, str] = {}
+    for number, raw in enumerate(path.read_text().splitlines(), 1):
+        if not raw.strip():
+            continue
+        fields = raw.split(maxsplit=1)
+        if len(fields) != 2:
+            fail(f"invalid checksum line {number}: {raw!r}")
+        digest, name = fields
+        name = normalized_manifest_name(name)
+        if name == "SHA256SUMS" or Path(name).name == "SHA256SUMS":
+            fail(f"SHA256SUMS must not list itself (line {number})")
+        if not re.fullmatch(r"[0-9a-fA-F]{64}", digest):
+            fail(f"invalid SHA256 digest on line {number}: {digest!r}")
+        if name in listed:
+            fail(f"duplicate checksum entry for {name!r}")
+        listed[name] = digest.lower()
+    return listed
+
+
+def validate_checksums(directory: Path, sums: Path) -> None:
+    listed = read_checksums(sums)
+    artifacts = {
+        path.name: path
+        for path in directory.iterdir()
+        if path.is_file() and path.name != "SHA256SUMS"
+    }
+    missing = sorted(set(artifacts) - set(listed))
+    extra = sorted(set(listed) - set(artifacts))
+    if missing:
+        fail(f"SHA256SUMS is missing entries: {', '.join(missing)}")
+    if extra:
+        fail(f"SHA256SUMS lists unknown files: {', '.join(extra)}")
+    for name, path in artifacts.items():
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if listed[name] != actual:
+            fail(f"missing or incorrect checksum for {name}")
 
 
 def main() -> None:
@@ -32,20 +81,15 @@ def main() -> None:
         parser.error("no release archives found")
 
     sums = args.directory / "SHA256SUMS"
+    if args.complete and not sums.exists():
+        fail(f"missing aggregate checksum manifest: {sums}")
     if sums.exists():
-        listed = {}
-        for line in sums.read_text().splitlines():
-            digest, name = line.split(maxsplit=1)
-            listed[name.lstrip("* ")] = digest
-        assert "SHA256SUMS" not in listed, "SHA256SUMS must not list itself"
-        artifacts = [p for p in args.directory.iterdir() if p.is_file() and p.name != "SHA256SUMS"]
-        for path in artifacts:
-            actual = hashlib.sha256(path.read_bytes()).hexdigest()
-            assert listed.get(path.name) == actual, f"missing or incorrect checksum for {path.name}"
+        validate_checksums(args.directory, sums)
 
 
 def validate_archive(path: Path, target: str) -> None:
-    assert path.is_file(), f"missing release archive: {path}"
+    if not path.is_file():
+        fail(f"missing release archive: {path}")
     root = path.name.removesuffix(".zip").removesuffix(".tar.gz")
     binary = "ctx.exe" if target.endswith("windows-msvc") else "ctx"
     required = {f"{root}/{name}" for name in (binary, "README.md", "LICENSE-MIT", "LICENSE-APACHE")}
@@ -55,7 +99,8 @@ def validate_archive(path: Path, target: str) -> None:
     else:
         with tarfile.open(path, "r:gz") as archive:
             names = set(archive.getnames())
-    assert required <= names, f"{path.name} missing {sorted(required - names)}"
+    if required > names:
+        fail(f"{path.name} missing {sorted(required - names)}")
 
 
 if __name__ == "__main__":

--- a/scripts/validate-release-assets.py
+++ b/scripts/validate-release-assets.py
@@ -37,6 +37,7 @@ def main() -> None:
         for line in sums.read_text().splitlines():
             digest, name = line.split(maxsplit=1)
             listed[name.lstrip("* ")] = digest
+        assert "SHA256SUMS" not in listed, "SHA256SUMS must not list itself"
         artifacts = [p for p in args.directory.iterdir() if p.is_file() and p.name != "SHA256SUMS"]
         for path in artifacts:
             actual = hashlib.sha256(path.read_bytes()).hexdigest()

--- a/tests/versioning/test_release_assets.py
+++ b/tests/versioning/test_release_assets.py
@@ -1,0 +1,74 @@
+import hashlib
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "ctx_validate_release_assets", ROOT / "scripts/validate-release-assets.py"
+)
+assets = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = assets
+SPEC.loader.exec_module(assets)
+
+
+class ReleaseChecksumTests(unittest.TestCase):
+    def test_valid_manifest_covers_exact_artifact_set(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact = root / "ctx.tar.gz"
+            artifact.write_bytes(b"payload")
+            digest = hashlib.sha256(b"payload").hexdigest()
+            sums = root / "SHA256SUMS"
+            sums.write_text(f"{digest}  {artifact.name}\n", encoding="utf-8")
+
+            assets.validate_checksums(root, sums)
+
+    def test_self_references_are_rejected_after_path_normalization(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sums = root / "SHA256SUMS"
+            digest = "0" * 64
+            for name in ("SHA256SUMS", "./SHA256SUMS", "nested/../SHA256SUMS"):
+                sums.write_text(f"{digest}  {name}\n", encoding="utf-8")
+                with self.subTest(name=name), self.assertRaises(SystemExit):
+                    assets.read_checksums(sums)
+
+    def test_missing_and_extra_entries_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact = root / "ctx.tar.gz"
+            artifact.write_bytes(b"payload")
+            digest = hashlib.sha256(b"payload").hexdigest()
+            sums = root / "SHA256SUMS"
+
+            sums.write_text(
+                f"{digest}  {artifact.name}\n"
+                f"{digest}  extra.zip\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(SystemExit):
+                assets.validate_checksums(root, sums)
+
+            sums.write_text("", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                assets.validate_checksums(root, sums)
+
+    def test_wrong_digest_is_rejected_with_optimization_enabled(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact = root / "ctx.tar.gz"
+            artifact.write_bytes(b"payload")
+            sums = root / "SHA256SUMS"
+            sums.write_text(f"{'0' * 64}  {artifact.name}\n", encoding="utf-8")
+
+            with self.assertRaises(SystemExit):
+                assets.validate_checksums(root, sums)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #103

- Exclude `SHA256SUMS` while generating the aggregate release manifest.
- Reject self-referential entries in release validation.