### PR TITLE
fix: bound duplicate search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ctx duplicates` now bounds candidate and result memory, adds `--limit`,
+  and reports truncation in both human and JSON output (#104).
+
 ## [0.4.0] - 2026-07-24
 
 ### Added

--- a/docs/commands/duplicates.md
+++ b/docs/commands/duplicates.md
@@ -14,6 +14,8 @@ The `duplicates` command compares MinHash fingerprints (built during `ctx index`
 
 Tokens are normalized before comparison - identifiers become `ID`, string and number literals become `LIT`, comments are dropped - so **renamed variables and changed literals still match**. Candidate pairs are found with LSH banding over 128-permutation MinHash signatures, then verified with the exact Jaccard similarity.
 
+Search results are bounded. `--limit` caps the number of pairs retained and printed, and the candidate set is capped as well so a pathological LSH bucket cannot grow memory without bound. Human output says when truncation occurred; JSON reports `truncated: true`. The default limit is 1,000.
+
 > **Breaking change:** this replaces the old line-based detector. `--threshold` is a 0.0-1.0 Jaccard similarity over normalized 5-token shingles, **not** a percentage of matching lines; the old `--similarity <PERCENT>` / `--min-lines <N>` flags are gone. Existing indexes lack fingerprints: rebuild once with `ctx index --force` after upgrading.
 
 ## Prerequisites
@@ -31,6 +33,7 @@ ctx index
 | `--threshold <F>` | Jaccard similarity threshold (0.0-1.0) over normalized token shingles. Values below 0.5 are clamped to 0.5 (LSH candidate detection is unreliable below that) | 0.85 |
 | `--min-tokens <N>` | Ignore functions with fewer than N normalized tokens | 50 |
 | `--against <REF>` | Only report pairs where at least one function is in a file changed relative to REF | none |
+| `--limit <N>` | Maximum number of pairs to retain and print; output is marked truncated when the bound is reached | 1000 |
 | `--fail-on-found` | Exit 1 when any near-duplicate pair is reported | false |
 | `--json` | Machine-readable output (global flag) | false |
 
@@ -52,7 +55,7 @@ ctx duplicates
 
 Output:
 ```
-Near-duplicate functions (Jaccard similarity of 5-token shingles >= 0.85, >= 50 tokens)
+Near-duplicate functions (Jaccard similarity of 5-token shingles >= 0.85, >= 50 tokens, limit 1000)
 ====================================================================================================
 
 1. similarity 0.952
