### PR TITLE
fix: support staged offline analytics extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- Added offline staging guidance for fastembed model caches and DuckDB's
+  `sqlite_scanner` extension; `CTX_DUCKDB_OFFLINE=1` now provides a clear
+  failure when the extension is not staged (#100).
+
 ## [0.4.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Added offline staging guidance for fastembed model caches and DuckDB's
-  `sqlite_scanner` extension; `CTX_DUCKDB_OFFLINE=1` now provides a clear
-  failure when the extension is not staged (#100).
+  `sqlite_scanner` extension; offline mode now suppresses passive network checks
+  and no-DuckDB builds fail clearly instead of returning empty analytics (#100).
 
 ## [0.4.0] - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ schema.
 
 Commit `config.toml` and `rules.toml` so the team and CI share the same defaults and policy. Ignore
 generated data such as `codebase.sqlite`; ctx can rebuild it with `ctx index`.
+See [Offline operation](docs/offline.md) when model files or DuckDB extensions
+must be staged before disconnecting a machine.
 
 - **Tree-sitter** parses every supported language into symbols and relationship edges.
 - **SQLite** (with FTS5 and `sqlite-vec`) is the persistent, single-file store.
@@ -352,6 +354,9 @@ Indexing respects `.gitignore`, an optional `.contextignore`, and 170+ built-in 
 | `OPENAI_API_KEY` | Required for `--provider openai` on `embed` / `semantic` / `smart` / `similar` |
 | `OLLAMA_HOST` | Ollama server URL for `--provider ollama` (default `http://localhost:11434`) |
 | `OLLAMA_EMBED_MODEL` | Ollama embedding model (default `nomic-embed-text`) |
+| `FASTEMBED_CACHE_DIR` | Directory for staged fastembed model files used by the local provider |
+| `CTX_DUCKDB_OFFLINE` | Set to `1` to disable DuckDB extension installation and require staged analytics extensions |
+| `CTX_DUCKDB_EXTENSION_DIRECTORY` | DuckDB extension directory used with `CTX_DUCKDB_OFFLINE=1` |
 | `GITHUB_TOKEN` | Optional for `review` (uses `gh` CLI auth by default) |
 | `CTX_NO_UPDATE_CHECK` | Silence the passive "new release available" notice |
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Indexing respects `.gitignore`, an optional `.contextignore`, and 170+ built-in 
 | `FASTEMBED_CACHE_DIR` | Directory for staged fastembed model files used by the local provider |
 | `CTX_DUCKDB_OFFLINE` | Set to `1` to disable DuckDB extension installation and require staged analytics extensions |
 | `CTX_DUCKDB_EXTENSION_DIRECTORY` | DuckDB extension directory used with `CTX_DUCKDB_OFFLINE=1` |
+| `CTX_OFFLINE` | Set to `1` to suppress passive update checks during air-gapped operation |
 | `GITHUB_TOKEN` | Optional for `review` (uses `gh` CLI auth by default) |
 | `CTX_NO_UPDATE_CHECK` | Silence the passive "new release available" notice |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -177,6 +177,9 @@ ctx semantic "functions that validate user input"
 ctx semantic "database connection management"
 ```
 
+For air-gapped machines, stage the local model cache and optional DuckDB
+extension before disconnecting; see [Offline operation](./offline.md).
+
 ### Explore Relationships
 
 **Who calls this function?**

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,79 @@
+# Offline operation
+
+The index, keyword search, tree-sitter extraction, and local Ollama embeddings
+run without sending source code to ctx. Two first-use artifacts need to be
+staged when a machine has no network access: the fastembed model and, when
+DuckDB analytics are enabled, DuckDB's `sqlite_scanner` extension.
+
+## Stage local embeddings
+
+The default local provider uses fastembed's `all-MiniLM-L6-v2` model. On a
+connected staging machine, choose a cache directory and run embedding once:
+
+```bash
+export FASTEMBED_CACHE_DIR="$PWD/.cache/ctx-fastembed"
+ctx index
+ctx embed --provider local
+```
+
+Copy that cache directory to the offline machine and set the same variable
+before running `ctx embed`, `ctx semantic`, `ctx smart`, or `ctx similar`.
+`FASTEMBED_CACHE_DIR` is the fastembed cache setting; it is separate from the
+project's `.ctx/codebase.sqlite` index. The first local embedding run may
+download about 90 MB of model files.
+
+Ollama can also be staged locally: pull the selected model while connected,
+then run Ollama on the offline machine and set `OLLAMA_HOST` and
+`OLLAMA_EMBED_MODEL`. The OpenAI provider is network-backed and is not an
+offline option.
+
+## Stage DuckDB analytics
+
+The default release build includes bundled DuckDB 1.10504 on Linux and macOS. When a
+DuckDB command first attaches `.ctx/codebase.sqlite`, DuckDB may need its
+`sqlite_scanner` extension. On a connected machine with a DuckDB CLI matching
+the version bundled by ctx, install that extension into a directory you can
+copy to the offline machine. Check `duckdb --version` before staging; an
+extension built for another DuckDB release may not load:
+
+```bash
+mkdir -p "$PWD/.cache/ctx-duckdb-extensions"
+duckdb -c "SET extension_directory='$PWD/.cache/ctx-duckdb-extensions'; INSTALL sqlite_scanner; LOAD sqlite_scanner;"
+```
+
+Copy the directory and run ctx with automatic extension installation disabled:
+
+```bash
+export CTX_DUCKDB_EXTENSION_DIRECTORY="$PWD/.cache/ctx-duckdb-extensions"
+export CTX_DUCKDB_OFFLINE=1
+ctx sql "SELECT * FROM v1.files LIMIT 10"
+```
+
+In offline mode ctx explicitly loads the staged extension and refuses network
+installation. If it is missing, the command exits with an error naming
+`sqlite_scanner` and the staging variables. Without `CTX_DUCKDB_OFFLINE=1`,
+DuckDB keeps its normal automatic extension behavior.
+
+Windows release artifacts are built without the optional DuckDB feature, so
+they do not need this extension staging step. The official release matrix
+does include both Intel (`x86_64-apple-darwin`) and Apple Silicon macOS
+artifacts; use a matching DuckDB extension build for the target architecture.
+Source builds that need the smallest/offline footprint can use
+`--no-default-features`, which omits DuckDB analytics.
+
+## Verify before disconnecting
+
+Run the real commands on the staging machine, then repeat them with network
+access disabled on the target machine:
+
+```bash
+ctx index
+ctx embed --provider local
+ctx smart --count-only --max-tokens 2000
+ctx sql "SELECT count(*) FROM v1.symbols"
+```
+
+Keep the staged cache and extension directory versioned or checksummed with
+the same ctx release and target architecture. The SQLite index itself is
+portable as a file, but it should still be rebuilt with `ctx index` when the
+checkout changes.

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -22,6 +22,9 @@ before running `ctx embed`, `ctx semantic`, `ctx smart`, or `ctx similar`.
 project's `.ctx/codebase.sqlite` index. The first local embedding run may
 download about 90 MB of model files.
 
+If model files are missing, ctx exits with a model error; it does not produce an
+incomplete embedding corpus.
+
 Ollama can also be staged locally: pull the selected model while connected,
 then run Ollama on the offline machine and set `OLLAMA_HOST` and
 `OLLAMA_EMBED_MODEL`. The OpenAI provider is network-backed and is not an
@@ -29,11 +32,13 @@ offline option.
 
 ## Stage DuckDB analytics
 
-The default release build includes bundled DuckDB 1.10504 on Linux and macOS. When a
+The default release build includes bundled DuckDB v1.5.4 (`duckdb-rs`
+1.10504.0) on Linux and Apple Silicon macOS. When a
 DuckDB command first attaches `.ctx/codebase.sqlite`, DuckDB may need its
 `sqlite_scanner` extension. On a connected machine with a DuckDB CLI matching
 the version bundled by ctx, install that extension into a directory you can
-copy to the offline machine. Check `duckdb --version` before staging; an
+copy to the offline machine. Check that `duckdb --version` reports v1.5.4
+before staging; an
 extension built for another DuckDB release may not load:
 
 ```bash
@@ -41,11 +46,20 @@ mkdir -p "$PWD/.cache/ctx-duckdb-extensions"
 duckdb -c "SET extension_directory='$PWD/.cache/ctx-duckdb-extensions'; INSTALL sqlite_scanner; LOAD sqlite_scanner;"
 ```
 
+Record and verify the staged extension with SHA-256 before copying it (use the
+platform equivalent of `shasum -a 256` where needed):
+
+```bash
+(cd .cache/ctx-duckdb-extensions && find . -type f ! -name SHA256SUMS -exec shasum -a 256 {} + | sort > SHA256SUMS)
+(cd .cache/ctx-duckdb-extensions && shasum -a 256 -c SHA256SUMS)
+```
+
 Copy the directory and run ctx with automatic extension installation disabled:
 
 ```bash
 export CTX_DUCKDB_EXTENSION_DIRECTORY="$PWD/.cache/ctx-duckdb-extensions"
 export CTX_DUCKDB_OFFLINE=1
+export CTX_OFFLINE=1
 ctx sql "SELECT * FROM v1.files LIMIT 10"
 ```
 
@@ -53,13 +67,16 @@ In offline mode ctx explicitly loads the staged extension and refuses network
 installation. If it is missing, the command exits with an error naming
 `sqlite_scanner` and the staging variables. Without `CTX_DUCKDB_OFFLINE=1`,
 DuckDB keeps its normal automatic extension behavior.
+`CTX_OFFLINE=1` also suppresses the common post-command update notice, so the
+offline command does not make a passive network request after completing.
 
-Windows release artifacts are built without the optional DuckDB feature, so
-they do not need this extension staging step. The official release matrix
-does include both Intel (`x86_64-apple-darwin`) and Apple Silicon macOS
-artifacts; use a matching DuckDB extension build for the target architecture.
+Windows release artifacts and Intel macOS artifacts are built without the
+optional DuckDB feature, so they do not need this extension staging step. The
+official release matrix includes separate Apple Silicon macOS and Linux builds;
+use a matching DuckDB extension build for the target architecture.
 Source builds that need the smallest/offline footprint can use
-`--no-default-features`, which omits DuckDB analytics.
+`--no-default-features`, which omits DuckDB analytics; affected commands exit
+with an actionable feature error instead of returning empty results.
 
 ## Verify before disconnecting
 

--- a/docs/website/docs/configuration.md
+++ b/docs/website/docs/configuration.md
@@ -471,6 +471,11 @@ ctx uses minimal environment variables:
 | `OLLAMA_HOST` | Ollama server URL (default `http://localhost:11434`) | Only for the Ollama provider |
 | `OLLAMA_EMBED_MODEL` | Ollama embedding model (default `nomic-embed-text`) | Only for the Ollama provider |
 | `OLLAMA_API_KEY` | Optional bearer token for a remote/authenticated Ollama host | No |
+| `FASTEMBED_CACHE_DIR` | Staged fastembed model cache for the local provider | No |
+| `CTX_DUCKDB_OFFLINE` | Disable DuckDB extension installation and require a staged `sqlite_scanner` extension | For offline DuckDB |
+| `CTX_DUCKDB_EXTENSION_DIRECTORY` | Directory containing the staged DuckDB extension | With `CTX_DUCKDB_OFFLINE=1` |
+| `CTX_OFFLINE` | Suppress passive update checks during air-gapped operation | For fully offline runs |
+| `CTX_NO_UPDATE_CHECK` | Suppress the passive update notice | No |
 | `CTX_LSP_REGISTRY_BASE_URL` | Alternate base URL for the `ctx lsp` community registry (mirrors/testing) | No |
 
 ### Project config (`.ctx/config.toml`)

--- a/docs/website/docs/getting-started.md
+++ b/docs/website/docs/getting-started.md
@@ -50,11 +50,15 @@ cargo install --path .
 ```
 
 On Windows without the MSVC C++ build tools, disable the default DuckDB analytics
-feature (call graphs, impact analysis, and complexity then return empty results):
+feature (call graphs, impact analysis, and complexity then exit with an actionable
+"DuckDB analytics are unavailable" error):
 
 ```bash
 cargo install agentis-ctx --no-default-features
 ```
+
+For air-gapped machines, stage the local embedding model and the optional DuckDB
+extension before disconnecting; see [Offline operation](offline.md).
 
 ### From Source
 

--- a/docs/website/docs/offline.md
+++ b/docs/website/docs/offline.md
@@ -1,0 +1,83 @@
+---
+id: offline
+title: Offline operation
+sidebar_position: 3
+---
+
+# Offline operation
+
+Indexing, keyword search, tree-sitter extraction, and local Ollama embeddings do
+not send source code to ctx. Two first-use artifacts must be staged before an
+air-gapped run: the fastembed model and, for DuckDB analytics, DuckDB's
+`sqlite_scanner` extension.
+
+## Stage local embeddings
+
+The default local provider uses fastembed's `all-MiniLM-L6-v2` model. On a
+connected staging machine:
+
+```bash
+export FASTEMBED_CACHE_DIR="$PWD/.cache/ctx-fastembed"
+ctx index
+ctx embed --provider local
+```
+
+Copy the cache directory to the offline machine and keep the same variable set.
+If model files are missing, `ctx embed` exits with a model error; it does not
+produce an incomplete embedding corpus. Ollama can be staged by pulling the
+selected model while connected and running Ollama locally. The OpenAI provider
+is network-backed and is not an offline option.
+
+## Stage DuckDB analytics
+
+The bundled DuckDB engine is v1.5.4 (`duckdb-rs` 1.10504.0). On a connected
+staging machine, use a DuckDB CLI reporting v1.5.4 and install the extension:
+
+```bash
+duckdb --version
+mkdir -p "$PWD/.cache/ctx-duckdb-extensions"
+duckdb -c "SET extension_directory='$PWD/.cache/ctx-duckdb-extensions'; INSTALL sqlite_scanner; LOAD sqlite_scanner;"
+```
+
+Copy the extension directory to the offline machine. Record and verify its
+contents with the platform's SHA-256 tool (for example, `shasum -a 256` on
+macOS):
+
+```bash
+(cd .cache/ctx-duckdb-extensions && find . -type f ! -name SHA256SUMS -exec shasum -a 256 {} + | sort > SHA256SUMS)
+(cd .cache/ctx-duckdb-extensions && shasum -a 256 -c SHA256SUMS)
+```
+
+Run ctx with automatic extension installation disabled and passive update
+checks suppressed:
+
+```bash
+export CTX_DUCKDB_EXTENSION_DIRECTORY="$PWD/.cache/ctx-duckdb-extensions"
+export CTX_DUCKDB_OFFLINE=1
+export CTX_OFFLINE=1
+ctx sql "SELECT * FROM v1.files LIMIT 10"
+```
+
+Offline mode explicitly loads the staged extension and fails with an error that
+names `sqlite_scanner` when the artifact is absent. `CTX_OFFLINE=1` also prevents
+the common post-command update notice from attempting a network request.
+
+Windows release artifacts are built without DuckDB, while Intel and Apple
+Silicon macOS artifacts have separate target builds. Source builds that need a
+smaller footprint can use `--no-default-features`, but DuckDB-backed commands
+then exit with an actionable feature error rather than returning empty results.
+
+## Verify before disconnecting
+
+Run the real commands on the staging machine, then repeat them with network
+access disabled:
+
+```bash
+ctx index
+ctx embed --provider local
+ctx smart --count-only --max-tokens 2000
+ctx sql "SELECT count(*) FROM v1.symbols"
+```
+
+The SQLite index is portable as a file, but rebuild it with `ctx index` when the
+checkout changes.

--- a/docs/website/sidebars.ts
+++ b/docs/website/sidebars.ts
@@ -6,6 +6,7 @@ const sidebars: SidebarsConfig = {
     'why-ctx',
     'comparison',
     'getting-started',
+    'offline',
     {
       type: 'category',
       label: 'Guides',

--- a/src/analytics/duckdb_impl.rs
+++ b/src/analytics/duckdb_impl.rs
@@ -30,14 +30,7 @@ impl Analytics {
         // Create in-memory DuckDB and attach SQLite
         let conn = Connection::open_in_memory()?;
 
-        // Attach SQLite database with properly escaped path
-        // DuckDB uses single quotes for strings, so we need to escape any single quotes in the path
-        let path_str = sqlite_path.display().to_string();
-        let escaped_path = path_str.replace('\'', "''");
-        conn.execute(
-            &format!("ATTACH '{}' AS code (TYPE sqlite, READ_ONLY)", escaped_path),
-            [],
-        )?;
+        attach_sqlite(&conn, &sqlite_path)?;
 
         // Create materialized views for better performance
         let analytics = Self { conn };
@@ -671,13 +664,7 @@ impl Analytics {
 
         let conn = Connection::open_in_memory()?;
 
-        // Attach the SQLite index read-only (single-quote-escape the path).
-        let path_str = sqlite_path.display().to_string();
-        let escaped_path = path_str.replace('\'', "''");
-        conn.execute(
-            &format!("ATTACH '{}' AS code (TYPE sqlite, READ_ONLY)", escaped_path),
-            [],
-        )?;
+        attach_sqlite(&conn, &sqlite_path)?;
 
         let analytics = Self { conn };
 
@@ -860,6 +847,59 @@ impl Analytics {
             truncated,
         })
     }
+}
+
+/// Configure DuckDB's extension loading and attach the SQLite index.
+///
+/// Normal runs preserve DuckDB's automatic extension behavior. Setting
+/// `CTX_DUCKDB_OFFLINE=1` disables network installation and explicitly loads
+/// the staged `sqlite_scanner` extension, turning a missing artifact into a
+/// useful operational error instead of a network attempt.
+fn attach_sqlite(conn: &Connection, sqlite_path: &Path) -> Result<()> {
+    let offline = std::env::var("CTX_DUCKDB_OFFLINE").ok().as_deref() == Some("1");
+    let extension_directory =
+        std::env::var_os("CTX_DUCKDB_EXTENSION_DIRECTORY").map(std::path::PathBuf::from);
+    configure_extensions(conn, offline, extension_directory.as_deref())?;
+
+    let path_str = sqlite_path.display().to_string();
+    let escaped_path = path_str.replace('\'', "''");
+    conn.execute(
+        &format!("ATTACH '{}' AS code (TYPE sqlite, READ_ONLY)", escaped_path),
+        [],
+    )
+    .map(|_| ())
+}
+
+fn configure_extensions(
+    conn: &Connection,
+    offline: bool,
+    extension_directory: Option<&Path>,
+) -> Result<()> {
+    if let Some(directory) = extension_directory {
+        let directory = directory.to_string_lossy().replace('\'', "''");
+        conn.execute(&format!("SET extension_directory = '{}'", directory), [])?;
+    }
+
+    if offline {
+        let extension_result = conn.execute_batch(
+            "SET autoload_known_extensions = false;\n\
+             SET autoinstall_known_extensions = false;\n\
+             LOAD sqlite_scanner;",
+        );
+        if let Err(err) = extension_result {
+            return Err(duckdb::Error::ToSqlConversionFailure(Box::new(
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!(
+                        "offline DuckDB mode needs a staged sqlite_scanner extension; \
+                         set CTX_DUCKDB_EXTENSION_DIRECTORY or unset CTX_DUCKDB_OFFLINE \
+                         to allow installation ({err})"
+                    ),
+                ),
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// A column in a `ctx sql` result: its name and DuckDB type name.
@@ -1185,5 +1225,14 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_offline_extension_failure_is_actionable() {
+        let conn = Connection::open_in_memory().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let err = configure_extensions(&conn, true, Some(temp.path())).unwrap_err();
+        assert!(err.to_string().contains("offline DuckDB mode"));
+        assert!(err.to_string().contains("sqlite_scanner"));
     }
 }

--- a/src/analytics/stub.rs
+++ b/src/analytics/stub.rs
@@ -1,86 +1,93 @@
 //! Stub analytics implementation used when the `duckdb` feature is disabled.
 //!
 //! This avoids pulling in the DuckDB C++ dependency on platforms where it
-//! cannot compile (e.g. Windows MSVC). All methods return empty results so
-//! analytics-dependent commands degrade gracefully.
+//! cannot compile (e.g. Windows MSVC). The public method set remains available
+//! so callers can compile against either build, while runtime callers receive
+//! an actionable error instead of mistaking unavailable analytics for no data.
 
 use std::path::Path;
 
 use super::{CallGraphNode, ComplexityResult, FileStats, ImpactNode, LocatedImpactNode};
-use crate::error::Result;
+use crate::error::{CtxError, Result};
 
-/// Stub analytics engine that returns empty results.
+const UNAVAILABLE: &str = "DuckDB analytics are unavailable in this build; reinstall ctx with default features or build with --features duckdb";
+
+fn unavailable<T>() -> Result<T> {
+    Err(CtxError::Other(UNAVAILABLE.to_string()))
+}
+
+/// Stub analytics engine retained only to keep the no-DuckDB API compilable.
 pub struct Analytics;
 
 impl Analytics {
-    /// Create a stub (always succeeds).
+    /// Reject analytics operations with an actionable build-feature error.
     pub fn open(_root: &Path) -> Result<Self> {
-        Ok(Analytics)
+        unavailable()
     }
 
-    /// Call graph: returns empty list.
+    /// Call graph is unavailable without DuckDB.
     pub fn call_graph(&self, _start_name: &str, _max_depth: i32) -> Result<Vec<CallGraphNode>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// Impact analysis: returns empty list.
+    /// Impact analysis is unavailable without DuckDB.
     pub fn impact_analysis(&self, _target_name: &str, _max_depth: i32) -> Result<Vec<ImpactNode>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// Located impact analysis: returns empty list.
+    /// Located impact analysis is unavailable without DuckDB.
     pub fn impact_analysis_located(
         &self,
         _target_name: &str,
         _max_depth: i32,
     ) -> Result<Vec<LocatedImpactNode>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// File statistics: returns empty list.
+    /// File statistics are unavailable without DuckDB.
     pub fn file_statistics(&self) -> Result<Vec<FileStats>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// Symbol summary: returns empty list.
+    /// Symbol summaries are unavailable without DuckDB.
     #[allow(dead_code)]
     pub fn symbol_summary(&self) -> Result<Vec<(String, i64, i64)>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// Path existence check: always returns false.
+    /// Path queries are unavailable without DuckDB.
     #[allow(dead_code)]
     pub fn has_path(&self, _from_name: &str, _to_name: &str, _max_depth: i32) -> Result<bool> {
-        Ok(false)
+        unavailable()
     }
 
-    /// Most connected symbols: returns empty list.
+    /// Connectivity queries are unavailable without DuckDB.
     pub fn most_connected(&self, _limit: i32) -> Result<Vec<(String, String, i64, i64)>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// Recursive functions: returns empty list.
+    /// Recursive-function queries are unavailable without DuckDB.
     #[allow(dead_code)]
     pub fn find_recursive_functions(&self) -> Result<Vec<(String, String)>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// File dependencies: returns empty list.
+    /// File-dependency queries are unavailable without DuckDB.
     pub fn file_dependencies(&self) -> Result<Vec<(String, String, i64)>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// Complexity analysis: returns empty list.
+    /// Complexity analysis is unavailable without DuckDB.
     pub fn complexity_analysis(&self, _threshold: i64) -> Result<Vec<ComplexityResult>> {
-        Ok(Vec::new())
+        unavailable()
     }
 
-    /// Full call graph: returns empty list.
+    /// Full call graphs are unavailable without DuckDB.
     pub fn full_call_graph(
         &self,
         _max_depth: i32,
     ) -> Result<Vec<(String, String, String, String)>> {
-        Ok(Vec::new())
+        unavailable()
     }
 }
 
@@ -89,11 +96,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn located_impact_analysis_returns_empty_data() {
-        let analytics = Analytics::open(Path::new(".")).unwrap();
-        assert!(analytics
-            .impact_analysis_located("anything", 5)
-            .unwrap()
-            .is_empty());
+    fn analytics_unavailable_is_actionable() {
+        let err = Analytics::open(Path::new("."))
+            .err()
+            .expect("stub analytics must be unavailable");
+        assert!(err.to_string().contains("DuckDB analytics are unavailable"));
+        assert!(err.to_string().contains("default features"));
     }
 }

--- a/src/commands/diff_cmd.rs
+++ b/src/commands/diff_cmd.rs
@@ -52,11 +52,21 @@ pub fn run_diff(
         }
     };
 
-    // Open analytics if we have a database
-    let analytics = if db.is_some() {
-        analytics::Analytics::open(&root).ok()
-    } else {
-        None
+    // Open analytics if we have a database. A diff can still fall back to
+    // changes-only output, but make the reason visible when graph analytics
+    // are unavailable (for example in a no-DuckDB or offline build).
+    let analytics = match db.as_ref() {
+        Some(_) => match analytics::Analytics::open(&root) {
+            Ok(analytics) => Some(analytics),
+            Err(error) => {
+                if !changes_only {
+                    eprintln!("Warning: DuckDB analytics unavailable: {error}");
+                    eprintln!("Using --changes-only mode.\n");
+                }
+                None
+            }
+        },
+        None => None,
     };
 
     // Configure diff context

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,9 +123,10 @@
 //! # Feature Flags
 //!
 //! - `duckdb` *(enabled by default)* - DuckDB-backed analytics (call graphs,
-//!   impact analysis, complexity). When disabled, [`analytics`] falls back to
-//!   a stub that compiles everywhere (use this on Windows MSVC): add the
-//!   dependency with `default-features = false`.
+//!   impact analysis, complexity). When disabled, [`analytics`] retains a
+//!   compile-compatible API but returns an actionable feature error at runtime
+//!   (use this on Windows MSVC): add the dependency with `default-features =
+//!   false`.
 //! - `mcp` - Model Context Protocol server support for editor/agent
 //!   integrations (see the `mcp` module).
 

--- a/src/mcp/tools/analysis.rs
+++ b/src/mcp/tools/analysis.rs
@@ -187,7 +187,7 @@ pub async fn smart_context(
     let has_analytics = server.with_analytics(|_| ()).is_some();
     if !has_analytics {
         return Err(internal_error(
-            "Analytics not available. Run 'ctx index' first.",
+            "DuckDB analytics are unavailable. Use a default-feature ctx build and, for offline runs, stage the sqlite_scanner extension before starting the server.",
         ));
     }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -317,7 +317,7 @@ fn execute_command(
             } else if let Some(a) = analytics {
                 cmd_callers(db, a, args)?;
             } else {
-                eprintln!("Analytics not available (run 'ctx index' first)");
+                eprintln!("DuckDB analytics unavailable; use a default-feature ctx build and stage sqlite_scanner for offline runs");
             }
             Ok(false)
         }
@@ -327,7 +327,7 @@ fn execute_command(
             } else if let Some(a) = analytics {
                 cmd_callees(db, a, args)?;
             } else {
-                eprintln!("Analytics not available (run 'ctx index' first)");
+                eprintln!("DuckDB analytics unavailable; use a default-feature ctx build and stage sqlite_scanner for offline runs");
             }
             Ok(false)
         }
@@ -337,7 +337,7 @@ fn execute_command(
             } else if let Some(a) = analytics {
                 cmd_impact(a, args)?;
             } else {
-                eprintln!("Analytics not available");
+                eprintln!("DuckDB analytics unavailable; use a default-feature ctx build and stage sqlite_scanner for offline runs");
             }
             Ok(false)
         }
@@ -345,7 +345,7 @@ fn execute_command(
             if let Some(a) = analytics {
                 cmd_complexity(a)?;
             } else {
-                eprintln!("Analytics not available");
+                eprintln!("DuckDB analytics unavailable; use a default-feature ctx build and stage sqlite_scanner for offline runs");
             }
             Ok(false)
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -663,6 +663,7 @@ pub fn record_check(stamp_file: &Path, now: u64) -> std::io::Result<()> {
 /// - `--json` is active (stdout is a machine-readable document),
 /// - stderr is not a terminal (covers CI, pipes, and test harnesses),
 /// - `CTX_NO_UPDATE_CHECK` is set (non-empty),
+/// - offline mode is enabled (`CTX_OFFLINE=1` or `CTX_DUCKDB_OFFLINE=1`),
 /// - a Claude Code hook/session environment is detected (`CLAUDECODE`,
 ///   `CLAUDE_PROJECT_DIR`, or `CLAUDE_PLUGIN_ROOT`).
 ///
@@ -675,6 +676,11 @@ where
         return false;
     }
     if env("CTX_NO_UPDATE_CHECK").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    if env("CTX_OFFLINE").as_deref() == Some("1")
+        || env("CTX_DUCKDB_OFFLINE").as_deref() == Some("1")
+    {
         return false;
     }
     // Inside a Claude Code hook or session: never interfere.
@@ -945,6 +951,17 @@ mod tests {
             .then(String::new)));
         // Claude Code hook environment: suppressed, any of the three vars.
         for var in ["CLAUDECODE", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT"] {
+            assert!(
+                !passive_check_allowed(false, true, env_with(var)),
+                "{var} must suppress the passive check"
+            );
+        }
+
+        // Air-gapped operation must not perform the passive GitHub request
+        // after an otherwise local command. CTX_DUCKDB_OFFLINE is included
+        // because it is the supported offline switch for DuckDB-backed
+        // commands and those commands still pass through main's common gate.
+        for var in ["CTX_OFFLINE", "CTX_DUCKDB_OFFLINE"] {
             assert!(
                 !passive_check_allowed(false, true, env_with(var)),
                 "{var} must suppress the passive check"


### PR DESCRIPTION
Fixes #100

- Add `CTX_DUCKDB_OFFLINE=1` and `CTX_DUCKDB_EXTENSION_DIRECTORY` for staged `sqlite_scanner` use.
- Fail clearly when the extension is not available in offline mode.
- Document fastembed cache staging, Ollama staging, DuckDB extension staging, and platform differences.