### PR TITLE
docs: refresh README facts and version examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- Refreshed README measurements, token-budget wording, LSP guidance, and
+  library version examples; governance now checks README version references
+  against the manifest (#101).
+
 ## [0.4.0] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ architecture, and declare "done" without proof.
 your repo into a queryable model (every symbol, call, and dependency) and uses it to **ground**
 your agent and **gate** its output on every turn:
 
-- **Ground:** hand the agent a map before it starts, and the right ~8k tokens of context instead of
-  the wrong 503k.
+- **Ground:** hand the agent a map before it starts, and a hard-bounded context selection instead
+  of dumping the whole repository. On the v0.4.0 tag, the full repository measured 502,856
+  `cl100k_base` file-content tokens before selection.
 - **Govern:** show the blast radius of every edit, and enforce your architecture rules as
   deterministic gates it can't ship past.
 
@@ -90,8 +91,9 @@ publication.
 ## The loop: index → ground → govern
 
 **Build the model first.** Every intelligence and governance command reads a prebuilt index, so
-`ctx index` always comes first (it writes a single `.ctx/codebase.sqlite`). On this repo it indexes
-**870 symbols and 5,463 call edges in 0.36s.** Run it once, then keep it warm with `--watch`.
+`ctx index` always comes first (it writes a single `.ctx/codebase.sqlite`). On the v0.4.0 tag, this
+repository indexed **132 files, 2,701 symbols, and 18,730 extracted edges**; counts and timings
+vary with the checkout and machine. Run it once, then keep it warm with `--watch`.
 
 ```bash
 ctx index                        # build the world model (or `ctx index --watch` in the background)
@@ -100,7 +102,7 @@ ctx index                        # build the world model (or `ctx index --watch`
 **Ground:** feed the agent the right context, selected by meaning *and* call-graph relevance:
 
 ```bash
-ctx smart "add rate limiting" --max-tokens 8000   # ~8.7k tokens instead of 503k, about 58× smaller
+ctx smart "add rate limiting" --max-tokens 8000   # hard cap on the complete rendered output
 ctx diff --summary                                # context for what changed, with dependency expansion
 ctx similar "retry with backoff"                  # reuse before you write: find it if it already exists
 ```
@@ -267,6 +269,16 @@ The full flag reference for every command lives at
 
 See [Language Support](https://docs.agentis.tools/docs/language-support) for detail.
 
+### LSP extraction
+
+Tree-sitter is the default, fast local extractor. For languages or repositories
+that need server-assisted resolution, configure an LSP backend with
+`ctx lsp add <language>` and inspect it with `ctx lsp list` and `ctx lsp doctor`.
+Each configured language can use `tree-sitter`, `lsp`, or `hybrid`; hybrid keeps
+tree-sitter extraction and asks the server only to resolve references that stay
+ambiguous or unresolved. Server failures fall back to tree-sitter, so indexing
+remains usable offline.
+
 ## Using ctx as a library
 
 Everything the CLI does is available as a Rust library, so you can embed indexing, search, and
@@ -275,10 +287,10 @@ context generation in your own tools. The package is `agentis-ctx`; the library 
 
 ```toml
 [dependencies]
-agentis-ctx = "0.3"
+agentis-ctx = "0.4"
 
 # On Windows (or to skip DuckDB analytics):
-# agentis-ctx = { version = "0.3", default-features = false }
+# agentis-ctx = { version = "0.4", default-features = false }
 ```
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ architecture, and declare "done" without proof.
 your repo into a queryable model (every symbol, call, and dependency) and uses it to **ground**
 your agent and **gate** its output on every turn:
 
-- **Ground:** hand the agent a map before it starts, and a hard-bounded context selection instead
-  of dumping the whole repository. On the v0.4.0 tag, the full repository measured 502,856
-  `cl100k_base` file-content tokens before selection.
+- **Ground:** hand the agent a map before it starts, and a token-budgeted, whole-file context
+  selection instead of dumping the whole repository. On the v0.4.0 tag
+  (`1425cfc5a5ba96802a7adf7a9271bd1f1c3c1dda`, 2026-07-24),
+  `ctx --count-only --encoding cl100k_base` from the repository root reported 502,856
+  file-content tokens with the default ignore rules. The count excludes formatter wrappers and
+  the optional tree block, which add rendered-output tokens.
 - **Govern:** show the blast radius of every edit, and enforce your architecture rules as
   deterministic gates it can't ship past.
 
@@ -91,9 +94,10 @@ publication.
 ## The loop: index → ground → govern
 
 **Build the model first.** Every intelligence and governance command reads a prebuilt index, so
-`ctx index` always comes first (it writes a single `.ctx/codebase.sqlite`). On the v0.4.0 tag, this
-repository indexed **132 files, 2,701 symbols, and 18,730 extracted edges**; counts and timings
-vary with the checkout and machine. Run it once, then keep it warm with `--watch`.
+`ctx index` always comes first (it writes a single `.ctx/codebase.sqlite`). On the v0.4.0 tag
+(`1425cfc5a5ba96802a7adf7a9271bd1f1c3c1dda`, 2026-07-24), running `ctx index` at the repository root with the default ignore rules
+produced **2,701 symbols and 18,730 extracted edges**; counts vary with the checkout and indexing
+configuration, while timing varies with the machine. Run it once, then keep it warm with `--watch`.
 
 ```bash
 ctx index                        # build the world model (or `ctx index --watch` in the background)
@@ -102,7 +106,7 @@ ctx index                        # build the world model (or `ctx index --watch`
 **Ground:** feed the agent the right context, selected by meaning *and* call-graph relevance:
 
 ```bash
-ctx smart "add rate limiting" --max-tokens 8000   # hard cap on the complete rendered output
+ctx smart "add rate limiting" --max-tokens 8000   # fit selected whole files to a token budget
 ctx diff --summary                                # context for what changed, with dependency expansion
 ctx similar "retry with backoff"                  # reuse before you write: find it if it already exists
 ```
@@ -276,8 +280,11 @@ that need server-assisted resolution, configure an LSP backend with
 `ctx lsp add <language>` and inspect it with `ctx lsp list` and `ctx lsp doctor`.
 Each configured language can use `tree-sitter`, `lsp`, or `hybrid`; hybrid keeps
 tree-sitter extraction and asks the server only to resolve references that stay
-ambiguous or unresolved. Server failures fall back to tree-sitter, so indexing
-remains usable offline.
+ambiguous or unresolved. For built-in languages, a failed server falls back to
+tree-sitter; for languages without a built-in grammar, ctx keeps file records but
+cannot extract server-backed symbols. In both cases indexing continues with a
+warning. The registry lookup and any configured server may be network-backed, so
+offline use requires a locally installed server and a committed/manual configuration.
 
 ## Using ctx as a library
 

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -56,9 +56,10 @@ relationships. And almost nothing checks a model's change against the structure 
 ctx builds the world model once (`ctx index`), then uses it to both ground and govern:
 
 **Ground — the right context, in:**
-- **Smart context** — `ctx smart "<task>"` ranks by meaning + call-graph relevance, fit to a token
-  budget. On this repo: **~8,700 tokens instead of 502,856 — about 58× smaller.**
-- **Token control** — `--count-only`, `--max-tokens`, `--encoding` to budget any model's window.
+- **Smart context** — `ctx smart "<task>"` ranks by meaning + call-graph relevance, then fits
+  whole files to a token budget.
+- **Token control** — `--count-only --encoding cl100k_base` measures file content; `--max-tokens`
+  budgets selected content, while rendered wrappers and the optional tree add output tokens.
 
 **Govern — guardrails, on what changes:**
 - **Architecture rules** — `ctx check` enforces `.ctx/rules.toml` (layers, forbidden deps, limits)
@@ -72,8 +73,9 @@ ctx builds the world model once (`ctx index`), then uses it to both ground and g
 - *Forthcoming (not yet shipped): `ctx sql` repo-committed SQL gates (`.ctx/gates/*.sql`), trend snapshots.*
 
 **Agent-native** — `ctx serve --mcp` exposes the whole world model as MCP tools; `--output json`
-everywhere. **Local & fast** — Rust, one SQLite file, local embeddings; indexes 870 symbols and
-5,463 edges in **0.36s**, offline, code never leaves your machine.
+everywhere. **Local by default** — Rust, one SQLite file, local embeddings; the v0.4.0 tag
+indexed 2,701 symbols and 18,730 extracted edges in this repository. Configured providers may
+have their own local or network dependencies.
 
 ## Audience
 
@@ -93,11 +95,14 @@ everywhere. **Local & fast** — Rust, one SQLite file, local embeddings; indexe
 **The line:** *a queryable world model — grounds the model's input, governs its output. Structural +
 semantic, agent-first, local.*
 
-## Proof points (REAL — ctx v0.2.1 on the ctx repo; see scratchpad/proof.md)
+## Proof points (ctx v0.4.0 tag on the ctx repo; see the reproducible commands below)
 
-- **Ground:** whole repo = **502,856 tokens** (`ctx --count-only`); `ctx smart "..." --max-tokens 8000`
-  = **4 files, ~8,700 tokens** — **≈58× smaller**.
-- **World model / speed:** `ctx index` builds it in **0.36 s** — 53 files, **870 symbols, 5,463 edges**.
+- **Ground:** the v0.4.0 tag at `1425cfc5a5ba96802a7adf7a9271bd1f1c3c1dda` reports **502,856
+  file-content tokens** from
+  `ctx --count-only --encoding cl100k_base` at the repository root; wrappers and the tree are
+  excluded.
+- **World model:** the same tag's default `ctx index` run reports **2,701 symbols and 18,730
+  extracted edges**; timing is machine-dependent and intentionally not claimed here.
 - **Govern:** `ctx query impact discover_files` shows a change ripples through `index`, `run_context`,
   `run` (the CLI entry point) and the MCP server across 5 hops.
 

--- a/docs/website/docs/guides/using-ctx-with-agents.md
+++ b/docs/website/docs/guides/using-ctx-with-agents.md
@@ -105,9 +105,10 @@ ctx smart "<task>" --max-tokens 8000
 ctx --encoding o200k_base --count-only    # o200k_base | cl100k_base | p50k_base
 ```
 
-On a real repo the difference is large: the ctx codebase is **502,856 tokens** as a full dump, but a
-task-scoped `ctx smart "..." --max-tokens 8000` returns about **8,700 tokens** — the same answer,
-~58× less to read and pay for.
+On a real repo the difference is large: measure the current file-content baseline with
+`ctx --count-only --encoding cl100k_base`, then use `ctx smart "..." --max-tokens 8000` to select
+whole files for the task. The budget applies to selected file content; formatter wrappers and the
+optional tree block add rendered-output tokens.
 
 ## Next steps
 

--- a/docs/website/docs/why-ctx.md
+++ b/docs/website/docs/why-ctx.md
@@ -25,9 +25,10 @@ Agents now write and change real code — but dropped into a repo, they operate 
 and nothing verifies what they produce. Two failure modes follow:
 
 - **They read too much.** To "be safe," an agent dumps whole directories into the prompt. That burns
-  tokens, fills the context window with noise, and makes the model slower and less accurate. This
-  repo alone is **502,856 tokens** as one dump — past most context windows, and mostly irrelevant to
-  any single task. *(A grounding failure.)*
+  tokens, fills the context window with noise, and makes the model slower and less accurate. Run
+  `ctx --count-only --encoding cl100k_base` to measure the file-content baseline for the current
+  checkout; formatter wrappers and the optional tree block are not part of that count. *(A
+  grounding failure.)*
 - **They read too little, and nothing checks the change.** An agent greps a couple of files, edits,
   and misses the caller three hops away that it just broke — and no guardrail flagged the blast
   radius before the change shipped. *(A grounding **and** a governance failure.)*
@@ -43,10 +44,9 @@ before it lands. There's no model of the world the agent edits — and no guardr
 ### Ground — the right context, in
 
 - **Smart context** — `ctx smart "<task>"` combines semantic search with call-graph expansion to
-  pull the files a task touches, fit to a token budget. On this repo, a task-scoped request returns
-  **~8,700 tokens instead of 502,856 — about 58× smaller.**
-- **Token control** — `--count-only`, `--max-tokens`, and `--encoding` measure and cap context to
-  any model's window, so you never overpay for tokens you didn't need.
+  pull the files a task touches and fit whole files to a token budget.
+- **Token control** — `--count-only`, `--max-tokens`, and `--encoding` measure selected file content
+  for any model's window; rendered wrappers and the optional tree block add output tokens.
 
 ### Govern — guardrails, on what changes
 
@@ -58,8 +58,10 @@ before it lands. There's no model of the world the agent edits — and no guardr
 ### Delivered where the agent lives
 
 `ctx serve --mcp` exposes the whole world model as MCP tools to Claude Desktop and other agents, and
-every command speaks `--output json`. It's Rust-fast and fully local: it indexes 870 symbols and
-5,463 call edges in **0.36s**, runs offline, and your code never leaves your machine.
+every command speaks `--output json`. It is local by default: the v0.4.0 tag
+(`1425cfc5a5ba96802a7adf7a9271bd1f1c3c1dda`) indexed
+2,701 symbols and 18,730 extracted edges from this repository; configured LSP and embedding
+providers can add their own local or network dependencies.
 
 ## Who it's for
 

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -49,15 +49,15 @@ function ProofBand(): ReactNode {
       <div className="container">
         <div className={styles.stats}>
           <div className={styles.stat}>
-            <div className={styles.statNum}>~27&times;</div>
+            <div className={styles.statNum}>budgeted</div>
             <div className={styles.statLabel}>
-              smaller context &mdash; 233k &rarr; ~8.7k tokens for a task with <code>ctx smart</code>
+              whole-file task context with <code>ctx smart</code>
             </div>
           </div>
           <div className={styles.stat}>
-            <div className={styles.statNum}>0.36s</div>
+            <div className={styles.statNum}>2,701</div>
             <div className={styles.statLabel}>
-              to index 870 symbols and 5,463 call edges (measured on this repo)
+              symbols indexed on the v0.4.0 tag (18,730 extracted edges)
             </div>
           </div>
           <div className={styles.stat}>

--- a/scripts/check-governance.py
+++ b/scripts/check-governance.py
@@ -87,6 +87,7 @@ def structural_check() -> None:
         if "docs/" not in text and relative == "governance/guardrails.md":
             errors.append("guardrails.md must state the documentation boundary")
     errors.extend(cookbook_structure_errors(ROOT))
+    errors.extend(readme_contract_errors(ROOT))
     action_files = list((ROOT / ".github/workflows").glob("*.yml"))
     action_files += list((ROOT / ".github/workflows").glob("*.yaml"))
     action_files += list((ROOT / ".github/actions").glob("**/action.yml"))
@@ -128,6 +129,28 @@ def structural_check() -> None:
     if errors:
         raise GovernanceError("\n".join(errors))
     print("OK: governance files and agent instructions respect the docs boundary")
+
+
+def readme_contract_errors(root: Path) -> list[str]:
+    """Catch stale README dependency and release references."""
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    version = manifest_version((root / "Cargo.toml").read_text(encoding="utf-8"))
+    major_minor = ".".join(version.split(".")[:2])
+    errors: list[str] = []
+
+    for match in re.finditer(r'agentis-ctx\s*=\s*"(\d+\.\d+(?:\.\d+)?)"', readme):
+        declared = match.group(1)
+        if declared != major_minor and not declared.startswith(f"{major_minor}."):
+            errors.append(
+                f"README.md declares agentis-ctx {declared}, but Cargo.toml is {version}"
+            )
+
+    for declared in sorted(set(re.findall(r"\bv(\d+\.\d+\.\d+)\b", readme))):
+        if declared != version:
+            errors.append(
+                f"README.md references release v{declared}, but Cargo.toml is {version}"
+            )
+    return errors
 
 
 def unreleased_body(text: str) -> str:

--- a/tests/versioning/test_governance.py
+++ b/tests/versioning/test_governance.py
@@ -65,6 +65,22 @@ example = "9.9.9"
 """
         self.assertEqual(governance.manifest_version(text), "0.3.4")
 
+    def test_readme_contract_errors_detect_stale_version_and_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Cargo.toml").write_text(
+                '[package]\nname = "agentis-ctx"\nversion = "0.4.0"\n',
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text(
+                'agentis-ctx = "0.3"\nSee v0.3.9\n', encoding="utf-8"
+            )
+            errors = governance.readme_contract_errors(root)
+
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(any("agentis-ctx" in error for error in errors))
+        self.assertTrue(any("release v0.3.9" in error for error in errors))
+
 
 class ContractPolicyTests(unittest.TestCase):
     def test_removed_commands_and_options_are_breaking(self):


### PR DESCRIPTION
Fixes #101

- Refresh v0.4.0 measurements, token-budget wording, LSP guidance, and dependency examples.
- Add a governance check that catches stale README dependency and release references.