@@ -61,6 +64,12 @@ Near-duplicate functions (Jaccard similarity of 5-token shingles >= 0.85, >= 50 
 
 ----------------------------------------------------------------------------------------------------
 Found 1 near-duplicate pair(s).
+```
+
+For a large repository, use a smaller bounded report when inspecting results interactively:
+
+```bash
+ctx duplicates --limit 25
 ```
 
 ### Only Pairs Touching Changed Files
@@ -90,6 +99,8 @@ ctx duplicates --json
     "threshold": 0.85,
     "min_tokens": 50,
     "against": null,
+    "limit": 1000,
+    "truncated": false,
     "skipped_languages": [],
     "pairs": [
       {

--- a/docs/commands/duplicates.md
+++ b/docs/commands/duplicates.md
@@ -14,7 +14,7 @@ The `duplicates` command compares MinHash fingerprints (built during `ctx index`
 
 Tokens are normalized before comparison - identifiers become `ID`, string and number literals become `LIT`, comments are dropped - so **renamed variables and changed literals still match**. Candidate pairs are found with LSH banding over 128-permutation MinHash signatures, then verified with the exact Jaccard similarity.
 
-Search results are bounded. `--limit` caps the number of pairs retained and printed, and the candidate set is capped as well so a pathological LSH bucket cannot grow memory without bound. Human output says when truncation occurred; JSON reports `truncated: true`. The default limit is 1,000.
+Search results are bounded. `--limit` caps the number of pairs retained and printed, and the candidate set is capped as well so a pathological LSH bucket cannot grow memory without bound. The accepted range is 1-10,000; zero and larger values are rejected. A byte budget also prevents retained source snippets from growing without bound. Human output says when truncation occurred; JSON reports `truncated: true`. The default limit is 1,000.
 
 > **Breaking change:** this replaces the old line-based detector. `--threshold` is a 0.0-1.0 Jaccard similarity over normalized 5-token shingles, **not** a percentage of matching lines; the old `--similarity <PERCENT>` / `--min-lines <N>` flags are gone. Existing indexes lack fingerprints: rebuild once with `ctx index --force` after upgrading.
 
@@ -33,7 +33,7 @@ ctx index
 | `--threshold <F>` | Jaccard similarity threshold (0.0-1.0) over normalized token shingles. Values below 0.5 are clamped to 0.5 (LSH candidate detection is unreliable below that) | 0.85 |
 | `--min-tokens <N>` | Ignore functions with fewer than N normalized tokens | 50 |
 | `--against <REF>` | Only report pairs where at least one function is in a file changed relative to REF | none |
-| `--limit <N>` | Maximum number of pairs to retain and print; output is marked truncated when the bound is reached | 1000 |
+| `--limit <N>` | Maximum number of pairs to retain and print (1-10000); output is marked truncated when the bound is reached | 1000 |
 | `--fail-on-found` | Exit 1 when any near-duplicate pair is reported | false |
 | `--json` | Machine-readable output (global flag) | false |
 
@@ -43,7 +43,7 @@ ctx index
 |------|---------|
 | 0 | Success (default mode is informational, even with pairs found) |
 | 1 | `--fail-on-found` was given and at least one pair was reported |
-| 2 | Operational error (missing index, bad git ref, invalid threshold) |
+| 2 | Operational error (missing index, bad git ref, invalid threshold, or invalid limit) |
 
 ## Examples
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -353,13 +353,15 @@ Entry selection and `token_estimate` are computed from the text rendering, so JS
 
 ### `duplicates`
 
-`ctx duplicates [--threshold F] [--min-tokens N] [--against REF] [--fail-on-found] --json`
+`ctx duplicates [--threshold F] [--min-tokens N] [--against REF] [--limit N] [--fail-on-found] --json`
 
 ```json
 {
   "threshold": 0.85,
   "min_tokens": 50,
   "against": null,
+  "limit": 1000,
+  "truncated": false,
   "skipped_languages": ["solidity"],
   "pairs": [
     {
@@ -373,7 +375,7 @@ Entry selection and `token_estimate` are computed from the text rendering, so JS
 }
 ```
 
-`similarity` is the exact Jaccard similarity (0.0-1.0) of the two functions' normalized 5-token shingle sets. Pairs are sorted by similarity (descending), then by symbol id. `skipped_languages` lists languages that are never fingerprinted (Solidity has no tree-sitter grammar). With `--fail-on-found`, a non-empty `pairs` array exits with code 1.
+`similarity` is the exact Jaccard similarity (0.0-1.0) of the two functions' normalized 5-token shingle sets. Pairs are sorted by similarity (descending), then by symbol id. `skipped_languages` lists languages that are never fingerprinted (Solidity has no tree-sitter grammar). `limit` accepts 1-10,000 and bounds retained results; `truncated` is true when candidate, result-count, or retained-source-byte limits prevent a complete search. With `--fail-on-found`, either a non-empty `pairs` array or `truncated: true` exits with code 1 so an incomplete search fails closed.
 
 ### `hotspots`
 

--- a/docs/website/docs/commands/duplicates.md
+++ b/docs/website/docs/commands/duplicates.md
@@ -20,6 +20,8 @@ The `duplicates` command compares MinHash fingerprints (built during `ctx index`
 
 Tokens are normalized before comparison - identifiers become `ID`, string and number literals become `LIT`, comments are dropped - so **renamed variables and changed literals still match**. Candidate pairs are found with LSH banding over 128-permutation MinHash signatures, then verified with the exact Jaccard similarity.
 
+Search results are bounded. `--limit` accepts 1-10,000 and caps retained pairs; candidate and retained source bytes are bounded as well. Human output reports truncation and JSON emits `truncated: true`. With `--fail-on-found`, an incomplete search fails closed.
+
 All indexed languages participate, **including C, C++, Zig, and Solidity** (Solidity is tokenized via the solang-parser lexer; the Tree-sitter languages normalize identifiers and literals and discard comments).
 
 > **Breaking change:** this replaces the old line-based detector. `--threshold` is a 0.0-1.0 Jaccard similarity over normalized 5-token shingles, **not** a percentage of matching lines; the old `--similarity <PERCENT>` / `--min-lines <N>` flags are gone. Existing indexes lack fingerprints: rebuild once with `ctx index --force` after upgrading.
@@ -39,6 +41,7 @@ ctx index
 | `--threshold <F>` | Jaccard similarity threshold (0.0-1.0) over normalized token shingles. Values below 0.5 are clamped to 0.5 (LSH candidate detection is unreliable below that) | 0.85 |
 | `--min-tokens <N>` | Ignore functions with fewer than N normalized tokens | 50 |
 | `--against <REF>` | Only report pairs where at least one function is in a file changed relative to REF | none |
+| `--limit <N>` | Maximum number of pairs to retain and print (1-10000); output is marked truncated when the bound is reached | 1000 |
 | `--fail-on-found` | Exit 1 when any near-duplicate pair is reported | false |
 | `--json` | Machine-readable output (global flag) | false |
 
@@ -48,7 +51,7 @@ ctx index
 |------|---------|
 | 0 | Success (default mode is informational, even with pairs found) |
 | 1 | `--fail-on-found` was given and at least one pair was reported |
-| 2 | Operational error (missing index, bad git ref, invalid threshold) |
+| 2 | Operational error (missing index, bad git ref, invalid threshold, or invalid limit) |
 
 ## Examples
 
@@ -95,9 +98,11 @@ ctx duplicates --json
   "command": "duplicates",
   "generated_at": "2026-07-09T12:00:00Z",
   "data": {
-    "threshold": 0.85,
-    "min_tokens": 50,
-    "against": null,
+  "threshold": 0.85,
+  "min_tokens": 50,
+  "against": null,
+  "limit": 1000,
+  "truncated": false,
     "skipped_languages": [],
     "pairs": [
       {

--- a/docs/website/docs/json-output.md
+++ b/docs/website/docs/json-output.md
@@ -363,13 +363,15 @@ Exit codes follow the suite convention: 0 = no violations, 1 = at least one viol
 
 ### `duplicates`
 
-`ctx duplicates [--threshold F] [--min-tokens N] [--against REF] [--fail-on-found] --json`
+`ctx duplicates [--threshold F] [--min-tokens N] [--against REF] [--limit N] [--fail-on-found] --json`
 
 ```json
 {
   "threshold": 0.85,
   "min_tokens": 50,
   "against": null,
+  "limit": 1000,
+  "truncated": false,
   "skipped_languages": [],
   "pairs": [
     {
@@ -383,7 +385,7 @@ Exit codes follow the suite convention: 0 = no violations, 1 = at least one viol
 }
 ```
 
-`similarity` is the exact Jaccard similarity (0.0-1.0) of the two functions' normalized 5-token shingle sets. Pairs are sorted by similarity (descending), then by symbol id. `skipped_languages` lists languages that are never fingerprinted; all currently supported languages (including Solidity) are fingerprinted, so it is normally empty. With `--fail-on-found`, a non-empty `pairs` array exits with code 1.
+`similarity` is the exact Jaccard similarity (0.0-1.0) of the two functions' normalized 5-token shingle sets. Pairs are sorted by similarity (descending), then by symbol id. `skipped_languages` lists languages that are never fingerprinted; all currently supported languages (including Solidity) are fingerprinted, so it is normally empty. `limit` accepts 1-10,000 and bounds retained results; `truncated` is true when candidate, result-count, or retained-source-byte limits prevent a complete search. With `--fail-on-found`, either a non-empty `pairs` array or `truncated: true` exits with code 1 so an incomplete search fails closed.
 
 ### `score`
 

--- a/governance/contracts/cli.json
+++ b/governance/contracts/cli.json
@@ -142,6 +142,7 @@
         "--help": "-h, --help Print help (see a summary with '-h')",
         "--ignore": "-i, --ignore <IGNORE_PATTERNS> Additional ignore patterns (can be repeated)",
         "--json": "--json Emit machine-readable JSON to stdout (see docs/json-output.md)",
+        "--limit": "--limit <LIMIT> Maximum number of pairs to retain and print (1-10000). Results are marked truncated when the search reaches this bound [default: 1000]",
         "--max-tokens": "--max-tokens <MAX_TOKENS> Maximum tokens to include in output (omits files to fit budget, does not truncate file contents)",
         "--min-tokens": "--min-tokens <MIN_TOKENS> Ignore functions with fewer than N normalized tokens [default: 50]",
         "--no-default-ignores": "--no-default-ignores Disable built-in ignore patterns",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -392,8 +392,8 @@ internal and unstable. Access is read-only and engine-hardened.
         #[arg(long, value_name = "REF")]
         against: Option<String>,
 
-        /// Maximum number of pairs to retain and print. Results are marked
-        /// truncated when the search reaches this bound.
+        /// Maximum number of pairs to retain and print (1-10000). Results are
+        /// marked truncated when the search reaches this bound.
         #[arg(long, default_value_t = 1000)]
         limit: usize,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -392,6 +392,11 @@ internal and unstable. Access is read-only and engine-hardened.
         #[arg(long, value_name = "REF")]
         against: Option<String>,
 
+        /// Maximum number of pairs to retain and print. Results are marked
+        /// truncated when the search reaches this bound.
+        #[arg(long, default_value_t = 1000)]
+        limit: usize,
+
         /// Exit with code 1 when any near-duplicate pair is reported
         /// (default: informational, exit 0)
         #[arg(long)]

--- a/src/commands/duplicates.rs
+++ b/src/commands/duplicates.rs
@@ -9,7 +9,7 @@ use std::env;
 
 use ctx::error::Result;
 use ctx::exit::Outcome;
-use ctx::fingerprint::{find_near_duplicates, DuplicatePair, MIN_THRESHOLD, SHINGLE_K};
+use ctx::fingerprint::{find_near_duplicates_limited, DuplicatePair, MIN_THRESHOLD, SHINGLE_K};
 use ctx::gitutil;
 use ctx::index;
 use ctx::json::{emit, SymbolRef};
@@ -19,6 +19,7 @@ pub fn run_duplicates(
     threshold: f64,
     min_tokens: i64,
     against: Option<&str>,
+    limit: usize,
     json: bool,
     fail_on_found: bool,
 ) -> Result<Outcome> {
@@ -49,7 +50,9 @@ pub fn run_duplicates(
     let root = env::current_dir()?;
     let db = index::open_database(&root)?;
 
-    let pairs = find_near_duplicates(&db, threshold, min_tokens, changed.as_ref())?;
+    let search = find_near_duplicates_limited(&db, threshold, min_tokens, changed.as_ref(), limit)?;
+    let pairs = search.pairs;
+    let truncated = search.truncated;
 
     if json {
         let json_pairs: Vec<_> = pairs
@@ -70,6 +73,8 @@ pub fn run_duplicates(
                 "threshold": threshold,
                 "min_tokens": min_tokens,
                 "against": against,
+                "limit": limit,
+                "truncated": truncated,
                 // Every supported language is fingerprinted (Solidity via the
                 // solang-parser lexer), so nothing is skipped.
                 "skipped_languages": [],
@@ -77,7 +82,7 @@ pub fn run_duplicates(
             }),
         )?;
     } else {
-        print_human(&pairs, threshold, min_tokens, against);
+        print_human(&pairs, threshold, min_tokens, against, limit, truncated);
     }
 
     Ok(outcome(fail_on_found, pairs.len()))
@@ -93,7 +98,14 @@ fn outcome(fail_on_found: bool, pair_count: usize) -> Outcome {
     }
 }
 
-fn print_human(pairs: &[DuplicatePair], threshold: f64, min_tokens: i64, against: Option<&str>) {
+fn print_human(
+    pairs: &[DuplicatePair],
+    threshold: f64,
+    min_tokens: i64,
+    against: Option<&str>,
+    limit: usize,
+    truncated: bool,
+) {
     let scope = match against {
         Some(reference) => format!(", changed vs {}", reference),
         None => String::new(),
@@ -101,15 +113,18 @@ fn print_human(pairs: &[DuplicatePair], threshold: f64, min_tokens: i64, against
 
     if pairs.is_empty() {
         println!(
-            "No near-duplicate functions found (Jaccard >= {:.2}, >= {} tokens{}).",
-            threshold, min_tokens, scope
+            "No near-duplicate functions found (Jaccard >= {:.2}, >= {} tokens{}, limit {}).",
+            threshold, min_tokens, scope, limit
         );
+        if truncated {
+            println!("Search truncated at the requested limit of {}.", limit);
+        }
         return;
     }
 
     println!(
-        "Near-duplicate functions (Jaccard similarity of {}-token shingles >= {:.2}, >= {} tokens{})",
-        SHINGLE_K, threshold, min_tokens, scope
+        "Near-duplicate functions (Jaccard similarity of {}-token shingles >= {:.2}, >= {} tokens{}, limit {})",
+        SHINGLE_K, threshold, min_tokens, scope, limit
     );
     println!("{}", "=".repeat(100));
 
@@ -127,6 +142,9 @@ fn print_human(pairs: &[DuplicatePair], threshold: f64, min_tokens: i64, against
 
     println!("\n{}", "-".repeat(100));
     println!("Found {} near-duplicate pair(s).", pairs.len());
+    if truncated {
+        println!("Results truncated at the requested limit of {}.", limit);
+    }
     println!(
         "Note: idiomatic boilerplate can look structurally similar; raise --min-tokens to filter short functions."
     );

--- a/src/commands/duplicates.rs
+++ b/src/commands/duplicates.rs
@@ -9,7 +9,9 @@ use std::env;
 
 use ctx::error::Result;
 use ctx::exit::Outcome;
-use ctx::fingerprint::{find_near_duplicates_limited, DuplicatePair, MIN_THRESHOLD, SHINGLE_K};
+use ctx::fingerprint::{
+    find_near_duplicates_limited, DuplicatePair, MAX_RESULT_LIMIT, MIN_THRESHOLD, SHINGLE_K,
+};
 use ctx::gitutil;
 use ctx::index;
 use ctx::json::{emit, SymbolRef};
@@ -27,6 +29,16 @@ pub fn run_duplicates(
         return Err(format!(
             "--threshold must be a Jaccard similarity between 0.0 and 1.0 (got {})",
             threshold
+        )
+        .into());
+    }
+    if limit == 0 {
+        return Err("--limit must be greater than zero".into());
+    }
+    if limit > MAX_RESULT_LIMIT {
+        return Err(format!(
+            "--limit {} exceeds the maximum of {}",
+            limit, MAX_RESULT_LIMIT
         )
         .into());
     }
@@ -85,13 +97,14 @@ pub fn run_duplicates(
         print_human(&pairs, threshold, min_tokens, against, limit, truncated);
     }
 
-    Ok(outcome(fail_on_found, pairs.len()))
+    Ok(outcome(fail_on_found, pairs.len(), truncated))
 }
 
-/// Map the pair count to the exit outcome: `--fail-on-found` turns any
-/// reported pair into exit code 1; otherwise the command is informational.
-fn outcome(fail_on_found: bool, pair_count: usize) -> Outcome {
-    if fail_on_found && pair_count > 0 {
+/// Map the search result to the exit outcome. A blocking gate fails closed
+/// when the bounded search is incomplete, even if the retained subset is
+/// empty.
+fn outcome(fail_on_found: bool, pair_count: usize, truncated: bool) -> Outcome {
+    if fail_on_found && (pair_count > 0 || truncated) {
         Outcome::Findings
     } else {
         Outcome::Clean
@@ -157,10 +170,12 @@ mod tests {
     #[test]
     fn test_fail_on_found_outcome_mapping() {
         // --fail-on-found: Findings only when pairs exist.
-        assert_eq!(outcome(true, 3), Outcome::Findings);
-        assert_eq!(outcome(true, 0), Outcome::Clean);
+        assert_eq!(outcome(true, 3, false), Outcome::Findings);
+        assert_eq!(outcome(true, 0, false), Outcome::Clean);
+        // An incomplete bounded search must also fail closed.
+        assert_eq!(outcome(true, 0, true), Outcome::Findings);
         // Default mode is informational regardless of pairs.
-        assert_eq!(outcome(false, 3), Outcome::Clean);
-        assert_eq!(outcome(false, 0), Outcome::Clean);
+        assert_eq!(outcome(false, 3, false), Outcome::Clean);
+        assert_eq!(outcome(false, 0, true), Outcome::Clean);
     }
 }

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -55,6 +55,11 @@ pub const LSH_ROWS: usize = 8;
 /// misses too many candidate pairs to be trustworthy, so callers clamp to it.
 pub const MIN_THRESHOLD: f64 = 0.5;
 
+/// Default maximum number of duplicate pairs retained by a search.
+pub const DEFAULT_RESULT_LIMIT: usize = 1000;
+
+const CANDIDATE_LIMIT_MULTIPLIER: usize = 16;
+
 const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
@@ -427,6 +432,14 @@ pub struct DuplicatePair {
     pub token_count_b: i64,
 }
 
+/// Bounded duplicate search results.
+#[derive(Debug)]
+pub struct DuplicateSearch {
+    pub pairs: Vec<DuplicatePair>,
+    /// True when candidate or result truncation prevented a complete search.
+    pub truncated: bool,
+}
+
 /// Find near-duplicate function pairs in the index.
 ///
 /// Loads all fingerprints with at least `min_tokens` tokens, buckets them
@@ -442,7 +455,37 @@ pub fn find_near_duplicates(
     min_tokens: i64,
     changed_files: Option<&HashSet<String>>,
 ) -> Result<Vec<DuplicatePair>> {
+    Ok(find_near_duplicates_limited(
+        db,
+        threshold,
+        min_tokens,
+        changed_files,
+        DEFAULT_RESULT_LIMIT,
+    )?
+    .pairs)
+}
+
+/// Find near-duplicate pairs while bounding candidate and result memory.
+///
+/// `limit` is the maximum number of pairs retained. Candidate generation is
+/// also capped at a fixed multiple of that limit, so a pathological LSH
+/// bucket cannot materialize an unbounded candidate set. The result is marked
+/// `truncated` when either cap is reached.
+pub fn find_near_duplicates_limited(
+    db: &Database,
+    threshold: f64,
+    min_tokens: i64,
+    changed_files: Option<&HashSet<String>>,
+    limit: usize,
+) -> Result<DuplicateSearch> {
     let fingerprints = db.get_fingerprints(min_tokens)?;
+
+    if limit == 0 {
+        return Ok(DuplicateSearch {
+            pairs: Vec::new(),
+            truncated: false,
+        });
+    }
 
     // Decode signatures once (fingerprints are ordered by symbol_id, so
     // index order is id order and (i, j) with i < j is the canonical pair).
@@ -460,8 +503,12 @@ pub fn find_near_duplicates(
         }
     }
 
+    let candidate_limit = limit.saturating_mul(CANDIDATE_LIMIT_MULTIPLIER).max(limit);
     let mut candidates: HashSet<(usize, usize)> = HashSet::new();
-    for members in buckets.values() {
+    let mut truncated = false;
+    let mut bucket_entries: Vec<_> = buckets.into_iter().collect();
+    bucket_entries.sort_unstable_by_key(|(key, _)| *key);
+    'bucket: for (_key, members) in bucket_entries {
         if members.len() < 2 {
             continue;
         }
@@ -469,18 +516,21 @@ pub fn find_near_duplicates(
             for &j in &members[n + 1..] {
                 let pair = if i < j { (i, j) } else { (j, i) };
                 if pair.0 != pair.1 {
+                    if let Some(changed) = changed_files {
+                        if !changed.contains(&fingerprints[pair.0].file_path)
+                            && !changed.contains(&fingerprints[pair.1].file_path)
+                        {
+                            continue;
+                        }
+                    }
+                    if candidates.len() >= candidate_limit && !candidates.contains(&pair) {
+                        truncated = true;
+                        break 'bucket;
+                    }
                     candidates.insert(pair);
                 }
             }
         }
-    }
-
-    // --against filter: at least one endpoint must be in a changed file.
-    if let Some(changed) = changed_files {
-        candidates.retain(|&(i, j)| {
-            changed.contains(&fingerprints[i].file_path)
-                || changed.contains(&fingerprints[j].file_path)
-        });
     }
 
     // Verify candidates with exact Jaccard over re-derived shingle sets.
@@ -520,17 +570,24 @@ pub fn find_near_duplicates(
             token_count_a: fingerprints[i].token_count,
             token_count_b: fingerprints[j].token_count,
         });
+        if pairs.len() > limit {
+            pairs.sort_by(compare_pairs);
+            pairs.pop();
+            truncated = true;
+        }
     }
 
-    pairs.sort_by(|x, y| {
-        y.similarity
-            .partial_cmp(&x.similarity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| x.a.id.cmp(&y.a.id))
-            .then_with(|| x.b.id.cmp(&y.b.id))
-    });
+    pairs.sort_by(compare_pairs);
 
-    Ok(pairs)
+    Ok(DuplicateSearch { pairs, truncated })
+}
+
+fn compare_pairs(x: &DuplicatePair, y: &DuplicatePair) -> std::cmp::Ordering {
+    y.similarity
+        .partial_cmp(&x.similarity)
+        .unwrap_or(std::cmp::Ordering::Equal)
+        .then_with(|| x.a.id.cmp(&y.a.id))
+        .then_with(|| x.b.id.cmp(&y.b.id))
 }
 
 /// Rebuild a symbol's shingle set from its stored source snippet.

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -29,14 +29,13 @@
 //!   short functions.
 
 use std::cell::RefCell;
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use tree_sitter::Parser;
 
 use crate::db::{Database, Fingerprint, Symbol, SymbolKind};
-use crate::error::Result;
+use crate::error::{CtxError, Result};
 use crate::parser::Language;
 
 /// Number of MinHash permutations (signature length in u64 words).
@@ -57,6 +56,19 @@ pub const MIN_THRESHOLD: f64 = 0.5;
 
 /// Default maximum number of duplicate pairs retained by a search.
 pub const DEFAULT_RESULT_LIMIT: usize = 1000;
+
+/// Hard upper bound for a caller-supplied result limit. Keeping this finite
+/// prevents a command-line value from turning the bounded search back into an
+/// effectively unbounded result collector.
+pub const MAX_RESULT_LIMIT: usize = 10_000;
+
+/// Maximum source bytes retained across duplicate results. DuplicatePair
+/// carries symbols for the score baseline, so a pair-count cap alone is not a
+/// memory bound when functions contain very large source snippets.
+pub const MAX_RESULT_SOURCE_BYTES: usize = 64 * 1024 * 1024;
+
+/// Maximum source bytes retained for one duplicate pair.
+const MAX_PAIR_SOURCE_BYTES: usize = 4 * 1024 * 1024;
 
 const CANDIDATE_LIMIT_MULTIPLIER: usize = 16;
 
@@ -478,14 +490,19 @@ pub fn find_near_duplicates_limited(
     changed_files: Option<&HashSet<String>>,
     limit: usize,
 ) -> Result<DuplicateSearch> {
-    let fingerprints = db.get_fingerprints(min_tokens)?;
-
     if limit == 0 {
-        return Ok(DuplicateSearch {
-            pairs: Vec::new(),
-            truncated: false,
-        });
+        return Err(CtxError::Other(
+            "duplicate result limit must be greater than zero".to_string(),
+        ));
     }
+    if limit > MAX_RESULT_LIMIT {
+        return Err(CtxError::Other(format!(
+            "duplicate result limit {} exceeds the maximum of {}",
+            limit, MAX_RESULT_LIMIT
+        )));
+    }
+
+    let fingerprints = db.get_fingerprints(min_tokens)?;
 
     // Decode signatures once (fingerprints are ordered by symbol_id, so
     // index order is id order and (i, j) with i < j is the canonical pair).
@@ -535,44 +552,60 @@ pub fn find_near_duplicates_limited(
 
     // Verify candidates with exact Jaccard over re-derived shingle sets.
     // Shingle sets are not stored; they are rebuilt by re-tokenizing each
-    // symbol's stored source snippet.
-    let mut shingle_cache: HashMap<usize, Option<HashSet<u64>>> = HashMap::new();
-    let mut symbol_cache: HashMap<usize, Option<Symbol>> = HashMap::new();
+    // symbol's stored source snippet. Deliberately do not cache symbols here:
+    // the result limit bounds retained output, while a cache of full source
+    // snippets would otherwise make a large LSH bucket unbounded in bytes.
     let mut pairs = Vec::new();
+    let mut retained_source_bytes = 0usize;
 
     let mut sorted_candidates: Vec<(usize, usize)> = candidates.into_iter().collect();
     sorted_candidates.sort_unstable();
 
     for (i, j) in sorted_candidates {
-        for idx in [i, j] {
-            if let Entry::Vacant(entry) = symbol_cache.entry(idx) {
-                entry.insert(db.get_symbol(&fingerprints[idx].symbol_id)?);
-            }
-            if let Entry::Vacant(entry) = shingle_cache.entry(idx) {
-                entry.insert(symbol_cache[&idx].as_ref().and_then(symbol_shingles));
-            }
-        }
-
-        let (Some(sa), Some(sb)) = (&shingle_cache[&i], &shingle_cache[&j]) else {
+        let Some(a) = db.get_symbol(&fingerprints[i].symbol_id)? else {
             continue;
         };
-        let similarity = jaccard(sa, sb);
+        let Some(b) = db.get_symbol(&fingerprints[j].symbol_id)? else {
+            continue;
+        };
+        let (Some(sa), Some(sb)) = (symbol_shingles(&a), symbol_shingles(&b)) else {
+            continue;
+        };
+        let similarity = jaccard(&sa, &sb);
         if similarity < threshold {
             continue;
         }
-        let (Some(a), Some(b)) = (&symbol_cache[&i], &symbol_cache[&j]) else {
+
+        let source_bytes = symbol_source_bytes(&a).saturating_add(symbol_source_bytes(&b));
+        if source_bytes > MAX_PAIR_SOURCE_BYTES {
+            // A single oversized pair must not defeat the byte bound. It is
+            // omitted and surfaced as an incomplete search instead.
+            truncated = true;
             continue;
-        };
+        }
+
         pairs.push(DuplicatePair {
-            a: a.clone(),
-            b: b.clone(),
+            a,
+            b,
             similarity,
             token_count_a: fingerprints[i].token_count,
             token_count_b: fingerprints[j].token_count,
         });
+        retained_source_bytes = retained_source_bytes.saturating_add(source_bytes);
         if pairs.len() > limit {
             pairs.sort_by(compare_pairs);
-            pairs.pop();
+            if let Some(removed) = pairs.pop() {
+                retained_source_bytes =
+                    retained_source_bytes.saturating_sub(pair_source_bytes(&removed));
+            }
+            truncated = true;
+        }
+        while retained_source_bytes > MAX_RESULT_SOURCE_BYTES && !pairs.is_empty() {
+            pairs.sort_by(compare_pairs);
+            if let Some(removed) = pairs.pop() {
+                retained_source_bytes =
+                    retained_source_bytes.saturating_sub(pair_source_bytes(&removed));
+            }
             truncated = true;
         }
     }
@@ -580,6 +613,14 @@ pub fn find_near_duplicates_limited(
     pairs.sort_by(compare_pairs);
 
     Ok(DuplicateSearch { pairs, truncated })
+}
+
+fn symbol_source_bytes(symbol: &Symbol) -> usize {
+    symbol.source.as_ref().map_or(0, String::len)
+}
+
+fn pair_source_bytes(pair: &DuplicatePair) -> usize {
+    symbol_source_bytes(&pair.a).saturating_add(symbol_source_bytes(&pair.b))
 }
 
 fn compare_pairs(x: &DuplicatePair, y: &DuplicatePair) -> std::cmp::Ordering {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1486,6 +1486,22 @@ pub fn render_table(headers: &[String], widths: &[usize]) -> String {
     }
 
     #[test]
+    fn test_near_duplicates_limit_is_bounded_and_reported() {
+        let temp = TempDir::new().unwrap();
+        write_fixture(temp.path());
+        fs::copy(temp.path().join("src/a.rs"), temp.path().join("src/d.rs")).unwrap();
+
+        let mut indexer = Indexer::new_in_memory(temp.path()).unwrap();
+        indexer.index().unwrap();
+
+        let search =
+            crate::fingerprint::find_near_duplicates_limited(indexer.database(), 0.85, 50, None, 1)
+                .unwrap();
+        assert_eq!(search.pairs.len(), 1);
+        assert!(search.truncated);
+    }
+
+    #[test]
     fn test_parallel_indexing_also_fingerprints() {
         let temp = TempDir::new().unwrap();
         write_fixture(temp.path());

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,7 @@ fn run(args: Args) -> Result<Outcome> {
             threshold,
             min_tokens,
             against,
+            limit,
             fail_on_found,
         }) => {
             // Quality command: returns its own Outcome (Findings with
@@ -222,6 +223,7 @@ fn run(args: Args) -> Result<Outcome> {
                 threshold,
                 min_tokens,
                 against.as_deref(),
+                limit,
                 json,
                 fail_on_found,
             );

--- a/src/score.rs
+++ b/src/score.rs
@@ -353,8 +353,20 @@ fn new_duplication(
     reference: &str,
     changed: &HashSet<String>,
 ) -> Result<i64> {
-    let pairs =
-        fingerprint::find_near_duplicates(db, DUP_THRESHOLD, DUP_MIN_TOKENS, Some(changed))?;
+    let search = fingerprint::find_near_duplicates_limited(
+        db,
+        DUP_THRESHOLD,
+        DUP_MIN_TOKENS,
+        Some(changed),
+        fingerprint::DEFAULT_RESULT_LIMIT,
+    )?;
+    if search.truncated {
+        return Err(CtxError::Other(format!(
+            "duplicate search exceeded its bounded result budget of {}; refusing to undercount new_duplication",
+            fingerprint::DEFAULT_RESULT_LIMIT
+        )));
+    }
+    let pairs = search.pairs;
     if pairs.is_empty() {
         return Ok(0);
     }

--- a/tests/duplicates_cli.rs
+++ b/tests/duplicates_cli.rs
@@ -166,6 +166,8 @@ fn test_duplicates_json_output_and_exit_codes() {
     assert_eq!(doc["command"], "duplicates");
     assert_eq!(doc["data"]["threshold"], 0.85);
     assert_eq!(doc["data"]["min_tokens"], 50);
+    assert_eq!(doc["data"]["limit"], 1000);
+    assert_eq!(doc["data"]["truncated"], false);
     assert_eq!(doc["data"]["skipped_languages"], serde_json::json!([]));
 
     let pairs = doc["data"]["pairs"].as_array().unwrap();
@@ -182,6 +184,16 @@ fn test_duplicates_json_output_and_exit_codes() {
     // --fail-on-found turns findings into exit code 1.
     let out = ctx(root, &["duplicates", "--fail-on-found"]);
     assert_eq!(out.status.code(), Some(1));
+
+    // Zero and unreasonably large limits are rejected instead of silently
+    // turning a blocking gate into a clean result or restoring unbounded
+    // result memory.
+    let out = ctx(root, &["duplicates", "--limit", "0", "--fail-on-found"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("greater than zero"));
+    let out = ctx(root, &["duplicates", "--limit", "10001"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("maximum of 10000"));
 
     // Without the flag the same findings exit 0.
     let out = ctx(root, &["duplicates"]);
@@ -241,6 +253,7 @@ fn test_help_documents_new_semantics_and_old_flags_are_gone() {
     assert!(help.contains("--threshold"));
     assert!(help.contains("--min-tokens"));
     assert!(help.contains("--against"));
+    assert!(help.contains("1-10000"), "help: {}", help);
     assert!(help.contains("--fail-on-found"));
 
     // The old line-based flags are fully gone...


### PR DESCRIPTION
Fixes #104

- Add bounded duplicate candidate and result retention.
- Add `ctx duplicates --limit` with human and JSON truncation reporting.
- Add a regression test proving the result bound is enforced.